### PR TITLE
Append python version to codecov flag

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Run tests
       run: poetry run pytest -- -k "not connected_to_drone" --cov-report=xml --cov blueye
     - name: Upload coverage
-      run: curl -s https://codecov.io/bash | bash -s - -F $(echo ${{ matrix.os}} | cut -d "-" -f 1 | sed "s/$/python${{ matrix.python }}/ | sed "s/\.//")"
+      run: curl -s https://codecov.io/bash | bash -s - -F $(echo ${{ matrix.os}} | cut -d "-" -f 1 | sed "s/$/python${{ matrix.python }}/" | sed "s/\.//")"
       shell: bash
       env:
         CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Run tests
       run: poetry run pytest -- -k "not connected_to_drone" --cov-report=xml --cov blueye
     - name: Upload coverage
-      run: curl -s https://codecov.io/bash | bash -s - -F $(echo ${{ matrix.os}} | cut -d "-" -f 1) | sed "s/$/python${{ matrix.python }}/"
+      run: curl -s https://codecov.io/bash | bash -s - -F $(echo ${{ matrix.os}} | cut -d "-" -f 1 | sed "s/$/python${{ matrix.python }}/ | sed "s/\.//")"
       shell: bash
       env:
         CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Run tests
       run: poetry run pytest -- -k "not connected_to_drone" --cov-report=xml --cov blueye
     - name: Upload coverage
-      run: curl -s https://codecov.io/bash | bash -s - -F $(echo ${{ matrix.os}} | cut -d "-" -f 1 | sed "s/$/python${{ matrix.python }}/" | sed "s/\.//")"
+      run: curl -s https://codecov.io/bash | bash -s - -F $(echo ${{ matrix.os}} | cut -d "-" -f 1 | sed "s/$/_python${{ matrix.python }}/" | sed "s/\.//")
       shell: bash
       env:
         CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -24,7 +24,13 @@ jobs:
     - name: Run tests
       run: poetry run pytest -- -k "not connected_to_drone" --cov-report=xml --cov blueye
     - name: Upload coverage
-      run: curl -s https://codecov.io/bash | bash -s - -F $(echo ${{ matrix.os}} | cut -d "-" -f 1 | sed "s/$/_python${{ matrix.python }}/" | sed "s/\.//")
+      run: |
+        curl -s https://codecov.io/bash |\
+        bash -s -- -F \
+          $(echo ${{ matrix.os}} |\
+          cut -d "-" -f 1 |\
+          sed "s/$/_python${{ matrix.python }}/" |\
+          sed "s/\.//")
       shell: bash
       env:
         CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Run tests
       run: poetry run pytest -- -k "not connected_to_drone" --cov-report=xml --cov blueye
     - name: Upload coverage
-      run: curl -s https://codecov.io/bash | bash -s - -F $(echo ${{ matrix.os}} | cut -d "-" -f 1)
+      run: curl -s https://codecov.io/bash | bash -s - -F $(echo ${{ matrix.os}} | cut -d "-" -f 1) | sed "s/$/python${{ matrix.python }}/"
       shell: bash
       env:
         CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"


### PR DESCRIPTION
I suspect that the reason that the step for publishing to codecov has been a bit flaky lately is that we're publishing to the same flag in short succession. So to remedy the situation I've appended the python version to the flag. This means that we're now publishing on `$(os)_python$(pythonVersion)`