### PR TITLE
Add configuration class

### DIFF
--- a/blueye/sdk/__init__.py
+++ b/blueye/sdk/__init__.py
@@ -1,2 +1,3 @@
 from .pioneer import Pioneer
 from .utils import open_local_documentation
+from .constants import WaterSalinity

--- a/blueye/sdk/__init__.py
+++ b/blueye/sdk/__init__.py
@@ -1,3 +1,3 @@
 from .pioneer import Pioneer
 from .utils import open_local_documentation
-from .constants import WaterSalinity
+from .constants import WaterDensities

--- a/blueye/sdk/constants.py
+++ b/blueye/sdk/constants.py
@@ -1,5 +1,5 @@
 """
-This file contains constants used by SDK.
+This file contains constants used by the SDK.
 """
 
 

--- a/blueye/sdk/constants.py
+++ b/blueye/sdk/constants.py
@@ -3,7 +3,11 @@ This file contains constants used by SDK.
 """
 
 
-class WaterSalinity:
+class WaterDensities:
+    """
+    Various typical densities for salt water (in grams/liter)
+    """
+
     fresh = 997
     brackish = 1011
-    salt = 1025
+    salty = 1025

--- a/blueye/sdk/constants.py
+++ b/blueye/sdk/constants.py
@@ -1,0 +1,9 @@
+"""
+This file contains constants used by SDK.
+"""
+
+
+class WaterSalinity:
+    fresh = 997
+    brackish = 1011
+    salt = 1025

--- a/blueye/sdk/pioneer.py
+++ b/blueye/sdk/pioneer.py
@@ -12,7 +12,7 @@ from blueye.protocol import TcpClient, UdpClient
 from blueye.protocol.exceptions import NoConnectionToDrone, ResponseTimeout
 
 from .camera import Camera
-from .constants import WaterSalinity
+from .constants import WaterDensities
 from .logs import Logs
 from .motion import Motion
 
@@ -78,7 +78,7 @@ class slaveTcpClient:
 class Config:
     def __init__(self, parent_drone: "Pioneer"):
         self._parent_drone = parent_drone
-        self._water_density = WaterSalinity.salt
+        self._water_density = WaterDensities.salty
 
     @property
     def water_density(self):
@@ -87,8 +87,8 @@ class Config:
         Setting the water density is only supported on drones with software version 1.5 or higher.
         Older software versions will assume a water density of 1025 grams per liter.
 
-        The WaterSalinity class contains three typical densities for salt, bracking, and fresh
-        water (these are the same values that the Blueye app uses).
+        The WaterDensities class contains typical densities for salty-, brackish-, and fresh water
+        (these are the same values that the Blueye app uses).
         """
         return self._water_density
 

--- a/blueye/sdk/pioneer.py
+++ b/blueye/sdk/pioneer.py
@@ -76,7 +76,7 @@ class slaveTcpClient:
 
 
 class Config:
-    def __init__(self, parent_drone):
+    def __init__(self, parent_drone: "Pioneer"):
         self._parent_drone = parent_drone
         self._water_density = WaterSalinity.salt
 

--- a/blueye/sdk/pioneer.py
+++ b/blueye/sdk/pioneer.py
@@ -102,6 +102,14 @@ class Config:
         self._water_density = density
         self._parent_drone._tcp_client.set_water_density(density)
 
