### PR TITLE
Add depth_sensor to drone_info api documentation

### DIFF
--- a/http-api.yml
+++ b/http-api.yml
@@ -819,6 +819,12 @@ components:
           type: string
           description: Commit-id of the software currently running on the drone.
           example: "299238949a"
+        depth_sensor:
+          type: string
+          description: |
+            Name of the depth sensor, f. ex. MS5837_30BA26, Keller_PA7LD.
+            Available from Blunux 2.3
+          example: "MS5837_30BA26"
         features:
           type: string
           description: Comma-separated list of available features on the drone.


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! 
Please make sure you fill out the blanks below.)
-->

**Description**
Add depth_sensor to drone_info api documentation. Activated from Blunux 2.3


#### Checklist before merging

- [ ] Run the tests while connected to a drone
- [ ] Update the package version according to [semver](https://semver.org/)
