### PR TITLE
Improve connection flow

### DIFF
--- a/blueye/sdk/logs.py
+++ b/blueye/sdk/logs.py
@@ -100,9 +100,10 @@ class Logs:
     the last 10 logs you can do `p.logs[:-10]`.
     """
 
-    def __init__(self, parent_drone, auto_download_index=True):
+    def __init__(self, parent_drone, auto_download_index=False):
         self.ip = parent_drone._ip
         self._parent_drone = parent_drone
+        self.index_downloaded = False
         if auto_download_index:
             self.refresh_log_index()
         else:
@@ -129,8 +130,11 @@ class Logs:
 
         list_of_logs_in_dictionaries = self._get_list_of_logs_from_drone()
         self._logs = self._build_log_files_from_dictionary(list_of_logs_in_dictionaries)
+        self.index_downloaded = True
 
     def __getitem__(self, item):
+        if not self.index_downloaded:
+            self.refresh_log_index()
         if type(item) == str:
             try:
                 return self._logs[item]

--- a/blueye/sdk/logs.py
+++ b/blueye/sdk/logs.py
@@ -124,8 +124,8 @@ class Logs:
     def refresh_log_index(self):
         """Refresh the log index from the drone
 
-        This is method is run on instantiation by default, but if you would like to
-        check for new log files it can be called at any time.
+        This is method is run on the first log access by default, but if you would like to check
+        for new log files it can be called at any time.
         """
 
         list_of_logs_in_dictionaries = self._get_list_of_logs_from_drone()

--- a/blueye/sdk/motion.py
+++ b/blueye/sdk/motion.py
@@ -101,7 +101,7 @@ class Motion:
                              a positive set point makes the drone move to the right
         * **heave** (float): Force set point in the heave direction in range <-1, 1>,
                              a positive set point makes the drone move down.
-        * **yaw** (float): Moment set point in the sway direction in range <-1, 1>,
+        * **yaw** (float): Moment set point in the yaw direction in range <-1, 1>,
                              a positive set point makes the drone rotate clockwise.
         """
         self.current_thruster_setpoints["surge"] = surge

--- a/blueye/sdk/pioneer.py
+++ b/blueye/sdk/pioneer.py
@@ -162,8 +162,7 @@ class Pioneer:
                 self.motion.send_thruster_setpoint(0, 0, 0, 0)
             except ResponseTimeout as e:
                 raise ConnectionError(
-                    f"Found drone at {self._tcp_client._ip}:{self._tcp_client._port}, "
-                    "but was unable to establish communication with it. "
+                    f"Found drone at {self._tcp_client._ip} but was unable to take control of it. "
                     "Is there another client connected?"
                 ) from e
             except BrokenPipeError:

--- a/blueye/sdk/pioneer.py
+++ b/blueye/sdk/pioneer.py
@@ -84,6 +84,7 @@ class Pioneer:
 
     def __init__(self, ip="192.168.1.101", tcpPort=2011, autoConnect=True, slaveModeEnabled=False):
         self._ip = ip
+        self._port = tcpPort
         self._slaveModeEnabled = slaveModeEnabled
         if slaveModeEnabled:
             self._tcp_client = slaveTcpClient()
@@ -165,6 +166,12 @@ class Pioneer:
                     "but was unable to establish communication with it. "
                     "Is there another client connected?"
                 ) from e
+            except BrokenPipeError:
+                # Have lost connection to drone, need to reestablish TCP client
+                self._tcp_client.stop()
+                self.connection_established = False
+                self._tcp_client = TcpClient(ip=self._ip, port=self._port, autoConnect=False)
+                self._establish_tcp_connection()
         try:
             self._state_watcher.start()
         except RuntimeError:

--- a/blueye/sdk/pioneer.py
+++ b/blueye/sdk/pioneer.py
@@ -98,7 +98,14 @@ class Pioneer:
 
     def _update_drone_info(self):
         """Request and store information about the connected drone"""
