### PR TITLE
Set drone time first to address timing issue

### DIFF
--- a/blueye/sdk/drone.py
+++ b/blueye/sdk/drone.py
@@ -265,12 +265,12 @@ class Drone:
             self._connect_to_tcp_socket()
 
         try:
-            self.ping()
-            self.motion.send_thruster_setpoint(0, 0, 0, 0)
-
             # The drone runs from a read-only filesystem, and as such does not keep any state,
             # therefore when we connect to it we should send the current time
             self.config.set_drone_time(int(time.time()))
+
+            self.ping()
+            self.motion.send_thruster_setpoint(0, 0, 0, 0)
 
             self._start_watchdog()
         except ResponseTimeout as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blueye.sdk"
-version = "1.0.0"
+version = "1.0.1"
 description = "SDK for controlling a Blueye underwater drone"
 authors = ["Sindre Hansen <sindre.hansen@blueye.no>",
            "Johannes Schrimpf <johannes.schrimpf@blueye.no>",


### PR DESCRIPTION
**Description**
Due to an initialization issue in the control system, the clock needs to be set right after connection. This will be fixed in Blunux 2.3, but this fix will make it possible to set the initial time also in earlier versions.


#### Checklist before merging

- [x] Run the tests while connected to a drone
- [x] Update the package version according to [semver](https://semver.org/)
