### PR TITLE
Document http endpoints

### DIFF
--- a/.github/workflows/DeployDocumentation.yml
+++ b/.github/workflows/DeployDocumentation.yml
@@ -18,6 +18,8 @@ jobs:
         version: 1.0.0b3
     - name: Install dependencies
       run: poetry install
+    - name: Build HTTP documentation
+      run: npx redoc-cli bundle http-api.yml --output docs/http-api.html
     - name: Build documentation
       run: poetry run portray -- as_html --overwrite
 

--- a/.github/workflows/PublishRelease.yml
+++ b/.github/workflows/PublishRelease.yml
@@ -21,6 +21,8 @@ jobs:
       run: poetry install
     - name: Update mkdocs config for local browsing
       run: sed -i "s/\[tool.portray.mkdocs\]$/&\nuse_directory_urls = false/" pyproject.toml
+    - name: Build HTTP documentation
+      run: npx redoc-cli bundle http-api.yml --output docs/http-api.html
     - name: Build documentation for publishing
       run: poetry run portray -- as_html --overwrite --output_dir blueye.sdk_docs
     - name: Build package with poetry, including documentation

--- a/http-api.yml
+++ b/http-api.yml
@@ -18,7 +18,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#components/schemas/DroneInfo'
+                $ref: '#/components/schemas/DroneInfo'
 
   /logcsv:
     get:

--- a/http-api.yml
+++ b/http-api.yml
@@ -92,10 +92,19 @@ components:
       properties:
         name:
           type: string
+          description: |
+            Name of the logfile. First part is the drones unique id, second part is the dive count.
+          example: ea9ac92e1817a1d4-00073.csv
         binsize:
           type: integer
+          description: Size of the log file. Unit is bytes.
+          example: 1099448
         timestamp:
           type: string
+          description: Start time of the dive. Unit is ISO8601 datetime without timezone data.
+          example: "2019-01-01T00:00:00.000001"
         maxdepth:
           type: number
           format: float
+          description: Maximum depth reached during the dive. Unit is millimeters.
+          example: 21050

--- a/http-api.yml
+++ b/http-api.yml
@@ -36,7 +36,41 @@ paths:
             import requests
             response = requests.get("http://192.168.1.101/diagnostics/drone_info")
             print(response.json())
+  /diagnostics/iperf:
+    post:
+      tags:
+        - "Diagnostics"
+      summary: Tether bandwidth test
+      description: |
+        Performs a bandwidth test on the connection between the surface unit and the drone. Set the
+        test duration with the "duration"-parameter. A longer duration should yield a more accurate
+        result.
+      parameters:
+        - in: query
+          name: "duration"
+          description: Duration of the test to perform. Unit is seconds.
+          required: false
+          schema:
+            type: integer
+            default: 10
+      responses:
+        '200':
+          description: A JSON string with the performance test results.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IperfResult"
+      x-code-samples:
+        - lang: "curl"
+          source: |
+            curl -X POST "http://192.168.1.101/diagnostics/iperf" -d duration=5
 
+        - lang: "Python"
+          source: |
+            import requests
+            response = requests.post("http://192.168.1.101/diagnostics/iperf",
+                                      data={"duration": 5})
+            print(response.json())
   /logcsv:
     get:
       tags:
@@ -285,6 +319,27 @@ components:
             Human-friendly name of software running on the drone.
             Format is $(Major).$(Minor).$(Build)-$(Yocto version)-$(Branch)
           example: "1.4.7-warrior-master"
+
+    IperfResult:
+      type: object
+      properties:
+        received_Mbps:
+          type: number
+          format: float
+          description: Bandwidth from surface unit to drone. Unit is Mbps.
+          example: 79.55458795899487
+        sent_Mbps:
+          type: number
+          format: float
+          description: Bandwidth from drone to surface unit. Unit is Mbps.
+          example: 80.37122746322603
+        success:
+          type: boolean
+          description: If the test was succesful or not.
+          enum:
+            - true
+            - false
+          example: true
 
     Log:
       type: object

--- a/http-api.yml
+++ b/http-api.yml
@@ -17,6 +17,37 @@ paths:
               schema:
                 $ref: '#components/schemas/DroneInfo'
 