-        response = requests.get(f"http://{self._ip}/diagnostics/drone_info").json()
+        try:
+            response = requests.get(f"http://{self._ip}/diagnostics/drone_info", timeout=3).json()
+        except (
+            requests.ConnectTimeout,
+            requests.ReadTimeout,
+            requests.ConnectionError,
+        ):
+            raise ConnectionError("Could not establish connection with drone")
         try:
             self.features = list(filter(None, response["features"].split(",")))
         except KeyError:

--- a/blueye/sdk/pioneer.py
+++ b/blueye/sdk/pioneer.py
@@ -3,9 +3,9 @@ import socket
 import threading
 import time
 import warnings
+from json import JSONDecodeError
 
 import requests
-
 from blueye.protocol import TcpClient, UdpClient
 from blueye.protocol.exceptions import ResponseTimeout
 
@@ -105,6 +105,7 @@ class Pioneer:
             requests.ConnectTimeout,
             requests.ReadTimeout,
             requests.ConnectionError,
+            JSONDecodeError,
         ):
             raise ConnectionError("Could not establish connection with drone")
         try:

--- a/blueye/sdk/pioneer.py
+++ b/blueye/sdk/pioneer.py
@@ -159,7 +159,7 @@ class Pioneer:
                 self._establish_tcp_connection()
             try:
                 self.ping()
