### PR TITLE
Publish documentation to PyPI

### DIFF
--- a/.github/workflows/PublishRelease.yml
+++ b/.github/workflows/PublishRelease.yml
@@ -17,7 +17,11 @@ jobs:
       uses: dschep/install-poetry-action@v1.2
       with:
         version: 1.0.0b3
-    - name: Build package with poetry
+    - name: Update mkdocs config for local browsing
+      run: sed -i "s/\[tool.portray.mkdocs\]$/&use_directory_urls = false/" pyproject.toml
+    - name: Build documentation for publishing
+      run: poetry run portray -- as_html --overwrite
+    - name: Build package with poetry, including documentation
       run: poetry build
     - name: Publish to PyPI
       run: poetry publish --username __token__ --password ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/PublishRelease.yml
+++ b/.github/workflows/PublishRelease.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Update mkdocs config for local browsing
       run: sed -i "s/\[tool.portray.mkdocs\]$/&use_directory_urls = false/" pyproject.toml
     - name: Build documentation for publishing
-      run: poetry run portray -- as_html --overwrite
+      run: poetry run portray -- as_html --overwrite --output_dir blueye.sdk_docs
     - name: Build package with poetry, including documentation
       run: poetry build
     - name: Publish to PyPI

--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ venv.bak/
 
 # mkdocs documentation
 /site
+blueye.sdk_docs
 
 # mypy
 .mypy_cache/

--- a/blueye/sdk/__init__.py
+++ b/blueye/sdk/__init__.py
@@ -1,1 +1,2 @@
 from .pioneer import Pioneer
+from .utils import open_local_documentation

--- a/blueye/sdk/utils.py
+++ b/blueye/sdk/utils.py
@@ -1,0 +1,16 @@
+import webbrowser
+import os
+import blueye.sdk
+
+
+def open_local_documentation():
+    """Open a pre-built local version of the SDK documentation
+
+    Useful when you are connected to the drone wifi, and don't have access to the online version.xs
+    """
+    sdk_path = os.path.dirname(blueye.sdk.__file__)
+
+    # The documentation is located next to the top-level package so we move up a couple of levels
+    documentation_path = sdk_path + "/../../blueye.sdk_docs/README.html"
+
+    webbrowser.open(documentation_path)

--- a/blueye/sdk/utils.py
+++ b/blueye/sdk/utils.py
@@ -6,7 +6,7 @@ import blueye.sdk
 def open_local_documentation():
     """Open a pre-built local version of the SDK documentation
 
-    Useful when you are connected to the drone wifi, and don't have access to the online version.xs
+    Useful when you are connected to the drone wifi, and don't have access to the online version.
     """
     sdk_path = os.path.dirname(blueye.sdk.__file__)
 

--- a/blueye/sdk/utils.py
+++ b/blueye/sdk/utils.py
@@ -11,6 +11,8 @@ def open_local_documentation():
     sdk_path = os.path.dirname(blueye.sdk.__file__)
 
     # The documentation is located next to the top-level package so we move up a couple of levels
-    documentation_path = sdk_path + "/../../blueye.sdk_docs/README.html"
+    documentation_path = os.path.abspath(
+        sdk_path + "/../../blueye.sdk_docs/README.html"
+    )
 
     webbrowser.open(documentation_path)

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -227,3 +227,15 @@ Remember to install the example dependencies before running the examples.
 ```shell
 pip install "blueye.sdk[examples]"
 ```
+
+### Local documentation
+Since the drone surface unit (usually) does not have internet access it can be a bit tricky to
+reference this documentation while developing on the drone. Luckily when you install the SDK from
+PyPI it includes a pre-built, local copy of this documentation. This documentation can be viewed by
+executing the following Python snippet:
+
+```python
+import blueye.sdk
+
+blueye.sdk.open_local_documentation()
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ packages = [
   { include = "blueye" }
 ]
 
+include= ["site/*"]
 readme = "README.md"
 repository="https://github.com/blueye-robotics/blueye.sdk"
 homepage ="https://www.blueyerobotics.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [
   { include = "blueye" }
 ]
 
-include= ["site/*"]
+include= ["blueye.sdk_docs/**/*"]
 readme = "README.md"
 repository="https://github.com/blueye-robotics/blueye.sdk"
 homepage ="https://www.blueyerobotics.com"

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -139,3 +139,14 @@ class TestSlaveMode:
         mocked_slave_pioneer.lights = 0
 
         mocked_warn.assert_called_once()
+
+
+def test_documentation_opener(mocker):
+    mocked_webbrowser_open = mocker.patch("webbrowser.open", autospec=True)
+    import blueye.sdk
+
+    blueye.sdk.__file__ = "/root/blueye/sdk/__init__.py"
+
+    blueye.sdk.open_local_documentation()
+
+    mocked_webbrowser_open.assert_called_with("/root/blueye.sdk_docs/README.html")

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -144,8 +144,9 @@ class TestSlaveMode:
 def test_documentation_opener(mocker):
     mocked_webbrowser_open = mocker.patch("webbrowser.open", autospec=True)
     import blueye.sdk
+    import os
 
-    blueye.sdk.__file__ = "/root/blueye/sdk/__init__.py"
+    blueye.sdk.__file__ = os.path.abspath("/root/blueye/sdk/__init__.py")
 
     blueye.sdk.open_local_documentation()
 

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -150,4 +150,6 @@ def test_documentation_opener(mocker):
 
     blueye.sdk.open_local_documentation()
 
-    mocked_webbrowser_open.assert_called_with("/root/blueye.sdk_docs/README.html")
+    mocked_webbrowser_open.assert_called_with(
+        os.path.abspath("/root/blueye.sdk_docs/README.html")
+    )


### PR DESCRIPTION
This PR ensures that for every release the documenation is built in a local-view-friendly way and included with the pip package. This ensures that you always have the documentation handy, even if you don't have internet access.

Fixes #31 
