### PR TITLE
Add hotfix for connecting to Blunux >3.0

### DIFF
--- a/blueye/sdk/drone.py
+++ b/blueye/sdk/drone.py
@@ -248,6 +248,12 @@ class Drone:
             # Ignore multiple starts
             pass
 
+    def _create_temporary_tcp_client(self):
+        temp_tcp_client = TcpClient()
+        temp_tcp_client.connect()
+        temp_tcp_client.stop()
+        temp_tcp_client._sock.close()
+
     def connect(self, timeout: float = None):
         """Start receiving telemetry info from the drone, and publishing watchdog messages
 
@@ -260,10 +266,8 @@ class Drone:
         self._update_drone_info()
         if version.parse(self.software_version_short) >= version.parse("3.0"):
             # Blunux 3.0 requires a TCP message before enabling UDP communication
-            temp_tcp_client = TcpClient()
-            temp_tcp_client.connect()
-            temp_tcp_client.stop()
-            temp_tcp_client._sock.close()
+            self._create_temporary_tcp_client()
+
         self._wait_for_udp_communication(timeout, self._ip)
         self._start_state_watcher_thread()
         if self._slave_mode_enabled:

--- a/blueye/sdk/drone.py
+++ b/blueye/sdk/drone.py
@@ -253,8 +253,14 @@ class Drone:
         - *timeout* (float): Seconds to wait for connection
         """
 
-        self._wait_for_udp_communication(timeout, self._ip)
         self._update_drone_info()
+        if version.parse(self.software_version_short) > version.parse("3.0"):
+            # Blunux 3.0 requires a TCP message before enabling UDP communication
+            temp_tcp_client = TcpClient()
+            temp_tcp_client.connect()
+            temp_tcp_client.stop()
+            temp_tcp_client._sock.close()
+        self._wait_for_udp_communication(timeout, self._ip)
         self._start_state_watcher_thread()
         if self._slave_mode_enabled:
             # No need to touch the TCP stuff if we're in slave mode so we return early

--- a/blueye/sdk/drone.py
+++ b/blueye/sdk/drone.py
@@ -7,7 +7,11 @@ from json import JSONDecodeError
 
 import requests
 from blueye.protocol import TcpClient, UdpClient
-from blueye.protocol.exceptions import MismatchedReply, NoConnectionToDrone, ResponseTimeout
+from blueye.protocol.exceptions import (
+    MismatchedReply,
+    NoConnectionToDrone,
+    ResponseTimeout,
+)
 from packaging import version
 
 from .camera import Camera

--- a/blueye/sdk/drone.py
+++ b/blueye/sdk/drone.py
@@ -258,7 +258,7 @@ class Drone:
         """
 
         self._update_drone_info()
-        if version.parse(self.software_version_short) > version.parse("3.0"):
+        if version.parse(self.software_version_short) >= version.parse("3.0"):
             # Blunux 3.0 requires a TCP message before enabling UDP communication
             temp_tcp_client = TcpClient()
             temp_tcp_client.connect()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blueye.sdk"
-version = "1.0.1"
+version = "1.0.2"
 description = "SDK for controlling a Blueye underwater drone"
 authors = ["Sindre Hansen <sindre.hansen@blueye.no>",
            "Johannes Schrimpf <johannes.schrimpf@blueye.no>",

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1,5 +1,5 @@
 from time import time
-from unittest.mock import PropertyMock
+from unittest.mock import Mock, PropertyMock
 
 import pytest
 import requests
@@ -91,6 +91,15 @@ def test_verify_sw_version_raises_connection_error_when_not_connected(mocked_dro
     )
     with pytest.raises(ConnectionError):
         mocked_drone._verify_required_blunux_version("1.4.7")
+
+
+def test_if_blunux_newer_than_3_create_tcp_first(mocked_drone: Drone):
+    mocked_drone.software_version_short = "3.0"
+    mocked_drone._create_temporary_tcp_client = Mock()
+    mocked_drone._update_drone_info = Mock()  # To avoid overwriting the version number
+    mocked_drone.connect()
+
+    mocked_drone._create_temporary_tcp_client.assert_called_once()
 
 
 def test_depth_reading(mocked_drone):

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1,11 +1,12 @@
 from time import time
 from unittest.mock import PropertyMock
 
-import blueye.sdk
 import pytest
 import requests
-from blueye.sdk import Drone
 from freezegun import freeze_time
+
+import blueye.sdk
+from blueye.sdk import Drone
 
 
 class TestLights:


### PR DESCRIPTION
Starting with Blunux 3.0 the drone requires a TCP connection before starting the service responsible for publishing UDP messages.