-                self.motion.update_setpoint()
+                self.motion.send_thruster_setpoint(0, 0, 0, 0)
             except ResponseTimeout as e:
                 raise ConnectionError(
                     f"Found drone at {self._tcp_client._ip}:{self._tcp_client._port}, "

--- a/blueye/sdk/pioneer.py
+++ b/blueye/sdk/pioneer.py
@@ -87,7 +87,7 @@ class Pioneer:
         if slaveModeEnabled:
             self._tcp_client = slaveTcpClient()
         else:
-            self._tcp_client = TcpClient(ip=ip, port=tcpPort, autoConnect=autoConnect)
+            self._tcp_client = TcpClient(ip=ip, port=tcpPort, autoConnect=False)
         self._state_watcher = _PioneerStateWatcher()
         self.camera = Camera(self)
         self.motion = Motion(self)
@@ -115,7 +115,6 @@ class Pioneer:
         When watchdog message are published the thrusters are armed, to stop the drone from moving
         unexpectedly when connecting all thruster set points are set to zero when connecting.
         """
-        self._state_watcher.start()
         self._update_drone_info()
         if self._slaveModeEnabled is False:
             if self._tcp_client._sock is None and not self._tcp_client.isAlive():
@@ -131,6 +130,7 @@ class Pioneer:
                     "Is there another client connected?"
                 ) from e
             self.motion.update_setpoint()
+        self._state_watcher.start()
 
     @property
     def lights(self) -> int:

--- a/blueye/sdk/pioneer.py
+++ b/blueye/sdk/pioneer.py
@@ -91,7 +91,7 @@ class Pioneer:
         self._state_watcher = _PioneerStateWatcher()
         self.camera = Camera(self)
         self.motion = Motion(self)
-        self.logs = Logs(self, auto_download_index=autoConnect)
+        self.logs = Logs(self)
 
         if autoConnect is True:
             self.connect()
@@ -116,7 +116,6 @@ class Pioneer:
         unexpectedly when connecting all thruster set points are set to zero when connecting.
         """
         self._state_watcher.start()
-        self.logs.refresh_log_index()
         self._update_drone_info()
         if self._slaveModeEnabled is False:
             if self._tcp_client._sock is None and not self._tcp_client.isAlive():

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -119,3 +119,12 @@ def test_logs_raises_KeyError(log_list_with_two_logs):
 def test_logs_raises_IndexError(log_list_with_two_logs):
     with pytest.raises(IndexError):
         log_list_with_two_logs[3]
+
+
+def test_index_is_downloaded_on_first_access(log_list_with_two_logs):
+    """Tests that logs are not downloaded before someone attempts to access the logs. And that the
+    logs are downloaded after an access is attempted.
+    """
+    assert log_list_with_two_logs._logs == {}
+    _ = log_list_with_two_logs[0]
+    assert len(log_list_with_two_logs[::]) == 2

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -256,3 +256,16 @@ def test_still_picture_works_with_new_drone_version(mocked_pioneer, version):
     mocked_pioneer.camera.take_picture()
     mocked_pioneer._tcp_client.take_still_picture.assert_called_once()
     mocked_pioneer._tcp_client.reset_mock()
+
+
+def test_update_drone_info_raises_ConnectionError_when_not_connected(
+    requests_mock, mocked_pioneer
+):
+    import requests
+
+    requests_mock.get(
+        "http://192.168.1.101/diagnostics/drone_info",
+        exc=requests.exceptions.ConnectTimeout,
+    )
+    with pytest.raises(ConnectionError):
+        mocked_pioneer._update_drone_info()

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -288,3 +288,18 @@ def test_wait_for_udp_com_raises_ConnectionError_on_timeout(mocker):
     mocked_udp.get_data_dict.side_effect = socket.timeout
     with pytest.raises(ConnectionError):
         blueye.sdk.Pioneer._wait_for_udp_communication(1)
+
+
+def test_establish_tcp_connection_raises_ConnectionError(mocked_pioneer):
+    from blueye.protocol.exceptions import NoConnectionToDrone
+
+    mocked_pioneer._tcp_client.connect.side_effect = NoConnectionToDrone("", "")
+    with pytest.raises(ConnectionError):
+        mocked_pioneer._establish_tcp_connection()
+
+
+def test_establish_tcp_connection_ignores_RuntimeErrors(mocked_pioneer):
+    mocked_pioneer.connection_established = False
+    mocked_pioneer._tcp_client.start.side_effect = RuntimeError
+    mocked_pioneer._establish_tcp_connection()
+    assert mocked_pioneer.connection_established is True

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1,9 +1,9 @@
 from time import time
 from unittest.mock import Mock
 
-import pytest
-
 import blueye.sdk
+import pytest
+import requests
 
 
 @pytest.fixture(scope="class")
@@ -258,14 +258,20 @@ def test_still_picture_works_with_new_drone_version(mocked_pioneer, version):
     mocked_pioneer._tcp_client.reset_mock()
 
 
+@pytest.mark.parametrize(
+    "exception",
+    [
+        requests.exceptions.ConnectTimeout,
+        requests.exceptions.ReadTimeout,
+        requests.exceptions.ConnectionError,
+    ],
+)
 def test_update_drone_info_raises_ConnectionError_when_not_connected(
-    requests_mock, mocked_pioneer
+    requests_mock, mocked_pioneer, exception
 ):
-    import requests
 
     requests_mock.get(
-        "http://192.168.1.101/diagnostics/drone_info",
-        exc=requests.exceptions.ConnectTimeout,
+        "http://192.168.1.101/diagnostics/drone_info", exc=exception,
     )
     with pytest.raises(ConnectionError):
         mocked_pioneer._update_drone_info()


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! 
Please make sure you fill out the blanks below.)
-->

**Description**
<!-- Describe the contents of the Pull request and problems it solves. -->
Key updates:
- Only download log index when logs are accessed (instead of on instantiation of Pioneer class)
- Only raise `ConnectionError`s instead of a bunch of different exceptions when there are connection errors
- Make it possible to repeatedly call Pioneer.connect() in a try-except-loop  while waiting for it to boot. E.g.:
  ```python
  from blueye.sdk import Pioneer
  p = Pioneer(autoConnect=False)
  while True:
      try:
		  p.connect(1)
		  print("Success")
		  break
	  except ConnectionError:
		  print("retrying..")
  ```


#### Checklist before merging

- [x] Run the tests while connected to a drone
