### PR TITLE
Add downsampling divisor to log download function

### DIFF
--- a/blueye/sdk/logs.py
+++ b/blueye/sdk/logs.py
@@ -48,7 +48,7 @@ class LogFile:
             num /= 1024.0
         return f"{num:.1f} Gi{suffix}"
 
-    def download(self, output_path=None, output_name=None):
+    def download(self, output_path=None, output_name=None, downsample_divisor=10):
         """
         Download the specified log to your local file system
 
@@ -57,8 +57,11 @@ class LogFile:
 
         Specifying output_name will overwrite the default file name with whatever you
         have specified (be sure to include the .csv extension).
+
+        The drone samples the log content at 10 Hz, and by default this function downsamples this
+        rate to 1 Hz.
         """
-        log = requests.get(self.download_path).content
+        log = requests.get(self.download_path, params={"divisor": downsample_divisor}).content
         if output_path is None:
             output_path = "./"
         if output_name is None:

--- a/http-api.yml
+++ b/http-api.yml
@@ -124,6 +124,14 @@ paths:
             type: string
             example: "dashware"
             default: ""
+        - name: divisor
+          in: query
+          description: Divisor to use when downsampling CSV before downloading. Set to 1 to get max resolution.
+          required: false
+          schema:
+            type: integer
+            example: 1
+            default: 10
 
       responses:
         '200':

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -128,3 +128,18 @@ def test_index_is_downloaded_on_first_access(log_list_with_two_logs):
     assert log_list_with_two_logs._logs == {}
     _ = log_list_with_two_logs[0]
     assert len(log_list_with_two_logs[::]) == 2
+
+
+@pytest.mark.parametrize("divisor", [1, 10])
+def test_divisor_parameter_is_passed_to_request(requests_mock, mocker, divisor):
+    logname = "log.csv"
+    dummylog = LogFile(0, logname, "2019-01-01T00:00:00.000000", 0, "192.168.1.101")
+
+    dummy_csv_content = b"1,2,3"
+    requests_mock.get(
+        f"http://192.168.1.101/logcsv/{logname}?divisor={divisor}", content=dummy_csv_content
+    )
+
+    mocker.patch("builtins.open", mocker.mock_open())
+
+    dummylog.download(downsample_divisor=divisor)


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! 
Please make sure you fill out the blanks below.)
-->

**Description**
<!-- Describe the contents of the Pull request and problems it solves. -->
Extends the log download function with the option to specify the divisor to use when the CSV is downsampled.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) --> 
Fixes #97 

#### Todo before merging:

- [ ] Test while connected to a drone
- [ ] Add runtime check to ensure the connected drone supports the divisor-parameter