+  /logcsv:
+    get:
+      summary: Returns a list of logs on the drone.
+      responses:
+        '200':
+          description: Array of logs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Log'
+
+  /logcsv/{filename}:
+    get:
+      summary: Returns a comma-separated-value file with the requested name
+      parameters:
+        - name: filename
+          in: path
+          description: Filename of log to download
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Comma-separated-value file with log data
+          content:
+            text/csv:
+              schema:
+                type: string
+
 components:
   schemas:
     DroneInfo:
@@ -42,3 +73,16 @@ components:
           type: string
         sw_version:
           type: string
+
+    Log:
+      type: object
+      properties:
+        name:
+          type: string
+        binsize:
+          type: integer
+        timestamp:
+          type: string
+        maxdepth:
+          type: number
+          format: float

--- a/http-api.yml
+++ b/http-api.yml
@@ -96,24 +96,41 @@ components:
       properties:
         commit_id_csys:
           type: string
+          description: Commit-id of the software currently running on the drone.
+          example: "299238949a"
         features:
           type: string
+          description: Comma-separated list of available features on the drone.
+          example: "lasers,jetpack"
         hardware_id:
           type: string
+          description: Unique hardware id of the built-in single board computer.
+          example: ea9ac92e1817a1d4
         manufacturer:
           type: string
+          example: "Blueye Robotics"
         model_description:
           type: string
+          example: "Blueye Pioneer Underwater Drone"
         model_name:
           type: string
+          example: "Blueye Pioneer"
         model_url:
           type: string
+          example: "https://www.blueyerobotics.com"
         operating_system:
           type: string
+          example: "blunux"
         serial_number:
           type: string
+          description: Serial number for the whole drone package as it left the factory.
+          example: "BYEDP123456"
         sw_version:
           type: string
+          description: |
+            Human-friendly name of software running on the drone.
+            Format is $(Major).$(Minor).$(Build)-$(Yocto version)-$(Branch)
+          example: "1.4.7-warrior-master"
 
     Log:
       type: object

--- a/http-api.yml
+++ b/http-api.yml
@@ -8,7 +8,10 @@ servers:
 paths:
   /diagnostics/drone_info:
     get:
-      summary: Returns a list of drone information.
+      summary: Drone information
+      description: |
+        Returns a JSON string of drone information. Using this endpoint is the easiest way to check
+        if there is a drone connected to your network.
       responses:
         '200':
           description: A JSON string of drone information.

--- a/http-api.yml
+++ b/http-api.yml
@@ -46,6 +46,16 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Log'
+      x-code-samples:
+        - lang: "curl"
+          source: |
+            curl -X GET "http://192.168.1.101/logcsv"
+
+        - lang: "Python"
+          source: |
+            import requests
+            response = requests.get("http://192.168.1.101/logcsv")
+            print(response.json())
 
   /logcsv/{filename}:
     get:
@@ -65,6 +75,19 @@ paths:
             text/csv:
               schema:
                 type: string
+      x-code-samples:
+        - lang: "curl"
+          source: |
+            # To get log with filename ea9ac92e1817a1d4-00090.csv
+            curl -X GET "http://192.168.1.101/logcsv/ea9ac92e1817a1d4-00090.csv"
+
+        - lang: "Python"
+          source: |
+            import requests
+            logname = "ea9ac92e1817a1d4-00090.csv"
+            response = requests.get(f"http://192.168.1.101/logcsv/{logname}")
+            with open(logname, "wb") as f:
+              f.write(response.content)
 
 components:
   schemas:

--- a/http-api.yml
+++ b/http-api.yml
@@ -36,6 +36,7 @@ paths:
             import requests
             response = requests.get("http://192.168.1.101/diagnostics/drone_info")
             print(response.json())
+
   /diagnostics/iperf:
     post:
       tags:
@@ -71,6 +72,7 @@ paths:
             response = requests.post("http://192.168.1.101/diagnostics/iperf",
                                       data={"duration": 5})
             print(response.json())
+
   /logcsv:
     get:
       tags:
@@ -133,6 +135,7 @@ paths:
             response = requests.get(f"http://192.168.1.101/logcsv/{logname}")
             with open(logname, "wb") as f:
               f.write(response.content)
+
   /srt:
     get:
       tags:
@@ -277,6 +280,7 @@ paths:
             response = requests.get("http://192.168.1.101/srt", params=parameters)
             with open(f"{videoName}.srt", "wb") as f:
               f.write(response.content)
+
 components:
   schemas:
     DroneInfo:

--- a/http-api.yml
+++ b/http-api.yml
@@ -32,7 +32,11 @@ paths:
 
   /logcsv:
     get:
-      summary: Returns a list of logs on the drone.
+      summary: Array of logs
+      description: |
+        Returns an array of logs from the drone. Each array item represents an available log file on
+        the drone. Use the /logcsv/{filename} endpoint to get the full log.
+
       responses:
         '200':
           description: Array of logs
@@ -45,7 +49,8 @@ paths:
 
   /logcsv/{filename}:
     get:
-      summary: Returns a comma-separated-value file with the requested name
+      summary: CSV log-file
+      description: Downloads a comma-separated-value (CSV) log-file with the requested name.
       parameters:
         - name: filename
           in: path

--- a/http-api.yml
+++ b/http-api.yml
@@ -8,6 +8,7 @@ servers:
 tags:
   - name: "Diagnostics"
   - name: "Logs"
+  - name: "Subtitles"
 
 paths:
   /diagnostics/drone_info:
@@ -98,7 +99,150 @@ paths:
             response = requests.get(f"http://192.168.1.101/logcsv/{logname}")
             with open(logname, "wb") as f:
               f.write(response.content)
+  /srt:
+    get:
+      tags:
+        - "Subtitles"
+      summary: Download subtitle file
+      description: |
+        Downloads a subtitle file (srt) for a video file containing log data from the dive. The data
+        is gathered from the videos accompanying logfile. By passing in varius queries it is
+        possible to select which data one wants displayed, and where to display it.
+      parameters:
+        - name: file
+          in: query
+          description: "Name of the videofile to download subtitle file for."
+          required: true
+          schema:
+            type: string
+            example: "video_BYEDP123456_2019-01-01_000001.mp4"
+        - name: title
+          in: query
+          description: "Title of the video."
+          required: false
+          schema:
+            type: string
+            default: ""
+        - name: length-units
+          in: query
+          description: Unit to use for depth. Use "meter" for metric units, and "feet" for imperial.
+          required: false
+          schema:
+            type: string
+            default: "meter"
+            enum:
+              - "meter"
+              - "feet"
+        - name: temp-units
+          in: query
+          description: |
+            Unit to use for temperature. Use "celsius" for metric units, and "fahrenheit" for
+            imperial.
+          required: false
+          schema:
+            type: string
+            default: "celsius"
+        - name: placement
+          in: query
+          description: |
+            Where to place the subtitle. Use "top" for placing on the top, "bottom" for placing on
+            the bottom, and "" for using the player default.
+          required: false
+          schema:
+            type: string
+            default: "top"
+            enum:
+              - "top"
+              - "bottom"
+              - ""
+        - name: field-date
+          in: query
+          description: Enable or disable the date field. "1" to enable, "0" to disable.
+          required: false
+          schema:
+            type: integer
+            default: 0
+            enum:
+              - 0
+              - 1
 
+        - name: field-depth
+          in: query
+          description: Enable or disable the depth field. "1" to enable, "0" to disable.
+          required: false
+          schema:
+            type: integer
+            default: 1
+            enum:
+              - 0
+              - 1
+        - name: field-heading
+          in: query
+          description: Enable or disable the heading field. "1" to enable, "0" to disable.
+          required: false
+          schema:
+            type: integer
+            default: 1
+            enum:
+              - 0
+              - 1
+        - name: field-temp
+          in: query
+          description: Enable or disable the temperature field. "1" to enable, "0" to disable.
+          required: false
+          schema:
+            type: integer
+            default: 1
+            enum:
+              - 0
+              - 1
+        - name: date-format
+          in: query
+          description: "Format of the date/time."
+          required: false
+          schema:
+            type: string
+            default: "%Y-%m-%d %H:%M:%S"
+            externalDocs:
+              description: Python3 documentation for datetime formatting
+              url: https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior
+        - name: tz_offset
+          in: query
+          description: |
+            The drone stores all time in UTC+0, so if you were diving in another timezone and want
+            to correct for that in the displayed time you can add a timezone offset here. The unit
+            is minutes and both positive and negative values are supported.
+          required: false
+          schema:
+            type: integer
+            default: 0
+            format: int32
+
+      responses:
+        '200':
+          description: Subtitle file for the requested video file
+          content:
+            text/srt:
+              schema:
+                type: object
+      x-code-samples:
+        - lang: "curl"
+          source: |
+            curl -X GET -G "http://192.168.1.101/srt" \
+              -d "file=video_BYEDP000000_2019-11-20_093727.mp4" \
+              -d "title=My title"
+
+        - lang: "Python"
+          source: |
+            import requests
+            videoName = "video_BYEDP123456_2019-01-01_000001"
+            parameters = {
+                          "file": f"{videoName}.mp4",
+                          "title": "My title"
+                         }
+            response = requests.get("http://192.168.1.101/srt", params=parameters)
+            with open(f"{videoName}.srt", "wb") as f:
+              f.write(response.content)
 components:
   schemas:
     DroneInfo:

--- a/http-api.yml
+++ b/http-api.yml
@@ -1,0 +1,44 @@
+openapi: '3.0.2'
+info:
+  title: Blueye HTTP API
+  version: '1.0'
+servers:
+  - url: http://192.168.1.101/
+
+paths:
+  /diagnostics/drone_info:
+    get:
+      summary: Returns a list of drone information.
+      responses:
+        '200':
+          description: A JSON string of drone information.
+          content:
+            application/json:
+              schema:
+                $ref: '#components/schemas/DroneInfo'
+
+components:
+  schemas:
+    DroneInfo:
+      type: object
+      properties:
+        commit_id_csys:
+          type: string
+        features:
+          type: string
+        hardware_id:
+          type: string
+        manufacturer:
+          type: string
+        model_description:
+          type: string
+        model_name:
+          type: string
+        model_url:
+          type: string
+        operating_system:
+          type: string
+        serial_number:
+          type: string
+        sw_version:
+          type: string

--- a/http-api.yml
+++ b/http-api.yml
@@ -19,6 +19,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DroneInfo'
+      x-code-samples:
+        - lang: "curl"
+          source: |
+            curl -X GET "http://192.168.1.101/diagnostics/drone_info"
+
+        - lang: "Python"
+          source: |
+            import requests
+            response = requests.get("http://192.168.1.101/diagnostics/drone_info")
+            print(response.json())
 
   /logcsv:
     get:

--- a/http-api.yml
+++ b/http-api.yml
@@ -1,7 +1,7 @@
 openapi: '3.0.2'
 info:
   title: Blueye HTTP API
-  version: '1.0'
+  version: '1.0.0'
 servers:
   - url: http://192.168.1.101/
 

--- a/http-api.yml
+++ b/http-api.yml
@@ -5,9 +5,15 @@ info:
 servers:
   - url: http://192.168.1.101/
 
+tags:
+  - name: "Diagnostics"
+  - name: "Logs"
+
 paths:
   /diagnostics/drone_info:
     get:
+      tags:
+        - "Diagnostics"
       summary: Drone information
       description: |
         Returns a JSON string of drone information. Using this endpoint is the easiest way to check
@@ -32,6 +38,8 @@ paths:
 
   /logcsv:
     get:
+      tags:
+        - "Logs"
       summary: Array of logs
       description: |
         Returns an array of logs from the drone. Each array item represents an available log file on
@@ -59,6 +67,8 @@ paths:
 
   /logcsv/{filename}:
     get:
+      tags:
+        - "Logs"
       summary: CSV log-file
       description: Downloads a comma-separated-value (CSV) log-file with the requested name.
       parameters:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,9 @@ palette = {primary = "white", accent = "blue"}
     [[tool.portray.mkdocs.nav.Logs]]
     "Plotting log files" = "docs/logs/plotting.md"
 
+[[tool.portray.mkdocs.nav]]
+"HTTP API" = "docs/http-api.html"
+
 [tool.black]
 line-lenght = 100
 


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you fill out the blanks below.)
-->

**Description**
<!-- Describe the contents of the Pull request and problems it solves. -->
This PR introduces an [openAPI/swagger](https://swagger.io/docs/specification/about/) file for defining the HTTP API for the drone. This file is then generated into a static html file with [redoc](https://github.com/Redocly/redoc) which is included in the documentation for the SDK. Here's a link to the output that's generated: [http-api.zip](https://github.com/BluEye-Robotics/blueye.sdk/files/3901550/http-api.zip)

I'm not sure if the SDK is the correct place for the API definition to "live", ideally it would be in it's own repository (similary to how [ProtocolDefinitions](https://github.com/BluEye-Robotics/ProtocolDefinitions) is handled), that way we could easily pull it into the webserver on the drone and automatically run CI tests against the definition to see if everything still works. Thoughts, @follesoe?

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) --> 
Fixes #52
Fixes #53  
Fixes #55 


#### Checklist before merging

- [x] Run the tests while connected to a drone
