### PR TITLE
Make coverage upload optional

### DIFF
--- a/.github/workflows/DeployDocumentation.yml
+++ b/.github/workflows/DeployDocumentation.yml
@@ -6,28 +6,28 @@ jobs:
   DeployDocumentation:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v1
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    - name: Install poetry
-      uses: dschep/install-poetry-action@v1.2
-      with:
-        version: 1.0.0b3
-    - name: Install dependencies
-      run: poetry install
-    - name: Build HTTP documentation
-      run: npx redoc-cli bundle http-api.yml --output docs/http-api.html
-    - name: Build documentation
-      run: poetry run portray -- as_html --overwrite
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install poetry
+        uses: dschep/install-poetry-action@v1.2
+        with:
+          version: 1.0.0b3
+      - name: Install dependencies
+        run: poetry install
+      - name: Build HTTP documentation
+        run: npx redoc-cli bundle http-api.yml --output docs/http-api.html
+      - name: Build documentation
+        run: poetry run portray -- as_html --overwrite
 
-    - name: Deploy documentation
-      uses: JamesIves/github-pages-deploy-action@master
-      env:
-        ACCESS_TOKEN: ${{ secrets.GIT_TOKEN }}
-        BASE_BRANCH: master
-        BRANCH: gh-pages
-        FOLDER: site
-      if: github.ref == 'refs/heads/master'
+      - name: Deploy documentation
+        uses: JamesIves/github-pages-deploy-action@master
+        env:
+          ACCESS_TOKEN: ${{ secrets.GIT_TOKEN }}
+          BASE_BRANCH: master
+          BRANCH: gh-pages
+          FOLDER: site
+        if: github.ref == 'refs/heads/master'

--- a/.github/workflows/PublishRelease.yml
+++ b/.github/workflows/PublishRelease.yml
@@ -9,23 +9,23 @@ jobs:
     name: Build and publish a release to PyPI
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v1
-    - name: Set up python
-      uses: actions/setup-python@v1
-    - name: Install poetry
-      uses: dschep/install-poetry-action@v1.2
-      with:
-        version: 1.0.0b3
-    - name: Install dependencies
-      run: poetry install
-    - name: Update mkdocs config for local browsing
-      run: sed -i "s/\[tool.portray.mkdocs\]$/&\nuse_directory_urls = false/" pyproject.toml
-    - name: Build HTTP documentation
-      run: npx redoc-cli bundle http-api.yml --output docs/http-api.html
-    - name: Build documentation for publishing
-      run: poetry run portray -- as_html --overwrite --output_dir blueye.sdk_docs
-    - name: Build package with poetry, including documentation
-      run: poetry build
-    - name: Publish to PyPI
-      run: poetry publish --username __token__ --password ${{ secrets.PYPI_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Set up python
+        uses: actions/setup-python@v1
+      - name: Install poetry
+        uses: dschep/install-poetry-action@v1.2
+        with:
+          version: 1.0.0b3
+      - name: Install dependencies
+        run: poetry install
+      - name: Update mkdocs config for local browsing
+        run: sed -i "s/\[tool.portray.mkdocs\]$/&\nuse_directory_urls = false/" pyproject.toml
+      - name: Build HTTP documentation
+        run: npx redoc-cli bundle http-api.yml --output docs/http-api.html
+      - name: Build documentation for publishing
+        run: poetry run portray -- as_html --overwrite --output_dir blueye.sdk_docs
+      - name: Build package with poetry, including documentation
+        run: poetry build
+      - name: Publish to PyPI
+        run: poetry publish --username __token__ --password ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -10,48 +10,48 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python: [3.7, 3.8]
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version:  ${{ matrix.python }}
-    - name: Install poetry
-      uses: dschep/install-poetry-action@v1.2
-      with:
-        version: 1.0.0b3
-    - name: Install dependencies
-      run: poetry install
-    - name: Run tests
-      run: poetry run pytest -- -k "not connected_to_drone" --cov-report=xml --cov blueye
-    - name: Upload coverage
-      run: |
-        curl -s https://codecov.io/bash |\
-        bash -s -- -F \
-          $(echo ${{ matrix.os}} |\
-          cut -d "-" -f 1 |\
-          sed "s/$/_python${{ matrix.python }}/" |\
-          sed "s/\.//")
-      shell: bash
-      env:
-        CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
+      - uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install poetry
+        uses: dschep/install-poetry-action@v1.2
+        with:
+          version: 1.0.0b3
+      - name: Install dependencies
+        run: poetry install
+      - name: Run tests
+        run: poetry run pytest -- -k "not connected_to_drone" --cov-report=xml --cov blueye
+      - name: Upload coverage
+        run: |
+          curl -s https://codecov.io/bash |\
+          bash -s -- -F \
+            $(echo ${{ matrix.os}} |\
+            cut -d "-" -f 1 |\
+            sed "s/$/_python${{ matrix.python }}/" |\
+            sed "s/\.//")
+        shell: bash
+        env:
+          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
 
   CheckFormatting:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout source
-      uses: actions/checkout@v1
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version:  3.8
-    - name: Install poetry
-      uses: dschep/install-poetry-action@v1.2
-      with:
-        version: 1.0.0b3
-    - name: poetry install
-      run: poetry install
-    - name: Check formatting
-      run: poetry run black -- --check .
-    - name: Print formatting diff
-      run: poetry run black -- --diff .
-      if: failure()
+      - name: Checkout source
+        uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install poetry
+        uses: dschep/install-poetry-action@v1.2
+        with:
+          version: 1.0.0b3
+      - name: poetry install
+        run: poetry install
+      - name: Check formatting
+        run: poetry run black -- --check .
+      - name: Print formatting diff
+        run: poetry run black -- --diff .
+        if: failure()

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -34,6 +34,7 @@ jobs:
         shell: bash
         env:
           CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
+        continue-on-error: true
 
   CheckFormatting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The bash script for uploading code coverage to codecov.io has proven to be quite unstable, and since the coverage is not in any way critical this PR enables `continue-on-error` for the upload step to avoid unnecessary failed builds.