+    def set_drone_time(self, time: int):
+        """Set the system for the drone
+
+        This method is used to set the system time for the drone. The argument `time` is expected to
+        be a Unix timestamp (ie. the number of seconds since the epoch).
+        """
+        self._parent_drone._tcp_client.set_system_time(time)
+
 
 class Pioneer:
     """A class providing a interface to the Blueye pioneer's basic functions

--- a/blueye/sdk/pioneer.py
+++ b/blueye/sdk/pioneer.py
@@ -200,6 +200,10 @@ class Pioneer:
             try:
                 self.ping()
                 self.motion.send_thruster_setpoint(0, 0, 0, 0)
+
+                # The drone runs from a read-only filesystem, and as such does not keep any state,
+                # therefore when we connect to it we should send the current time
+                self.config.set_drone_time(int(time.time()))
             except ResponseTimeout as e:
                 raise ConnectionError(
                     f"Found drone at {self._tcp_client._ip} but was unable to take control of it. "

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,8 +32,7 @@ from blueye.sdk import Pioneer
 
 p = Pioneer()
 
-p.camera.bitrate = 8000000 # 8 Mbit bitrate
-
+p.camera.bitrate = 8_000_000 # 8 Mbit bitrate
 ```
 
 Due to a bug in the camera streaming on the drone a camera stream has to have been opened at least once before camera parameters can be set on the drone, see issue [#67](https://github.com/BluEye-Robotics/blueye.sdk/issues/67). For instructions on how to start a video stream see, the [`Quick Start Guide`](../quick_start/#watching-the-video-stream).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,38 @@
+There are settings on the drone that are remotely configurable from the Blueye mobile app. These can be set directly from the SDK.
+
+### Configure time and date
+The drone does not keep track of time internally. The SDK sets the time on the drone automatically when you connect initially. But you can also configure time and date manually like this
+
+```python
+import time
+from blueye.sdk import Pioneer
+
+p = Pioneer()
+
+time_to_set_on_drone = int(time.time()) # Unix Timestamp
+p.config.set_drone_time(time_to_set_on_drone)
+```
+
+### Configure water density
+The water density on the drone default to a reasonable density for salt water: 1025 grams per liter. For more accurate depth readings, the water density can be configured manually to suit your local conditions
+
+```python
+from blueye.sdk import Pioneer
+
+p = Pioneer()
+
+p.config.water_density = 997 # water density in grams per liter for fresh water
+```
+
+### Configure camera parameters
+There are 6 different camera parameters that can be set. For a full list of camera parameters and their possible values see the [`camera reference`](https://blueye-robotics.github.io/blueye.sdk/reference/blueye/sdk/pioneer/) section. For example you could set the camera bit rate like this
+
+```python
+from blueye.sdk import Pioneer
+
+p = Pioneer()
+
+p.camera.bitrate = 8000000 # 8 Mbit bitrate
+
+```
+Due to a bug in the camera streaming on the drone a camera stream has to have been opened at least once before camera parameters can be set on the drone, see issue [#67](https://github.com/BluEye-Robotics/blueye.sdk/issues/67). For instructions on how to start a video stream see, the [`Quick Start Guide`](https://blueye-robotics.github.io/blueye.sdk/docs/quick_start/).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,15 +13,25 @@ time_to_set_on_drone = int(time.time()) # Unix Timestamp
 p.config.set_drone_time(time_to_set_on_drone)
 ```
 
-### Configure water density
+### Calibrate pressure sensor for water density
 The water density on the drone default to a reasonable density for salt water: 1025 grams per liter. For more accurate depth readings, the water density can be configured manually to suit your local conditions
 
 ```python
-from blueye.sdk import Pioneer
+from blueye.sdk import Pioneer, WaterDensities
 
 p = Pioneer()
 
-p.config.water_density = 997 # water density in grams per liter for fresh water
+# Salt water
+p.config.water_density = WaterDensities.salty  # 1025 g/L
+
+# Brackish water
+p.config.water_density = WaterDensities.brackish  # 1011 g/L
+
+# Fresh water
+p.config.water_density = WaterDensities.fresh  # 997 g/L
+
+# Can also be set to arbitrary values
+p.config.water_density = 1234
 ```
 
 ### Configure camera parameters

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,4 +1,4 @@
-There are settings on the drone that are remotely configurable from the Blueye mobile app. These can be set directly from the SDK.
+There are settings on the drone that are remotely configurable from the Blueye mobile app. These can also be set directly from the SDK.
 
 ### Configure time and date
 The drone does not keep track of time internally. The SDK sets the time on the drone automatically when you connect initially. But you can also configure time and date manually like this
@@ -11,6 +11,21 @@ p = Pioneer()
 
 time_to_set_on_drone = int(time.time()) # Unix Timestamp
 p.config.set_drone_time(time_to_set_on_drone)
+```
+
+or if we for example want to offset the drone time 5 hours relative to our current system time we can do something like this:
+
+```python
+from blueye.sdk import Pioneer
+from datetime import timezone, timedelta, datetime
+
+p = Pioneer()
+
+offset_in_hours = timedelta(hours=5)
+equivalent_timezone = timezone(offset_in_hours)
+unix_timestamp = datetime.now(tz=equivalent_timezone).timestamp()
+
+p.config.set_drone_time(int(unix_timestamp))
 ```
 
 ### Calibrate pressure sensor for water density

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ p.config.water_density = 997 # water density in grams per liter for fresh water
 ```
 
 ### Configure camera parameters
-There are 6 different camera parameters that can be set. For a full list of camera parameters and their possible values see the [`camera reference`](https://blueye-robotics.github.io/blueye.sdk/reference/blueye/sdk/pioneer/) section. For example you could set the camera bit rate like this
+There are 6 different camera parameters that can be set. For a full list of camera parameters and their possible values see the [`camera reference`](../../reference/blueye/sdk/camera) section. For example you could set the bit rate like this
 
 ```python
 from blueye.sdk import Pioneer
@@ -35,4 +35,5 @@ p = Pioneer()
 p.camera.bitrate = 8000000 # 8 Mbit bitrate
 
 ```
-Due to a bug in the camera streaming on the drone a camera stream has to have been opened at least once before camera parameters can be set on the drone, see issue [#67](https://github.com/BluEye-Robotics/blueye.sdk/issues/67). For instructions on how to start a video stream see, the [`Quick Start Guide`](https://blueye-robotics.github.io/blueye.sdk/docs/quick_start/).
+
+Due to a bug in the camera streaming on the drone a camera stream has to have been opened at least once before camera parameters can be set on the drone, see issue [#67](https://github.com/BluEye-Robotics/blueye.sdk/issues/67). For instructions on how to start a video stream see, the [`Quick Start Guide`](../quick_start/#watching-the-video-stream).

--- a/poetry.lock
+++ b/poetry.lock
@@ -200,6 +200,18 @@ pycodestyle = ">=2.5.0,<2.6.0"
 pyflakes = ">=2.1.0,<2.2.0"
 
 [[package]]
+category = "dev"
+description = "Let your Python tests travel through time"
+name = "freezegun"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.3.15"
+
+[package.dependencies]
+python-dateutil = ">=1.0,<2.0 || >2.0"
+six = "*"
+
+[[package]]
 category = "main"
 description = "Clean single-source support for Python 3 and 2"
 name = "future"
@@ -744,7 +756,7 @@ dev = ["pre-commit", "tox"]
 category = "main"
 description = "Extensions to the standard Python datetime module"
 name = "python-dateutil"
-optional = true
+optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 version = "2.8.1"
 
@@ -948,7 +960,7 @@ testing = ["jaraco.itertools"]
 examples = ["inputs", "asciimatics", "pandas", "matplotlib", "webdavclient3"]
 
 [metadata]
-content-hash = "d637e4a629ee420507a6af673c2a5ddb654a23ccaf6c2da1d3ed4310bd13355c"
+content-hash = "4ad237b800c42994c6a46da8b2ad2b73b2857027696b598efee235c2fcc629f0"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -1064,6 +1076,10 @@ falcon = [
 flake8 = [
     {file = "flake8-3.7.9-py2.py3-none-any.whl", hash = "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"},
     {file = "flake8-3.7.9.tar.gz", hash = "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb"},
+]
+freezegun = [
+    {file = "freezegun-0.3.15-py2.py3-none-any.whl", hash = "sha256:82c757a05b7c7ca3e176bfebd7d6779fd9139c7cb4ef969c38a28d74deef89b2"},
+    {file = "freezegun-0.3.15.tar.gz", hash = "sha256:e2062f2c7f95cc276a834c22f1a17179467176b624cc6f936e8bc3be5535ad1b"},
 ]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,5 +104,5 @@ line-length = 100
 target-version = ['py37', 'py38']
 
 [build-system]
-requires = ["poetry>=1.0.0b3"]
+requires = ["poetry>=1.0.0"]
 build-backend = "poetry.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,9 @@ palette = {primary = "white", accent = "blue"}
     "Plotting log files" = "docs/logs/plotting.md"
 
 [[tool.portray.mkdocs.nav]]
+"Configure drone parameters" = "docs/configuration.md"
+
+[[tool.portray.mkdocs.nav]]
 "HTTP API" = "docs/http-api.html"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ flake8 = "^3.7.8"
 pymdown-extensions = "^6.1"
 pytest-cov = "^2.8.1"
 requests-mock = "^1.7.0"
+freezegun = "^0.3.15"
 
 [tool.poetry.extras]
 examples = ["inputs", "asciimatics", "pandas", "matplotlib", "webdavclient3"]

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 import requests
+from freezegun import freeze_time
 
 import blueye.sdk
 from blueye.sdk import Pioneer
@@ -398,3 +399,9 @@ class TestConfig:
         mocked_pioneer.config.water_density = new_value
         assert mocked_pioneer.config.water_density == new_value
         mocked_pioneer._tcp_client.set_water_density.assert_called_once()
+
+    def test_set_drone_time_is_called_on_connetion(self, mocked_pioneer: Pioneer):
+        with freeze_time("2019-01-01"):
+            expected_time = int(time())
+            mocked_pioneer.connect()
+            mocked_pioneer._tcp_client.set_system_time.assert_called_with(expected_time)

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1,15 +1,15 @@
 from time import time
 from unittest.mock import Mock
 
-import blueye.sdk
 import pytest
 import requests
+
+import blueye.sdk
+from blueye.sdk import Pioneer
 
 
 @pytest.fixture(scope="class")
 def pioneer():
-    from blueye.sdk import Pioneer
-
     return Pioneer()
 
 
@@ -376,3 +376,25 @@ class TestTilt:
         mocked_pioneer.software_version_short = "1.5.33"
         mocked_pioneer._state_watcher._general_state = {"debug_flags": debug_flags}
         assert mocked_pioneer.camera.tilt.angle == expected_angle
+
+
+class TestConfig:
+    def test_water_density_property_returns_correct_value(self, mocked_pioneer: Pioneer):
+        mocked_pioneer.software_version_short = "1.5.33"
+        mocked_pioneer.config._water_density = 1000
+        assert mocked_pioneer.config.water_density == 1000
+
+    @pytest.mark.parametrize("version", ["0.1.2", "1.2.3", "1.4.7"])
+    def test_setting_density_fails_on_old_versions(self, mocked_pioneer: Pioneer, version):
+        mocked_pioneer.software_version_short = version
+        with pytest.raises(RuntimeError):
+            mocked_pioneer.config.water_density = 1000
+
+    @pytest.mark.parametrize("version", ["1.5.0", "1.6.2", "2.1.3"])
+    def test_setting_density_works_on_new_versions(self, mocked_pioneer: Pioneer, version):
+        mocked_pioneer.software_version_short = version
+        old_value = mocked_pioneer.config.water_density
+        new_value = old_value + 10
+        mocked_pioneer.config.water_density = new_value
+        assert mocked_pioneer.config.water_density == new_value
+        mocked_pioneer._tcp_client.set_water_density.assert_called_once()


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! 
Please make sure you fill out the blanks below.)
-->

**Description**
<!-- Describe the contents of the Pull request and problems it solves. -->
This PR adds a Config class containing various functionality for configuring the environment or state of the drone.

Currently it has functions for getting/setting the current water density, and for setting system time on the drone. I've also added a call in the connect() function to automatically set the time when connection is established.
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) --> 
Fixes #76
Fixes #72


#### Checklist before merging

- [x] Run the tests while connected to a drone
- [x] Add page to documentation explaining the new functions. 
