### PR TITLE
Publish package to PyPI when new release is created on Github

### DIFF
--- a/.github/workflows/PublishRelease.yml
+++ b/.github/workflows/PublishRelease.yml
@@ -1,0 +1,23 @@
+name: Publish release to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish_release_to_pypi:
+    name: Build and publish a release to PyPI
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Set up python
+      uses: actions/setup-python@v1
+    - name: Install poetry
+      uses: dschep/install-poetry-action@v1.2
+      with:
+        version: 1.0.0b3
+    - name: Build package with poetry
+      run: poetry build
+    - name: Publish to PyPI
+      run: poetry publish --username __token__ --password ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
The way to publish a new version of the SDK to PyPi would be to create and
publish a new release in the github project.

<!--
(Thanks for sending a pull request! Please make sure you fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
<!-- Describe the contents of the Pull request and problems it solves. -->

#### Checklist before merging

- [x] Run the tests while connected to a drone
- [x] Update the package version according to [semver](https://semver.org/)
