### PR TITLE
Add v3 binlog support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ venv.bak/
 # mkdocs documentation
 /site
 blueye.sdk_docs
+docs/http-api.html
 
 # mypy
 .mypy_cache/

--- a/blueye/sdk/drone.py
+++ b/blueye/sdk/drone.py
@@ -16,7 +16,7 @@ from .battery import Battery
 from .camera import Camera
 from .connection import CtrlClient, ReqRepClient, TelemetryClient, WatchdogPublisher
 from .constants import WaterDensities
-from .logs import Logs
+from .logs import LegacyLogs
 from .motion import Motion
 
 logger = logging.getLogger(__name__)
@@ -171,7 +171,7 @@ class Drone:
         self._ip = ip
         self.camera = Camera(self, is_guestport_camera=False)
         self.motion = Motion(self)
-        self.logs = Logs(self)
+        self.legacy_logs = LegacyLogs(self)
         self.config = Config(self)
         self.battery = Battery(self)
         self.telemetry = Telemetry(self)

--- a/blueye/sdk/drone.py
+++ b/blueye/sdk/drone.py
@@ -16,7 +16,7 @@ from .battery import Battery
 from .camera import Camera
 from .connection import CtrlClient, ReqRepClient, TelemetryClient, WatchdogPublisher
 from .constants import WaterDensities
-from .logs import LegacyLogs
+from .logs import LegacyLogs, Logs
 from .motion import Motion
 
 logger = logging.getLogger(__name__)
@@ -171,6 +171,7 @@ class Drone:
         self._ip = ip
         self.camera = Camera(self, is_guestport_camera=False)
         self.motion = Motion(self)
+        self.logs = Logs(self)
         self.legacy_logs = LegacyLogs(self)
         self.config = Config(self)
         self.battery = Battery(self)

--- a/blueye/sdk/logs.py
+++ b/blueye/sdk/logs.py
@@ -2,6 +2,7 @@ import logging
 from datetime import datetime
 from typing import List, Optional
 import zlib
+from pathlib import Path
 
 import dateutil.parser
 import requests
@@ -52,28 +53,34 @@ class LogFile:
 
     def download(
         self,
-        output_path: Optional[str] = None,
-        output_name: Optional[str] = None,
+        output_path: Optional[Path] = None,
         write_to_file: bool = True,
     ) -> bytes:
-        """
-        Download the specified log to your local file system
+        """Download a log file from the drone
 
-        If you specify an output_path the log file will be downloaded to that directory
-        instead of the current one.
+        *Arguments*:
 
-        Specifying output_name will overwrite the default file name with whatever you
-        have specified.
+        * `output_path`:
+            Path to write the log file to. If `None`, the log will be written to the
+            current working directory. If the path is a directory, the log will be
+            downloaded to that directory with its original name. Else the log will be
+            downloaded to the specified path.
+        * `write_to_file`:
+            If True, the log will be written to the specified path. If False, the
+            log will only be returned as a bytes object.
 
-        Returns the downloaded log as bytes
+        *Returns*:
+
+        The compressed log file as a bytes object.
         """
         log = requests.get(self.download_url).content
         if write_to_file:
             if output_path is None:
-                output_path = "./"
-            if output_name is None:
-                output_name = f"{self.name}.bez"
-            with open(f"{output_path}{output_name}", "wb") as f:
+                output_path = Path(f"{self.name}.bez")
+            else:
+                if output_path.is_dir():
+                    output_path = output_path.joinpath(f"{self.name}.bez")
+            with open(output_path, "wb") as f:
                 f.write(log)
         return log
 

--- a/blueye/sdk/logs.py
+++ b/blueye/sdk/logs.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 import dateutil.parser
 import requests
@@ -44,7 +44,11 @@ class LogFile:
             human_readable_filesize(self.filesize),
         ]
 
-    def download(self, output_path: Optional[str] = None, output_name: Optional[str] = None):
+    def download(
+        self,
+        output_path: Optional[str] = None,
+        output_name: Optional[str] = None,
+    ) -> bytes:
         """
         Download the specified log to your local file system
 
@@ -54,6 +58,7 @@ class LogFile:
         Specifying output_name will overwrite the default file name with whatever you
         have specified.
 
+        Returns the downloaded log as bytes
         """
         log = requests.get(self.download_url).content
         if output_path is None:
@@ -62,6 +67,7 @@ class LogFile:
             output_name = f"{self.name}.bez"
         with open(f"{output_path}{output_name}", "wb") as f:
             f.write(log)
+        return log
 
     def __format__(self, format_specifier):
         if format_specifier == "with_header":

--- a/blueye/sdk/logs.py
+++ b/blueye/sdk/logs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from datetime import datetime
 from typing import List, Optional
@@ -53,7 +55,7 @@ class LogFile:
 
     def download(
         self,
-        output_path: Optional[Path] = None,
+        output_path: Optional[Path | str] = None,
         write_to_file: bool = True,
         timeout: float = 1,
     ) -> bytes:
@@ -81,6 +83,8 @@ class LogFile:
             if output_path is None:
                 output_path = Path(f"{self.name}.bez")
             else:
+                if type(output_path) == str:
+                    output_path = Path(output_path)
                 if output_path.is_dir():
                     output_path = output_path.joinpath(f"{self.name}.bez")
             with open(output_path, "wb") as f:

--- a/blueye/sdk/logs.py
+++ b/blueye/sdk/logs.py
@@ -55,6 +55,7 @@ class LogFile:
         self,
         output_path: Optional[Path] = None,
         write_to_file: bool = True,
+        timeout: float = 1,
     ) -> bytes:
         """Download a log file from the drone
 
@@ -68,12 +69,14 @@ class LogFile:
         * `write_to_file`:
             If True, the log will be written to the specified path. If False, the
             log will only be returned as a bytes object.
+        * `timeout`:
+            Seconds to wait for response
 
         *Returns*:
 
         The compressed log file as a bytes object.
         """
-        log = requests.get(self.download_url).content
+        log = requests.get(self.download_url, timeout=timeout).content
         if write_to_file:
             if output_path is None:
                 output_path = Path(f"{self.name}.bez")

--- a/blueye/sdk/logs.py
+++ b/blueye/sdk/logs.py
@@ -8,7 +8,7 @@ import tabulate
 logger = logging.getLogger(__name__)
 
 
-class LogFile:
+class LegacyLogFile:
     """
     This class is a container for a log file stored on the drone
 
@@ -88,14 +88,14 @@ class LogFile:
         return self._formatted_values[item]
 
 
-class Logs:
-    """This class is an index of the log files stored on the drone
+class LegacyLogs:
+    """This class is an index of the legacy csv log files stored on the drone
 
     To show the available logs you simply print this object, ie. if your Drone object
     is called `myDrone`, you can do:
 
     ```
-    print(myDrone.logs)
+    print(myDrone.legacy_logs)
     ```
 
     This will print a list of all available logs, with some of their metadata, such as
@@ -124,7 +124,7 @@ class Logs:
         loglist = {}
         for log in list_of_logs_in_dictionaries:
             try:
-                loglist[log["name"]] = LogFile(
+                loglist[log["name"]] = LegacyLogFile(
                     log["maxdepth"], log["name"], log["timestamp"], log["binsize"], self.ip
                 )
             except dateutil.parser.ParserError:

--- a/blueye/sdk/logs.py
+++ b/blueye/sdk/logs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import zlib
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable, Iterator, List, Optional, Tuple
 
@@ -99,7 +99,7 @@ class LogFile:
         self.name = name
         self.is_dive = is_dive
         self.filesize = filesize
-        self.start_time: datetime = datetime.fromtimestamp(start_time)
+        self.start_time: datetime = datetime.fromtimestamp(start_time, tz=timezone.utc)
         self.max_depth_magnitude = max_depth_magnitude
         self.download_url = f"http://{ip}/logs/{self.name}/binlog"
         self._formatted_values = [

--- a/blueye/sdk/logs.py
+++ b/blueye/sdk/logs.py
@@ -182,6 +182,7 @@ class Logs:
                 "The connection to the drone is not established, try calling the connect method "
                 "before retrying"
             )
+        logger.debug("Refreshing log index")
         logs_endpoint = f"http://{self._parent_drone._ip}/logs"
         logs: List[dict] = requests.get(logs_endpoint).json()
 
@@ -189,6 +190,7 @@ class Logs:
             # Extend index with dive info, sends a request for each log file so can be quite slow
             # for drones with many logs. Not necessary for Blunux >= 3.3 as dive info is included in
             # the index.
+            logger.debug(f"Getting dive info for {len(logs)} logs")
             for index, log in enumerate(logs):
                 dive_info = requests.get(f"{logs_endpoint}/{log['name']}/dive_info").json()
                 logs[index].update(dive_info)

--- a/blueye/sdk/logs.py
+++ b/blueye/sdk/logs.py
@@ -86,6 +86,11 @@ class Logs:
                 logger.info(f"Log {log['name']} does not have a binlog, ignoring")
         self.index_downloaded = True
 
+    def __len__(self):
+        if not self.index_downloaded:
+            self.refresh_log_index()
+        return len(self._logs)
+
 
 class LegacyLogFile:
     """

--- a/blueye/sdk/logs.py
+++ b/blueye/sdk/logs.py
@@ -152,6 +152,17 @@ class LogFile:
                 f.write(self.content)
         return self.content
 
+    def parse_to_stream(self) -> LogStream:
+        """Parse the log file to a stream
+
+        Will download the log if it is not already downloaded.
+
+        *Returns*:
+
+        A `LogStream` object
+        """
+        return LogStream(self.download(write_to_file=False))
+
     def __format__(self, format_specifier):
         if format_specifier == "with_header":
             return tabulate.tabulate(

--- a/blueye/sdk/logs.py
+++ b/blueye/sdk/logs.py
@@ -8,6 +8,17 @@ import tabulate
 logger = logging.getLogger(__name__)
 
 
+def human_readable_filesize(binsize: int) -> str:
+    """Convert bytes to human readable string"""
+    suffix = "B"
+    num = binsize
+    for unit in ["", "Ki", "Mi"]:
+        if abs(num) < 1024.0:
+            return f"{num:3.1f} {unit}{suffix}"
+        num /= 1024.0
+    return f"{num:.1f} Gi{suffix}"
+
+
 class LegacyLogFile:
     """
     This class is a container for a log file stored on the drone
@@ -40,17 +51,8 @@ class LegacyLogFile:
             self.name,
             self.timestamp.strftime("%d. %b %Y %H:%M"),
             f"{self.maxdepth/1000:.2f} m",
-            self._human_readable_filesize(),
+            human_readable_filesize(self.binsize),
         ]
-
-    def _human_readable_filesize(self):
-        suffix = "B"
-        num = self.binsize
-        for unit in ["", "Ki", "Mi"]:
-            if abs(num) < 1024.0:
-                return f"{num:3.1f} {unit}{suffix}"
-            num /= 1024.0
-        return f"{num:.1f} Gi{suffix}"
 
     def download(self, output_path=None, output_name=None, downsample_divisor=10):
         """

--- a/blueye/sdk/logs.py
+++ b/blueye/sdk/logs.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime
 from typing import List, Optional
+import zlib
 
 import dateutil.parser
 import requests
@@ -19,6 +20,11 @@ def human_readable_filesize(binsize: int) -> str:
             return f"{num:3.1f} {unit}{suffix}"
         num /= 1024.0
     return f"{num:.1f} Gi{suffix}"
+
+
+def decompress_log(log: bytes) -> bytes:
+    """Decompress a log file"""
+    return zlib.decompressobj(wbits=zlib.MAX_WBITS | 16).decompress(log)
 
 
 class LogFile:

--- a/blueye/sdk/logs.py
+++ b/blueye/sdk/logs.py
@@ -44,6 +44,25 @@ class LogFile:
             human_readable_filesize(self.filesize),
         ]
 
+    def download(self, output_path: Optional[str] = None, output_name: Optional[str] = None):
+        """
+        Download the specified log to your local file system
+
+        If you specify an output_path the log file will be downloaded to that directory
+        instead of the current one.
+
+        Specifying output_name will overwrite the default file name with whatever you
+        have specified.
+
+        """
+        log = requests.get(self.download_url).content
+        if output_path is None:
+            output_path = "./"
+        if output_name is None:
+            output_name = f"{self.name}.bez"
+        with open(f"{output_path}{output_name}", "wb") as f:
+            f.write(log)
+
     def __format__(self, format_specifier):
         if format_specifier == "with_header":
             return tabulate.tabulate(

--- a/blueye/sdk/logs.py
+++ b/blueye/sdk/logs.py
@@ -118,8 +118,10 @@ class LegacyLogs:
         else:
             self._logs = {}
 
-    def _get_list_of_logs_from_drone(self):
-        list_of_dictionaries = requests.get("http://" + self.ip + "/logcsv").json()
+    def _get_list_of_logs_from_drone(self, get_all: bool):
+        list_of_dictionaries = requests.get(
+            "http://" + self.ip + "/logcsv", params={"all": True} if get_all else {}
+        ).json()
         return list_of_dictionaries
 
     def _build_log_files_from_dictionary(self, list_of_logs_in_dictionaries):
@@ -135,18 +137,20 @@ class LegacyLogs:
                 )
         return loglist
 
-    def refresh_log_index(self):
+    def refresh_log_index(self, get_all_logs=False):
         """Refresh the log index from the drone
 
         This is method is run on the first log access by default, but if you would like to check
         for new log files it can be called at any time.
+
+        Pass with `get_all_logs=True` to include logs that are not classified as dives.
         """
         if not self._parent_drone.connected:
             raise ConnectionError(
                 "The connection to the drone is not established, try calling the connect method "
                 "before retrying"
             )
-        list_of_logs_in_dictionaries = self._get_list_of_logs_from_drone()
+        list_of_logs_in_dictionaries = self._get_list_of_logs_from_drone(get_all_logs)
         self._logs = self._build_log_files_from_dictionary(list_of_logs_in_dictionaries)
         self.index_downloaded = True
 

--- a/blueye/sdk/logs.py
+++ b/blueye/sdk/logs.py
@@ -48,6 +48,7 @@ class LogFile:
         self,
         output_path: Optional[str] = None,
         output_name: Optional[str] = None,
+        write_to_file: bool = True,
     ) -> bytes:
         """
         Download the specified log to your local file system
@@ -61,12 +62,13 @@ class LogFile:
         Returns the downloaded log as bytes
         """
         log = requests.get(self.download_url).content
-        if output_path is None:
-            output_path = "./"
-        if output_name is None:
-            output_name = f"{self.name}.bez"
-        with open(f"{output_path}{output_name}", "wb") as f:
-            f.write(log)
+        if write_to_file:
+            if output_path is None:
+                output_path = "./"
+            if output_name is None:
+                output_name = f"{self.name}.bez"
+            with open(f"{output_path}{output_name}", "wb") as f:
+                f.write(log)
         return log
 
     def __format__(self, format_specifier):

--- a/docs/logs/legacy-log-file-format.md
+++ b/docs/logs/legacy-log-file-format.md
@@ -1,4 +1,6 @@
-# Log file format
+# Legacy log file format
+This page describes the legacy log file format. Blunux v3.0 introduced a new logfile format, and no longer logs telemetry in this format. See [Plotting](../plotting) for an example on how to use the new format.
+
 The log files from the Blueye drones are in essence a recording of the data that is
 published over UDP stored as a comma-separated-value (CSV) file.
 

--- a/docs/logs/listing-and-downloading.md
+++ b/docs/logs/listing-and-downloading.md
@@ -1,75 +1,111 @@
 # Logs from the drone
 
-When the drone is powered on a new comma-separated-value file, where it
-stores telemetry data such as depth, temperature, and more, is created. The drone will log data
-as long as it is powered on. These files can be downloaded to your local system where you can plot
-them or use them however you see fit.
+When the drone is powered on a new log file is created, where it stores telemetry data such as depth, temperature, and more, is created. The drone will log data as long as it is powered on. These files can be downloaded to your local system where you can plot them or use them however you see fit.
 
 ## Listing the log files
 If your drone has completed 5 dives and you do
 
-```python
-from blueye.sdk import Drone
+=== "Binary logs"
+    ```python
+    from blueye.sdk import Drone
+    myDrone = Drone()
+    print(myDrone.logs)
+    ```
 
-myDrone = Drone()
-
-print(myDrone.logs)
-```
+=== "Legacy logs"
+    ```python
+    from blueye.sdk import Drone
+    myDrone = Drone()
+    print(myDrone.legacy_logs)
+    ```
 
 you should see something like the following lines be printed
 
-```
-Name                        Time                Max depth  Size
-ea9add4d40f69d4-00000.csv   24. Oct 2018 09:40  21.05 m    6.3 MiB
-ea9add4d40f69d4-00001.csv   25. Oct 2018 10:29  21.06 m    879.2 KiB
-ea9add4d40f69d4-00002.csv   31. Oct 2018 10:05  60.69 m    8.5 MiB
-ea9add4d40f69d4-00003.csv   31. Oct 2018 12:13  41.68 m    8.4 MiB
-ea9add4d40f69d4-00004.csv   02. Nov 2018 08:59  52.52 m    7.8 MiB
-```
+=== "Binary logs"
+    ```
+    Name                                Time                Max depth    Size
+    BYEDP000000_ea9ac92e1817a1d4_00000  07. Aug 2023 12:10  7 m          217.1 KiB
+    BYEDP000000_ea9ac92e1817a1d4_00001  08. Aug 2023 12:35  20 m         1.6 MiB
+    BYEDP000000_ea9ac92e1817a1d4_00002  09. Aug 2023 14:20  100 m        3.8 MiB
+    BYEDP000000_ea9ac92e1817a1d4_00003  10. Aug 2023 09:15  200 m        6.5 MiB
+    BYEDP000000_ea9ac92e1817a1d4_00004  11. Aug 2023 15:01  300 m        10.2 MiB
 
-The first part of the filename (the part before the -) is the unique ID of your drone
-and second part is the dive number. In addition we see the start time of the dive, the
-maximum depth reached, as well as the size of the log file.
+    ```
+    The first part of the filename (the part before the _) is the serial number of your drone, the second part is the unique ID of the drone, and the third part is the dive number. In addition we see the start time of the dive, the maximum depth reached, as well as the size of the log file.
 
-You might notice that there can be more log files listed then the amount of dives you have done.
-This is due to the fact that the drone creates a new log file whenever it is turned on,
-regardless of whether you actually took the drone for a dive. To easier separate out the
-log files that result from actual dives you can filter out all the dives with a max depth
-below some threshold. The Blueye app does this, filtering out all log files with a max depth
-below 20 cm.
+    Max depth is rounded down to the nearest meter for dives up to 10 meters, rounded down to the nearest 10 meters for dives up to 100 meters, and rounded down to the nearest 100 meters for deeper dives.
+
+=== "Legacy logs"
+    ```
+    Name                        Time                Max depth  Size
+    ea9add4d40f69d4-00000.csv   24. Oct 2018 09:40  21.05 m    6.3 MiB
+    ea9add4d40f69d4-00001.csv   25. Oct 2018 10:29  21.06 m    879.2 KiB
+    ea9add4d40f69d4-00002.csv   31. Oct 2018 10:05  60.69 m    8.5 MiB
+    ea9add4d40f69d4-00003.csv   31. Oct 2018 12:13  41.68 m    8.4 MiB
+    ea9add4d40f69d4-00004.csv   02. Nov 2018 08:59  52.52 m    7.8 MiB
+    ```
+
+    The first part of the filename (the part before the -) is the unique ID of your drone and second part is the dive number. In addition we see the start time of the dive, the maximum depth reached, as well as the size of the log file.
+
+    The drone will by default filter out logs with a max depth below 20 cm. If you wish to list all logs you can do so by manually refreshing the log index with the `get_all_logs` parameter set to to `True`.
+
+    ```python
+    myDrone.legacy_logs.refresh_log_index(get_all_logs=True)
+    ```
 
 ## Downloading a log file to your computer
 When you want to download a log file all you have to do is to call the `download()`
 method on the desired log and the file will be downloaded to your current folder.
 
-The `download()` method takes two optional parameters, `output_path` and `output_name`.
-These specify, respectively, which folder the log is downloaded to and what name it's
-stored with.
+Following are some examples of how one can download log files.
 
-## Example: Downloading multiple log files
-Downloading multiple log files is solved by a simple Python for-loop. The example below
-shows how one can download the last 3 logs to the current folder:
+!!! example "Downloading a single log file"
+    === "Binary logs"
+        The following will download the first log with its default name to the current folder:
+        ```python
+        myDrone.logs[0].download()
+        ```
 
-```python
-from blueye.sdk import Drone
+        If we wish to specify the name/path of the log file we can use the optional `output_path` parameter:
+        ```python
+        myDrone.logs[0].download(output_path="/tmp/my_log.bez")
+        ```
+    === "Legacy logs"
+        ```python
+        myDrone.legacy_logs[0].download()
+        ```
+        The `download()` method takes two optional parameters, `output_path` and `output_name`. These specify, respectively, which folder the log is downloaded to and what name it's stored with. So if we want to download the first log to the folder `/tmp` and name it `my_log` we can do
 
-myDrone = Drone()
+        ```python
+        myDrone.legacy_logs[0].download(output_path="/tmp", output_name="my_log")
+        ```
 
-for log in myDrone.logs[:-3]:
-    log.download()
-```
+!!! example "Downloading multiple log files"
+    Downloading multiple log files is solved by a simple Python for-loop. The example below shows how one can download the last 3 logs to the current folder:
+    === "Binary logs"
+        ```python
+        for log in myDrone.logs[:-3]:
+            log.download()
+        ```
+    === "Legacy logs"
+        ```python
+        for log in myDrone.legacy_logs[:-3]:
+            log.download()
+        ```
 
-## Example: Adding a prefix to log names
-The example code below shows how one can add a simple prefix to all log files when
-downloading:
+!!! example "Adding a prefix to log names"
+    The example code below shows how one can add a simple prefix to all log files when downloading:
 
-```python
-from blueye.sdk import Drone
+    === "Binary logs"
+        ```python
+        prefix = "pre_"
+        for log in myDrone.logs:
+            log.download(output_path=prefix+log.name+".bez")
+        ```
 
-myDrone = Drone()
-
-prefix = "pre_"
-
-for log in myDrone.logs:
-    log.download(output_name=prefix+log.name)
-```
+    === "Legacy logs"
+        ```python
+        prefix = "pre_"
+        for log in myDrone.logs:
+            log.download(output_name=prefix+log.name)
+        ```

--- a/docs/logs/listing-and-downloading.md
+++ b/docs/logs/listing-and-downloading.md
@@ -57,6 +57,45 @@ you should see something like the following lines be printed
     myDrone.legacy_logs.refresh_log_index(get_all_logs=True)
     ```
 
+## Selecting a log file
+There are multiple ways to select a log file from the logs index, here are some examples showing how to select by index, by name, and by slice.
+
+!!! example "By index"
+    === "Binary logs"
+        ```python
+        first_log: LogFile = myDrone.logs[0]
+        last_log: LogFile = myDrone.logs[-1]
+        ```
+
+    === "Legacy logs"
+        ```python
+        first_log: LegacyLogFile = myDrone.legacy_logs[0]
+        last_log: LegacyLogFile = myDrone.legacy_logs[-1]
+        ```
+
+!!! example "By name"
+    === "Binary logs"
+        ```python
+        log: LogFile = myDrone.logs["BYEDP000000_ea9ac92e1817a1d4_00000"]
+        ```
+
+    === "Legacy logs"
+        ```python
+        log: LegacyLogFile = myDrone.legacy_logs["ea9add4d40f69d4-00000.csv"]
+        ```
+
+!!! example "By slice"
+    === "Binary logs"
+        ```python
+        first_three_logs: Logs = myDrone.logs[:3]
+        every_other_log: Logs = myDrone.logs[::2]
+        ```
+
+    === "Legacy logs"
+        ```python
+        first_three_logs: List[LegacyLogFile] = myDrone.legacy_logs[:3]
+        every_other_log: List[LegacyLogFile] = myDrone.legacy_logs[::2]
+        ```
 ## Downloading a log file to your computer
 When you want to download a log file all you have to do is to call the `download()`
 method on the desired log and the file will be downloaded to your current folder.

--- a/docs/logs/listing-and-downloading.md
+++ b/docs/logs/listing-and-downloading.md
@@ -2,6 +2,10 @@
 
 When the drone is powered on a new log file is created, where it stores telemetry data such as depth, temperature, and more, is created. The drone will log data as long as it is powered on. These files can be downloaded to your local system where you can plot them or use them however you see fit.
 
+ Blunux v3.0 introduced a a modern binary log format to replace the older CSV-based logs. This updated format employs gzip compression and Google's Protocol Buffers (Protobuf) for serialization. Gzip compression reduces log file sizes, optimizing storage and data transfer. The integration of Protobuf streamlines log parsing and analysis, offering more efficient data handling.
+
+ Every entry in the binary log is a [BinlogRecord](../../protobuf-protocol/#binlogrecord) Protobuf message, which in turn contains a unix timestamp in UTC, the monotonic timestamp (time since boot), and an Any message wrapping the Blueye telemetry message. The telemetry messages are documented in the [telemtry proto](../../docs/protobuf-protocol/#telemetryproto).
+
 ## Listing the log files
 If your drone has completed 5 dives and you do
 

--- a/docs/logs/plotting.md
+++ b/docs/logs/plotting.md
@@ -10,7 +10,8 @@ it.
     from blueye.sdk import Drone
 
     myDrone = Drone()
-    log_bytes = d.logs[0].download(write_to_file=False)
+    log = myDrone.logs[0]
+    log_bytes = log.download(write_to_file=False)
     ```
 
     The `log_bytes` variable now contains the raw bytes of the log file. We can now initialize a `LogStream` object with these bytes and use it to iterate over the log entries.
@@ -31,12 +32,17 @@ it.
     divelog = pd.DataFrame.from_records(log_stream, columns=columns)
     ```
 
-    We'll now filter out all entries that are not depth telemetry messages, and extract the depth value from the remaining entries.
+    We'll now filter out all entries that are not depth telemetry messages and messages that were logged before the start of the dive.
 
     ```python
     depth_log = divelog[divelog.meta == bp.DepthTel]
-    depth_log["depth"] = depth_log["message"].apply(lambda x: x.depth.value)
+    depth_log = depth_log[depth_log.rt > log.start_time]
+    ```
 
+    We can now extract the depth value from the remaining entries
+
+    ```python
+    depth_log["depth"] = depth_log["message"].apply(lambda x: x.depth.value)
     ```
 
     We'll prepare our axes for plotting

--- a/docs/logs/plotting.md
+++ b/docs/logs/plotting.md
@@ -11,24 +11,16 @@ it.
 
     myDrone = Drone()
     log = myDrone.logs[0]
-    log_bytes = log.download(write_to_file=False)
     ```
 
-    The `log_bytes` variable now contains the raw bytes of the log file. We can now initialize a `LogStream` object with these bytes and use it to iterate over the log entries.
-
-    ```python
-    from blueye.sdk.logs import LogStream
-
-    log_stream = LogStream(log_bytes)
-    ```
-
-    Next we'll create a pandas dataframe from the log stream. We'll also specify the column names to make it easier to work with the dataframe later.
+    Next we'll parse the log to a stream and create a pandas dataframe from the records. We'll also specify the column names to make it easier to work with the dataframe later.
 
     ```python
     import pandas as pd
     import blueye.protocol as bp
 
     columns = ["rt", "delta", "meta", "message"]
+    log_stream = log.parse_to_stream()
     divelog = pd.DataFrame.from_records(log_stream, columns=columns)
     ```
 

--- a/examples/parse_log_to_dataframe.py
+++ b/examples/parse_log_to_dataframe.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import pandas as pd
+
+from blueye.sdk import Drone
+from blueye.sdk.logs import LogFile, LogStream
+
+
+def parse_to_dataframe(log: LogFile | Path) -> pd.DataFrame:
+    """Parse a log file to a pandas dataframe
+
+    Args:
+        log (LogFile | Path): The log file to parse
+
+    Returns:
+        pd.DataFrame: The dataframe with columns rt, delta, meta, message
+    """
+    log_bytes = b""
+    if isinstance(log, Path):
+        with open(log, "rb") as f:
+            log_bytes = f.read()
+    else:
+        log_bytes = log.download(write_to_file=False)
+    log_stream = LogStream(log_bytes)
+    columns = ["rt", "delta", "meta", "message"]
+    return pd.DataFrame.from_records(log_stream, columns=columns)
+
+
+if __name__ == "__main__":
+    d = Drone()
+    log = d.logs[0]
+    df_from_logfile = parse_to_dataframe(log)
+    path = Path("/tmp/logfile.bez")
+    log.download(output_path=path)
+    df_from_path = parse_to_dataframe(path)
+    assert df_from_logfile.equals(df_from_path)

--- a/http-api.yml
+++ b/http-api.yml
@@ -136,6 +136,42 @@ paths:
             with open(f"{logname}.bez", "wb") as f:
               f.write(response.content)
 
+  /logs/{logname}/dive_info:
+    get:
+      tags:
+        - "Dive data"
+      summary: Get dive info for binlog
+      description: |
+        Returns extended meta data for the requested log. This endpoint is mostly useful for Blunux
+        < 3.3, as the dive info is included with the output of the /logs endpoint from 3.3 and
+        onwards.
+      parameters:
+        - name: logname
+          in: path
+          description: Name of the log to download info for
+          required: true
+          schema:
+            type: string
+          example: BYEDP070018_ea9add4d0c1961d4_00388
+      responses:
+        "200":
+          description: Dive info
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DiveInfo"
+      x-code-samples:
+        - lang: "curl"
+          source: |
+            # To get info for log with name BYEDP070018_ea9add4d0c1961d4_00388
+            curl -X GET "http://192.168.1.101/logs/BYEDP070018_ea9add4d0c1961d4_00388/dive_info"
+        - lang: "Python"
+          source: |
+            import requests
+            logname = "BYEDP070018_ea9add4d0c1961d4_00388"
+            response = requests.get(f"http://192.168.1.101/logs/{logname}/dive_info")
+            print(response.json())
+
   /logcsv:
     get:
       tags:

--- a/http-api.yml
+++ b/http-api.yml
@@ -450,17 +450,17 @@ paths:
             type: integer
             example: "-180"
       responses:
-            description: Picture
-            content:
-              application/json:
-                schema:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/Picture'
-              image/jpeg:
-                schema:
-                  type: object
         "200":
+          description: Picture
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Picture"
+            image/jpeg:
+              schema:
+                type: object
       x-code-samples:
         - lang: "curl"
           source: |
@@ -515,12 +515,12 @@ paths:
             type: integer
             default: 85
       responses:
-            description: Picture thumbnail
-            content:
-              image/jpeg:
-                schema:
-                  type: object
         "200":
+          description: Picture thumbnail
+          content:
+            image/jpeg:
+              schema:
+                type: object
       x-code-samples:
         - lang: "curl"
           source: |
@@ -569,7 +569,7 @@ paths:
             default: ""
         - name: length-units
           in: query
-          description: | 
+          description: |
             Unit to use for all distance/length measurements such as depth, altitude, distance etc.
             For shorter lengths `mm` or `inches` will be used accordingly.
             * `meter` - Metric unit
@@ -673,7 +673,7 @@ paths:
           schema:
             type: integer
             default: 0
-            example:  "60"
+            example: "60"
             format: int32
         - name: logo
           in: query
@@ -768,25 +768,25 @@ paths:
                 type: object
 
       responses:
-            description: Upload sucessful
-            content:
-              text/html:
-                schema:
-                  type: string
-                  description: Image upload successful!
         "200":
+          description: Upload sucessful
+          content:
+            text/html:
+              schema:
+                type: string
+                description: Image upload successful!
 
-            description: Upload failed
-            content:
-              text/html:
-                schema:
-                  oneOf:
-                    - $ref: "#/components/schemas/FileNotPresent"
-                    - $ref: "#/components/schemas/FileSizeTooLarge"
-                    - $ref: "#/components/schemas/ImageIsCorrupt"
-                    - $ref: "#/components/schemas/ImageIsInvalid"
-                    - $ref: "#/components/schemas/ImageResolutionTooHigh"
         "400":
+          description: Upload failed
+          content:
+            text/html:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/FileNotPresent"
+                  - $ref: "#/components/schemas/FileSizeTooLarge"
+                  - $ref: "#/components/schemas/ImageIsCorrupt"
+                  - $ref: "#/components/schemas/ImageIsInvalid"
+                  - $ref: "#/components/schemas/ImageResolutionTooHigh"
 
       x-code-samples:
         - lang: "curl"
@@ -810,23 +810,23 @@ paths:
         Download the original user uploaded logo (PNG or JPG)
 
       responses:
-            description: Logo as an image file PNG/JPG
-            content:
-              image/png:
-                schema:
-                  type: object
-              image/jpeg:
-                schema:
-                  type: object
         "200":
+          description: Logo as an image file PNG/JPG
+          content:
+            image/png:
+              schema:
+                type: object
+            image/jpeg:
+              schema:
+                type: object
 
-            description: No logo found
-            content:
-              text/html:
-                schema:
-                  type: string
-                  description: No custom logo found!
         "404":
+          description: No logo found
+          content:
+            text/html:
+              schema:
+                type: string
+                description: No custom logo found!
 
       x-code-samples:
         - lang: "curl"
@@ -847,14 +847,14 @@ paths:
       description: |
         Delete the uploaded logo
       responses:
-            description: Deletes the uploaded logo file
-            content:
-              text/html:
-                schema:
-                  oneOf:
-                    - $ref: "#/components/schemas/LogoDeleted"
-                    - $ref: "#/components/schemas/NoLogoToDelete"
         "200":
+          description: Deletes the uploaded logo file
+          content:
+            text/html:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/LogoDeleted"
+                  - $ref: "#/components/schemas/NoLogoToDelete"
 
       x-code-samples:
         - lang: "curl"

--- a/http-api.yml
+++ b/http-api.yml
@@ -1,7 +1,7 @@
-openapi: '3.0.2'
+openapi: "3.0.2"
 info:
   title: Blueye HTTP API
-  version: '1.0.1'
+  version: "1.0.1"
 servers:
   - url: http://192.168.1.101/
 
@@ -21,12 +21,12 @@ paths:
         Returns a JSON string of drone information. Using this endpoint is the easiest way to check
         if there is a drone connected to your network.
       responses:
-        '200':
+        "200":
           description: A JSON string of drone information.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DroneInfo'
+                $ref: "#/components/schemas/DroneInfo"
       x-code-samples:
         - lang: "curl"
           source: |
@@ -56,7 +56,7 @@ paths:
             type: integer
             default: 10
       responses:
-        '200':
+        "200":
           description: A JSON string with the performance test results.
           content:
             application/json:
@@ -84,14 +84,14 @@ paths:
         the drone. Use the /logcsv/{filename} endpoint to get the full log.
 
       responses:
-        '200':
+        "200":
           description: Array of logs
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Log'
+                  $ref: "#/components/schemas/Log"
       x-code-samples:
         - lang: "curl"
           source: |
@@ -134,7 +134,7 @@ paths:
             default: 10
 
       responses:
-        '200':
+        "200":
           description: Comma-separated-value file with log data
           content:
             text/csv:
@@ -177,7 +177,7 @@ paths:
             type: integer
             example: "20"
       responses:
-        '200':
+        "200":
           description: Comma-separated-value file with log data
           content:
             text/csv:
@@ -241,7 +241,7 @@ paths:
             maximum: 360
             example: 180
       responses:
-        '200':
+        "200":
           description: Comma-separated-value file with log data
           content:
             text/csv:
@@ -394,7 +394,7 @@ paths:
               - "vtt"
 
       responses:
-        '200':
+        "200":
           description: Subtitle file for the requested video file
           content:
             text/srt:
@@ -450,7 +450,6 @@ paths:
             type: integer
             example: "-180"
       responses:
-        '200':
             description: Picture
             content:
               application/json:
@@ -461,6 +460,7 @@ paths:
               image/jpeg:
                 schema:
                   type: object
+        "200":
       x-code-samples:
         - lang: "curl"
           source: |
@@ -515,12 +515,12 @@ paths:
             type: integer
             default: 85
       responses:
-        '200':
             description: Picture thumbnail
             content:
               image/jpeg:
                 schema:
                   type: object
+        "200":
       x-code-samples:
         - lang: "curl"
           source: |
@@ -727,7 +727,7 @@ paths:
             enum: [0, 1]
 
       responses:
-        '200':
+        "200":
           description: Picture with overlay metadata
           content:
             image/jpeg:
@@ -768,15 +768,14 @@ paths:
                 type: object
 
       responses:
-        '200':
             description: Upload sucessful
             content:
               text/html:
                 schema:
                   type: string
                   description: Image upload successful!
+        "200":
 
-        '400':
             description: Upload failed
             content:
               text/html:
@@ -787,6 +786,7 @@ paths:
                     - $ref: "#/components/schemas/ImageIsCorrupt"
                     - $ref: "#/components/schemas/ImageIsInvalid"
                     - $ref: "#/components/schemas/ImageResolutionTooHigh"
+        "400":
 
       x-code-samples:
         - lang: "curl"
@@ -810,7 +810,6 @@ paths:
         Download the original user uploaded logo (PNG or JPG)
 
       responses:
-        '200':
             description: Logo as an image file PNG/JPG
             content:
               image/png:
@@ -819,14 +818,15 @@ paths:
               image/jpeg:
                 schema:
                   type: object
+        "200":
 
-        '404':
             description: No logo found
             content:
               text/html:
                 schema:
                   type: string
                   description: No custom logo found!
+        "404":
 
       x-code-samples:
         - lang: "curl"
@@ -847,7 +847,6 @@ paths:
       description: |
         Delete the uploaded logo
       responses:
-        '200':
             description: Deletes the uploaded logo file
             content:
               text/html:
@@ -855,6 +854,7 @@ paths:
                   oneOf:
                     - $ref: "#/components/schemas/LogoDeleted"
                     - $ref: "#/components/schemas/NoLogoToDelete"
+        "200":
 
       x-code-samples:
         - lang: "curl"
@@ -875,14 +875,14 @@ paths:
       description: |
         Returns uploaded logo md5sum
       responses:
-        '200':
+        "200":
           description: A JSON with the user defined logo MD5 checksum
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Md5"
 
-        '404':
+        "404":
           description: No custom logo found!
           content:
             text/html:

--- a/http-api.yml
+++ b/http-api.yml
@@ -1094,6 +1094,62 @@ components:
               "/videos/video_BYEDP070018_2023-07-31_125743_cam2.mp4",
             ]
 
+    DiveInfo:
+      type: object
+      properties:
+        blunux_version:
+          type: string
+          description: |
+            Version of the Blunux operating system running on the drone.
+            Format is $(Major).$(Minor).$(Build)-$(Yocto version)-$(Branch)
+          example: "3.0.47-honister-master"
+        is_dive:
+          type: boolean
+          description: |
+            If this log is a dive or not. If maximum depth has exceeded 0.25m or if any of the auto
+            function have been used the log will be classified as a dive.
+        is_valid:
+          type: boolean
+          description: |
+            If this log is valid or not. Unless something unexpected has occured this should be
+            True.
+        log_name:
+          type: string
+          description: |
+            Name of the logfile. First part is the drones serial number, seconds is the unique
+            hardware ID, and the last part is the dive number.
+            Note: Unlike the csv logs there is no extension in this name.
+          example: BYEDP070018_ea9add4d0c1961d4_00386
+        max_depth_magnitude:
+          type: integer
+          description: |
+            Maximum depth of the dive,  rounded down to the nearest meter for dives up to 10 meters,
+            rounded down to the nearest 10 meters for dives up to 100 meters, and rounded down to
+            the nearest 100 meters for deeper dives.
+        model_name:
+          type: string
+          description: |
+            Name of the drone model.
+          enum:
+            - Blueye Pioneer
+            - Blueye Pro
+            - Blueye X3
+        start_time:
+          type: integer
+          description: Unix timestamp of the start of the dive.
+          example: 1692002908
+        videos:
+          description: |
+            List of paths to videos recorded during the dive.
+          type: array
+          items:
+            type: string
+          example:
+            [
+              "/videos/video_BYEDP070018_2023-07-31_125743.mp4",
+              "/videos/video_BYEDP070018_2023-07-31_125743_cam2.mp4",
+            ]
+
     Log:
       type: object
       properties:

--- a/http-api.yml
+++ b/http-api.yml
@@ -27,7 +27,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DroneInfo"
-      x-code-samples:
+      x-codeSamples:
         - lang: "curl"
           source: |
             curl -X GET "http://192.168.1.101/diagnostics/drone_info"
@@ -62,7 +62,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/IperfResult"
-      x-code-samples:
+      x-codeSamples:
         - lang: "curl"
           source: |
             curl -X POST "http://192.168.1.101/diagnostics/iperf" -d duration=5
@@ -91,7 +91,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/BinLog"
-      x-code-samples:
+      x-codeSamples:
         - lang: "curl"
           source: |
             curl -X GET "http://192.168.1.101/logs"
@@ -123,7 +123,7 @@ paths:
               schema:
                 type: string
                 format: binary
-      x-code-samples:
+      x-codeSamples:
         - lang: "curl"
           source: |
             # To get log with name BYEDP070018_ea9add4d0c1961d4_00388
@@ -160,7 +160,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DiveInfo"
-      x-code-samples:
+      x-codeSamples:
         - lang: "curl"
           source: |
             # To get info for log with name BYEDP070018_ea9add4d0c1961d4_00388
@@ -210,7 +210,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Log"
-      x-code-samples:
+      x-codeSamples:
         - lang: "curl"
           source: |
             curl -X GET "http://192.168.1.101/logcsv"
@@ -250,7 +250,7 @@ paths:
             text/csv:
               schema:
                 type: string
-      x-code-samples:
+      x-codeSamples:
         - lang: "curl"
           source: |
             # To get log with filename ea9ac92e1817a1d4-00090.csv
@@ -277,7 +277,7 @@ paths:
             application/zip:
               schema:
                 type: file
-      x-code-samples:
+      x-codeSamples:
         - lang: "curl"
           source: |
             curl -X GET "http://192.168.1.101/logcsv/binary_logs.zip"
@@ -334,7 +334,7 @@ paths:
             text/csv:
               schema:
                 type: string
-      x-code-samples:
+      x-codeSamples:
         - lang: "curl"
           source: |
             # To get log CSV for videofile video_BYEDP123456_2019-01-01_000001.mp4
@@ -487,7 +487,7 @@ paths:
             text/srt:
               schema:
                 type: object
-      x-code-samples:
+      x-codeSamples:
         - lang: "curl"
           source: |
             curl -X GET -G "http://192.168.1.101/srt" \
@@ -549,7 +549,7 @@ paths:
             image/jpeg:
               schema:
                 type: object
-      x-code-samples:
+      x-codeSamples:
         - lang: "curl"
           source: |
             curl -X GET -G "http://192.168.1.101/picture" \
@@ -609,7 +609,7 @@ paths:
             image/jpeg:
               schema:
                 type: object
-      x-code-samples:
+      x-codeSamples:
         - lang: "curl"
           source: |
             curl -X GET -G "http://192.168.1.101/picture/thumbnail" \
@@ -821,7 +821,7 @@ paths:
             image/jpeg:
               schema:
                 type: object
-      x-code-samples:
+      x-codeSamples:
         - lang: "curl"
           source: |
             curl -X GET -G "http://192.168.1.101/picture/overlay" \
@@ -876,7 +876,7 @@ paths:
                   - $ref: "#/components/schemas/ImageIsInvalid"
                   - $ref: "#/components/schemas/ImageResolutionTooHigh"
 
-      x-code-samples:
+      x-codeSamples:
         - lang: "curl"
           source: |
             curl -X POST "http://192.168.1.101/asset/logo" --form 'image=@"logo.png"'
@@ -916,7 +916,7 @@ paths:
                 type: string
                 description: No custom logo found!
 
-      x-code-samples:
+      x-codeSamples:
         - lang: "curl"
           source: |
             curl -X GET "http://192.168.1.101/asset/logo"
@@ -944,7 +944,7 @@ paths:
                   - $ref: "#/components/schemas/LogoDeleted"
                   - $ref: "#/components/schemas/NoLogoToDelete"
 
-      x-code-samples:
+      x-codeSamples:
         - lang: "curl"
           source: |
             curl -X DELETE "http://192.168.1.101/asset/logo"
@@ -977,7 +977,7 @@ paths:
               schema:
                 type: string
                 description: No custom logo found!
-      x-code-samples:
+      x-codeSamples:
         - lang: "curl"
           source: |
             curl -X GET "http://192.168.1.101/asset/logo/md5"

--- a/http-api.yml
+++ b/http-api.yml
@@ -443,8 +443,9 @@ paths:
             example: "2"
         - name: tz-offset
           in: query
-          description: "Add timezone offset to the picture EXIF data in minutes, can also be negative number.
-          For example in Norway during summer time the correct value would be 60, while it would be -180 in Chile"
+          description: |
+            Add timezone offset to the picture EXIF data in minutes, can also be negative number.
+            For example in Norway during summer time the correct value would be 60, while it would be -180 in Chile
           required: false
           schema:
             type: integer

--- a/http-api.yml
+++ b/http-api.yml
@@ -82,6 +82,26 @@ paths:
       description: |
         Returns an array of logs from the drone. Each array item represents an available log file on
         the drone. Use the /logcsv/{filename} endpoint to get the full log.
+      parameters:
+        - name: all
+          in: query
+          description: |
+            Add `all` to the parameter list to show logs that are not classified as dives (no auto
+            functions enabled, and max depth < 0.25m). All logs will be shown regardless of the
+            content of the all parameter (even false, 0, etc).
+          required: false
+          schema:
+            type: any
+        - name: filter_depth_min_mm
+          in: query
+          description: |
+            Filter the minimum depth of the listed logs. Will be ignored if `all` is included in
+            parameter list.
+          required: false
+          schema:
+            type: integer
+            example: 1000
+            default: 250
 
       responses:
         "200":

--- a/http-api.yml
+++ b/http-api.yml
@@ -74,6 +74,34 @@ paths:
                                       data={"duration": 5})
             print(response.json())
 
+  /logs:
+    get:
+      tags:
+        - "Dive data"
+      summary: Array of binary logs
+      description: |
+        Returns an array of binary logs from the drone. Each array item represents an available log
+        file on the drone. Use the /logs/{filename}/binlog endpoint to get the full log.
+      responses:
+        "200":
+          description: Array of binary logs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/BinLog"
+      x-code-samples:
+        - lang: "curl"
+          source: |
+            curl -X GET "http://192.168.1.101/logs"
+        - lang: "Python"
+          source: |
+            import requests
+            response = requests.get("http://192.168.1.101/logs")
+            print(response.json())
+
+
   /logcsv:
     get:
       tags:

--- a/http-api.yml
+++ b/http-api.yml
@@ -166,54 +166,6 @@ paths:
             with open(logname, "wb") as f:
               f.write(response.content)
 
-  /pix4d:
-    get:
-      tags:
-        - "Dive data"
-      summary: Download CSV file with data for creating scaled 3D models
-      description: |
-        Download CSV file with data for creating scaled 3D models in Pix4d
-      parameters:
-        - name: file
-          in: query
-          description: "Name of the video file to download data for"
-          required: true
-          schema:
-            type: string
-            example: "video_BYEDP123456_2019-01-01_000001.mp4"
-        - name: frame-step
-          in: query
-          description: "Amout of steps between each frame grab"
-          required: false
-          schema:
-            type: integer
-            example: "20"
-      responses:
-        "200":
-          description: Comma-separated-value file with log data
-          content:
-            text/csv:
-              schema:
-                type: string
-      x-code-samples:
-        - lang: "curl"
-          source: |
-            # To get CSV logfile for filename video_BYEDP123456_2019-01-01_000001.mp4
-            curl -X GET "http://192.168.1.101/pix4d/" \
-              -d "file=video_BYEDP123456_2019-01-01_000001.mp4"
-
-        - lang: "Python"
-          source: |
-            import requests
-            fileName = "video_BYEDP123456_2019-01-01_000001"
-            parameters =  {
-                            "file": f"{fileName}.mp4",
-                            "frame-step": 20
-                          }
-            response = requests.get(f"http://192.168.1.101/pix4d" params=parameters)
-            with open(f"{fileName".csv}, "wb") as f:
-              f.write(response.content)
-
   /agisoft:
     get:
       tags:

--- a/http-api.yml
+++ b/http-api.yml
@@ -136,14 +136,6 @@ paths:
           required: true
           schema:
             type: string
-        - name: format
-          in: query
-          description: Add format=dashware to get a CSV file customized for use in Dashware to create video overlays
-          required: false
-          schema:
-            type: string
-            example: "dashware"
-            default: ""
         - name: divisor
           in: query
           description: Divisor to use when downsampling CSV before downloading. Set to 1 to get max resolution.

--- a/http-api.yml
+++ b/http-api.yml
@@ -101,6 +101,40 @@ paths:
             response = requests.get("http://192.168.1.101/logs")
             print(response.json())
 
+  /logs/{logname}/binlog:
+    get:
+      tags:
+        - "Dive data"
+      summary: Download a binary log file
+      description: Returns the binary content of the requested log
+      parameters:
+        - name: logname
+          in: path
+          description: Name of the log to download
+          required: true
+          schema:
+            type: string
+          example: BYEDP070018_ea9add4d0c1961d4_00388
+      responses:
+        "200":
+          description: Binary log file
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+      x-code-samples:
+        - lang: "curl"
+          source: |
+            # To get log with name BYEDP070018_ea9add4d0c1961d4_00388
+            curl -X GET "http://192.168.1.101/logs/BYEDP070018_ea9add4d0c1961d4_00388/binlog"
+        - lang: "Python"
+          source: |
+            import requests
+            logname = "BYEDP070018_ea9add4d0c1961d4_00388"
+            response = requests.get(f"http://192.168.1.101/logs/{logname}/binlog")
+            with open(f"{logname}.bez", "wb") as f:
+              f.write(response.content)
 
   /logcsv:
     get:

--- a/http-api.yml
+++ b/http-api.yml
@@ -960,6 +960,78 @@ components:
             - false
           example: true
 
+    BinLog:
+      type: object
+      properties:
+        binlog_size:
+          type: integer
+          description: Size of the log file. Unit is bytes.
+          example: 1099448
+        blunux_version:
+          type: string
+          description: |
+            Version of the Blunux operating system running on the drone.
+            Format is $(Major).$(Minor).$(Build)-$(Yocto version)-$(Branch)
+          example: "3.0.47-honister-master"
+        has_binlog:
+          type: boolean
+          description: |
+            If this log has a binlog or not. Unless something unexpected has occured this should be
+            True.
+        has_dive_info:
+          type: boolean
+          description: |
+            If this log has dive info or not. Unless something unexpected has occured this should be
+            True.
+        is_dive:
+          type: boolean
+          description: |
+            If this log is a dive or not. If maximum depth has exceeded 0.25m or if any of the auto
+            function have been used the log will be classified as a dive.
+        is_open:
+          type: boolean
+          description: If this is the log currently being written to.
+        log_number:
+          type: integer
+          description: |
+            Number of the log. This is the same as the number in the filename.
+        max_depth_magnitude:
+          type: integer
+          description: |
+            Maximum depth of the dive,  rounded down to the nearest meter for dives up to 10 meters,
+            rounded down to the nearest 10 meters for dives up to 100 meters, and rounded down to
+            the nearest 100 meters for deeper dives.
+        model_name:
+          type: string
+          description: |
+            Name of the drone model.
+          enum:
+            - Blueye Pioneer
+            - Blueye Pro
+            - Blueye X3
+        name:
+          type: string
+          description: |
+            Name of the logfile. First part is the drones serial number, seconds is the unique
+            hardware ID, and the last part is the dive number.
+            Note: Unlike the csv logs there is no extension in this name.
+          example: BYEDP070018_ea9add4d0c1961d4_00386
+        start_time:
+          type: integer
+          description: Unix timestamp of the start of the dive.
+          example: 1692002908
+        videos:
+          description: |
+            List of paths to videos recorded during the dive.
+          type: array
+          items:
+            type: string
+          example:
+            [
+              "/videos/video_BYEDP070018_2023-07-31_125743.mp4",
+              "/videos/video_BYEDP070018_2023-07-31_125743_cam2.mp4",
+            ]
+
     Log:
       type: object
       properties:

--- a/http-api.yml
+++ b/http-api.yml
@@ -166,6 +166,31 @@ paths:
             with open(logname, "wb") as f:
               f.write(response.content)
 
+  /logcsv/binary_logs.zip:
+    get:
+      tags:
+        - "Dive data"
+      summary: "Zipped CSV log files"
+      description: "Download all CSV log files as a zlib compressed zip file"
+      responses:
+        "200":
+          description:
+          content:
+            application/zip:
+              schema:
+                type: file
+      x-code-samples:
+        - lang: "curl"
+          source: |
+            curl -X GET "http://192.168.1.101/logcsv/binary_logs.zip"
+
+        - lang: "Python"
+          source: |
+            import requests
+            response = requests.get(f"http://192.168.1.101/logcsv/binary_logs.zip")
+            with open(logname, "wb") as f:
+              f.write(response.content)
+
   /agisoft:
     get:
       tags:

--- a/poetry.lock
+++ b/poetry.lock
@@ -19,79 +19,34 @@ pywin32 = {version = "*", markers = "sys_platform == \"win32\""}
 wcwidth = "*"
 
 [[package]]
-name = "aspy-yaml"
-version = "1.3.0"
-description = "A few extensions to pyyaml."
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "aspy.yaml-1.3.0-py2.py3-none-any.whl", hash = "sha256:463372c043f70160a9ec950c3f1e4c3a82db5fca01d334b6bc89c7164d744bdc"},
-    {file = "aspy.yaml-1.3.0.tar.gz", hash = "sha256:e7c742382eff2caed61f87a39d13f99109088e5e93f04d76eb8d4b28aa143f45"},
-]
-
-[package.dependencies]
-pyyaml = "*"
-
-[[package]]
-name = "atomicwrites"
-version = "1.4.1"
-description = "Atomic file writes."
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
-]
-
-[[package]]
-name = "attrs"
-version = "23.1.0"
-description = "Classes Without Boilerplate"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "attrs-23.1.0-py3-none-any.whl", hash = "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04"},
-    {file = "attrs-23.1.0.tar.gz", hash = "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"},
-]
-
-[package.extras]
-cov = ["attrs[tests]", "coverage[toml] (>=5.3)"]
-dev = ["attrs[docs,tests]", "pre-commit"]
-docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope-interface"]
-tests = ["attrs[tests-no-zope]", "zope-interface"]
-tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
-
-[[package]]
 name = "black"
-version = "23.3.0"
+version = "23.7.0"
 description = "The uncompromising code formatter."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "black-23.3.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:0945e13506be58bf7db93ee5853243eb368ace1c08a24c65ce108986eac65915"},
-    {file = "black-23.3.0-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:67de8d0c209eb5b330cce2469503de11bca4085880d62f1628bd9972cc3366b9"},
-    {file = "black-23.3.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:7c3eb7cea23904399866c55826b31c1f55bbcd3890ce22ff70466b907b6775c2"},
-    {file = "black-23.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32daa9783106c28815d05b724238e30718f34155653d4d6e125dc7daec8e260c"},
-    {file = "black-23.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:35d1381d7a22cc5b2be2f72c7dfdae4072a3336060635718cc7e1ede24221d6c"},
-    {file = "black-23.3.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:a8a968125d0a6a404842fa1bf0b349a568634f856aa08ffaff40ae0dfa52e7c6"},
-    {file = "black-23.3.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:c7ab5790333c448903c4b721b59c0d80b11fe5e9803d8703e84dcb8da56fec1b"},
-    {file = "black-23.3.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:a6f6886c9869d4daae2d1715ce34a19bbc4b95006d20ed785ca00fa03cba312d"},
-    {file = "black-23.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f3c333ea1dd6771b2d3777482429864f8e258899f6ff05826c3a4fcc5ce3f70"},
-    {file = "black-23.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:11c410f71b876f961d1de77b9699ad19f939094c3a677323f43d7a29855fe326"},
-    {file = "black-23.3.0-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:1d06691f1eb8de91cd1b322f21e3bfc9efe0c7ca1f0e1eb1db44ea367dff656b"},
-    {file = "black-23.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50cb33cac881766a5cd9913e10ff75b1e8eb71babf4c7104f2e9c52da1fb7de2"},
-    {file = "black-23.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e114420bf26b90d4b9daa597351337762b63039752bdf72bf361364c1aa05925"},
-    {file = "black-23.3.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:48f9d345675bb7fbc3dd85821b12487e1b9a75242028adad0333ce36ed2a6d27"},
-    {file = "black-23.3.0-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:714290490c18fb0126baa0fca0a54ee795f7502b44177e1ce7624ba1c00f2331"},
-    {file = "black-23.3.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:064101748afa12ad2291c2b91c960be28b817c0c7eaa35bec09cc63aa56493c5"},
-    {file = "black-23.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:562bd3a70495facf56814293149e51aa1be9931567474993c7942ff7d3533961"},
-    {file = "black-23.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:e198cf27888ad6f4ff331ca1c48ffc038848ea9f031a3b40ba36aced7e22f2c8"},
-    {file = "black-23.3.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:3238f2aacf827d18d26db07524e44741233ae09a584273aa059066d644ca7b30"},
-    {file = "black-23.3.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:f0bd2f4a58d6666500542b26354978218a9babcdc972722f4bf90779524515f3"},
-    {file = "black-23.3.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:92c543f6854c28a3c7f39f4d9b7694f9a6eb9d3c5e2ece488c327b6e7ea9b266"},
-    {file = "black-23.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a150542a204124ed00683f0db1f5cf1c2aaaa9cc3495b7a3b5976fb136090ab"},
-    {file = "black-23.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:6b39abdfb402002b8a7d030ccc85cf5afff64ee90fa4c5aebc531e3ad0175ddb"},
-    {file = "black-23.3.0-py3-none-any.whl", hash = "sha256:ec751418022185b0c1bb7d7736e6933d40bbb14c14a0abcf9123d1b159f98dd4"},
-    {file = "black-23.3.0.tar.gz", hash = "sha256:1c7b8d606e728a41ea1ccbd7264677e494e87cf630e399262ced92d4a8dac940"},
+    {file = "black-23.7.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:5c4bc552ab52f6c1c506ccae05681fab58c3f72d59ae6e6639e8885e94fe2587"},
+    {file = "black-23.7.0-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:552513d5cd5694590d7ef6f46e1767a4df9af168d449ff767b13b084c020e63f"},
+    {file = "black-23.7.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:86cee259349b4448adb4ef9b204bb4467aae74a386bce85d56ba4f5dc0da27be"},
+    {file = "black-23.7.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:501387a9edcb75d7ae8a4412bb8749900386eaef258f1aefab18adddea1936bc"},
+    {file = "black-23.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:fb074d8b213749fa1d077d630db0d5f8cc3b2ae63587ad4116e8a436e9bbe995"},
+    {file = "black-23.7.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:b5b0ee6d96b345a8b420100b7d71ebfdd19fab5e8301aff48ec270042cd40ac2"},
+    {file = "black-23.7.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:893695a76b140881531062d48476ebe4a48f5d1e9388177e175d76234ca247cd"},
+    {file = "black-23.7.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:c333286dc3ddca6fdff74670b911cccedacb4ef0a60b34e491b8a67c833b343a"},
+    {file = "black-23.7.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:831d8f54c3a8c8cf55f64d0422ee875eecac26f5f649fb6c1df65316b67c8926"},
+    {file = "black-23.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:7f3bf2dec7d541b4619b8ce526bda74a6b0bffc480a163fed32eb8b3c9aed8ad"},
+    {file = "black-23.7.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:f9062af71c59c004cd519e2fb8f5d25d39e46d3af011b41ab43b9c74e27e236f"},
+    {file = "black-23.7.0-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:01ede61aac8c154b55f35301fac3e730baf0c9cf8120f65a9cd61a81cfb4a0c3"},
+    {file = "black-23.7.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:327a8c2550ddc573b51e2c352adb88143464bb9d92c10416feb86b0f5aee5ff6"},
+    {file = "black-23.7.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d1c6022b86f83b632d06f2b02774134def5d4d4f1dac8bef16d90cda18ba28a"},
+    {file = "black-23.7.0-cp38-cp38-win_amd64.whl", hash = "sha256:27eb7a0c71604d5de083757fbdb245b1a4fae60e9596514c6ec497eb63f95320"},
+    {file = "black-23.7.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:8417dbd2f57b5701492cd46edcecc4f9208dc75529bcf76c514864e48da867d9"},
+    {file = "black-23.7.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:47e56d83aad53ca140da0af87678fb38e44fd6bc0af71eebab2d1f59b1acf1d3"},
+    {file = "black-23.7.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:25cc308838fe71f7065df53aedd20327969d05671bac95b38fdf37ebe70ac087"},
+    {file = "black-23.7.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:642496b675095d423f9b8448243336f8ec71c9d4d57ec17bf795b67f08132a91"},
+    {file = "black-23.7.0-cp39-cp39-win_amd64.whl", hash = "sha256:ad0014efc7acf0bd745792bd0d8857413652979200ab924fbf239062adc12491"},
+    {file = "black-23.7.0-py3-none-any.whl", hash = "sha256:9fd59d418c60c0348505f2ddf9609c1e1de8e7493eab96198fc89d9f865e7a96"},
+    {file = "black-23.7.0.tar.gz", hash = "sha256:022a582720b0d9480ed82576c920a8c1dde97cc38ff11d8d8859b3bd6ca9eedb"},
 ]
 
 [package.dependencies]
@@ -127,13 +82,13 @@ setuptools = ">=40"
 
 [[package]]
 name = "certifi"
-version = "2023.5.7"
+version = "2023.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2023.5.7-py3-none-any.whl", hash = "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"},
-    {file = "certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
+    {file = "certifi-2023.7.22-py3-none-any.whl", hash = "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"},
+    {file = "certifi-2023.7.22.tar.gz", hash = "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"},
 ]
 
 [[package]]
@@ -225,97 +180,97 @@ files = [
 
 [[package]]
 name = "charset-normalizer"
-version = "3.1.0"
+version = "3.2.0"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "charset-normalizer-3.1.0.tar.gz", hash = "sha256:34e0a2f9c370eb95597aae63bf85eb5e96826d81e3dcf88b8886012906f509b5"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e0ac8959c929593fee38da1c2b64ee9778733cdf03c482c9ff1d508b6b593b2b"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d7fc3fca01da18fbabe4625d64bb612b533533ed10045a2ac3dd194bfa656b60"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:04eefcee095f58eaabe6dc3cc2262f3bcd776d2c67005880894f447b3f2cb9c1"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20064ead0717cf9a73a6d1e779b23d149b53daf971169289ed2ed43a71e8d3b0"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1435ae15108b1cb6fffbcea2af3d468683b7afed0169ad718451f8db5d1aff6f"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c84132a54c750fda57729d1e2599bb598f5fa0344085dbde5003ba429a4798c0"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75f2568b4189dda1c567339b48cba4ac7384accb9c2a7ed655cd86b04055c795"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:11d3bcb7be35e7b1bba2c23beedac81ee893ac9871d0ba79effc7fc01167db6c"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:891cf9b48776b5c61c700b55a598621fdb7b1e301a550365571e9624f270c203"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:5f008525e02908b20e04707a4f704cd286d94718f48bb33edddc7d7b584dddc1"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:b06f0d3bf045158d2fb8837c5785fe9ff9b8c93358be64461a1089f5da983137"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:49919f8400b5e49e961f320c735388ee686a62327e773fa5b3ce6721f7e785ce"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:22908891a380d50738e1f978667536f6c6b526a2064156203d418f4856d6e86a"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-win32.whl", hash = "sha256:12d1a39aa6b8c6f6248bb54550efcc1c38ce0d8096a146638fd4738e42284448"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:65ed923f84a6844de5fd29726b888e58c62820e0769b76565480e1fdc3d062f8"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9a3267620866c9d17b959a84dd0bd2d45719b817245e49371ead79ed4f710d19"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6734e606355834f13445b6adc38b53c0fd45f1a56a9ba06c2058f86893ae8017"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f8303414c7b03f794347ad062c0516cee0e15f7a612abd0ce1e25caf6ceb47df"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aaf53a6cebad0eae578f062c7d462155eada9c172bd8c4d250b8c1d8eb7f916a"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3dc5b6a8ecfdc5748a7e429782598e4f17ef378e3e272eeb1340ea57c9109f41"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e1b25e3ad6c909f398df8921780d6a3d120d8c09466720226fc621605b6f92b1"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ca564606d2caafb0abe6d1b5311c2649e8071eb241b2d64e75a0d0065107e62"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b82fab78e0b1329e183a65260581de4375f619167478dddab510c6c6fb04d9b6"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bd7163182133c0c7701b25e604cf1611c0d87712e56e88e7ee5d72deab3e76b5"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:11d117e6c63e8f495412d37e7dc2e2fff09c34b2d09dbe2bee3c6229577818be"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:cf6511efa4801b9b38dc5546d7547d5b5c6ef4b081c60b23e4d941d0eba9cbeb"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:abc1185d79f47c0a7aaf7e2412a0eb2c03b724581139193d2d82b3ad8cbb00ac"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cb7b2ab0188829593b9de646545175547a70d9a6e2b63bf2cd87a0a391599324"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-win32.whl", hash = "sha256:c36bcbc0d5174a80d6cccf43a0ecaca44e81d25be4b7f90f0ed7bcfbb5a00909"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:cca4def576f47a09a943666b8f829606bcb17e2bc2d5911a46c8f8da45f56755"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0c95f12b74681e9ae127728f7e5409cbbef9cd914d5896ef238cc779b8152373"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fca62a8301b605b954ad2e9c3666f9d97f63872aa4efcae5492baca2056b74ab"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ac0aa6cd53ab9a31d397f8303f92c42f534693528fafbdb997c82bae6e477ad9"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c3af8e0f07399d3176b179f2e2634c3ce9c1301379a6b8c9c9aeecd481da494f"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a5fc78f9e3f501a1614a98f7c54d3969f3ad9bba8ba3d9b438c3bc5d047dd28"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:628c985afb2c7d27a4800bfb609e03985aaecb42f955049957814e0491d4006d"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:74db0052d985cf37fa111828d0dd230776ac99c740e1a758ad99094be4f1803d"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:1e8fcdd8f672a1c4fc8d0bd3a2b576b152d2a349782d1eb0f6b8e52e9954731d"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:04afa6387e2b282cf78ff3dbce20f0cc071c12dc8f685bd40960cc68644cfea6"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:dd5653e67b149503c68c4018bf07e42eeed6b4e956b24c00ccdf93ac79cdff84"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d2686f91611f9e17f4548dbf050e75b079bbc2a82be565832bc8ea9047b61c8c"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-win32.whl", hash = "sha256:4155b51ae05ed47199dc5b2a4e62abccb274cee6b01da5b895099b61b1982974"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:322102cdf1ab682ecc7d9b1c5eed4ec59657a65e1c146a0da342b78f4112db23"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e633940f28c1e913615fd624fcdd72fdba807bf53ea6925d6a588e84e1151531"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:3a06f32c9634a8705f4ca9946d667609f52cf130d5548881401f1eb2c39b1e2c"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7381c66e0561c5757ffe616af869b916c8b4e42b367ab29fedc98481d1e74e14"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3573d376454d956553c356df45bb824262c397c6e26ce43e8203c4c540ee0acb"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e89df2958e5159b811af9ff0f92614dabf4ff617c03a4c1c6ff53bf1c399e0e1"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:78cacd03e79d009d95635e7d6ff12c21eb89b894c354bd2b2ed0b4763373693b"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de5695a6f1d8340b12a5d6d4484290ee74d61e467c39ff03b39e30df62cf83a0"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1c60b9c202d00052183c9be85e5eaf18a4ada0a47d188a83c8f5c5b23252f649"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:f645caaf0008bacf349875a974220f1f1da349c5dbe7c4ec93048cdc785a3326"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ea9f9c6034ea2d93d9147818f17c2a0860d41b71c38b9ce4d55f21b6f9165a11"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:80d1543d58bd3d6c271b66abf454d437a438dff01c3e62fdbcd68f2a11310d4b"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:73dc03a6a7e30b7edc5b01b601e53e7fc924b04e1835e8e407c12c037e81adbd"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6f5c2e7bc8a4bf7c426599765b1bd33217ec84023033672c1e9a8b35eaeaaaf8"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-win32.whl", hash = "sha256:12a2b561af122e3d94cdb97fe6fb2bb2b82cef0cdca131646fdb940a1eda04f0"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:3160a0fd9754aab7d47f95a6b63ab355388d890163eb03b2d2b87ab0a30cfa59"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:38e812a197bf8e71a59fe55b757a84c1f946d0ac114acafaafaf21667a7e169e"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6baf0baf0d5d265fa7944feb9f7451cc316bfe30e8df1a61b1bb08577c554f31"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8f25e17ab3039b05f762b0a55ae0b3632b2e073d9c8fc88e89aca31a6198e88f"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3747443b6a904001473370d7810aa19c3a180ccd52a7157aacc264a5ac79265e"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b116502087ce8a6b7a5f1814568ccbd0e9f6cfd99948aa59b0e241dc57cf739f"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d16fd5252f883eb074ca55cb622bc0bee49b979ae4e8639fff6ca3ff44f9f854"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21fa558996782fc226b529fdd2ed7866c2c6ec91cee82735c98a197fae39f706"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f6c7a8a57e9405cad7485f4c9d3172ae486cfef1344b5ddd8e5239582d7355e"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:ac3775e3311661d4adace3697a52ac0bab17edd166087d493b52d4f4f553f9f0"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:10c93628d7497c81686e8e5e557aafa78f230cd9e77dd0c40032ef90c18f2230"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:6f4f4668e1831850ebcc2fd0b1cd11721947b6dc7c00bf1c6bd3c929ae14f2c7"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:0be65ccf618c1e7ac9b849c315cc2e8a8751d9cfdaa43027d4f6624bd587ab7e"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:53d0a3fa5f8af98a1e261de6a3943ca631c526635eb5817a87a59d9a57ebf48f"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-win32.whl", hash = "sha256:a04f86f41a8916fe45ac5024ec477f41f886b3c435da2d4e3d2709b22ab02af1"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:830d2948a5ec37c386d3170c483063798d7879037492540f10a475e3fd6f244b"},
-    {file = "charset_normalizer-3.1.0-py3-none-any.whl", hash = "sha256:3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d"},
+    {file = "charset-normalizer-3.2.0.tar.gz", hash = "sha256:3bb3d25a8e6c0aedd251753a79ae98a093c7e7b471faa3aa9a93a81431987ace"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0b87549028f680ca955556e3bd57013ab47474c3124dc069faa0b6545b6c9710"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7c70087bfee18a42b4040bb9ec1ca15a08242cf5867c58726530bdf3945672ed"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a103b3a7069b62f5d4890ae1b8f0597618f628b286b03d4bc9195230b154bfa9"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94aea8eff76ee6d1cdacb07dd2123a68283cb5569e0250feab1240058f53b623"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:db901e2ac34c931d73054d9797383d0f8009991e723dab15109740a63e7f902a"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b0dac0ff919ba34d4df1b6131f59ce95b08b9065233446be7e459f95554c0dc8"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:193cbc708ea3aca45e7221ae58f0fd63f933753a9bfb498a3b474878f12caaad"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09393e1b2a9461950b1c9a45d5fd251dc7c6f228acab64da1c9c0165d9c7765c"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:baacc6aee0b2ef6f3d308e197b5d7a81c0e70b06beae1f1fcacffdbd124fe0e3"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:bf420121d4c8dce6b889f0e8e4ec0ca34b7f40186203f06a946fa0276ba54029"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:c04a46716adde8d927adb9457bbe39cf473e1e2c2f5d0a16ceb837e5d841ad4f"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:aaf63899c94de41fe3cf934601b0f7ccb6b428c6e4eeb80da72c58eab077b19a"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d62e51710986674142526ab9f78663ca2b0726066ae26b78b22e0f5e571238dd"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-win32.whl", hash = "sha256:04e57ab9fbf9607b77f7d057974694b4f6b142da9ed4a199859d9d4d5c63fe96"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:48021783bdf96e3d6de03a6e39a1171ed5bd7e8bb93fc84cc649d11490f87cea"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4957669ef390f0e6719db3613ab3a7631e68424604a7b448f079bee145da6e09"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46fb8c61d794b78ec7134a715a3e564aafc8f6b5e338417cb19fe9f57a5a9bf2"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f779d3ad205f108d14e99bb3859aa7dd8e9c68874617c72354d7ecaec2a054ac"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f25c229a6ba38a35ae6e25ca1264621cc25d4d38dca2942a7fce0b67a4efe918"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2efb1bd13885392adfda4614c33d3b68dee4921fd0ac1d3988f8cbb7d589e72a"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1f30b48dd7fa1474554b0b0f3fdfdd4c13b5c737a3c6284d3cdc424ec0ffff3a"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:246de67b99b6851627d945db38147d1b209a899311b1305dd84916f2b88526c6"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9bd9b3b31adcb054116447ea22caa61a285d92e94d710aa5ec97992ff5eb7cf3"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8c2f5e83493748286002f9369f3e6607c565a6a90425a3a1fef5ae32a36d749d"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:3170c9399da12c9dc66366e9d14da8bf7147e1e9d9ea566067bbce7bb74bd9c2"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:7a4826ad2bd6b07ca615c74ab91f32f6c96d08f6fcc3902ceeedaec8cdc3bcd6"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:3b1613dd5aee995ec6d4c69f00378bbd07614702a315a2cf6c1d21461fe17c23"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9e608aafdb55eb9f255034709e20d5a83b6d60c054df0802fa9c9883d0a937aa"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-win32.whl", hash = "sha256:f2a1d0fd4242bd8643ce6f98927cf9c04540af6efa92323e9d3124f57727bfc1"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:681eb3d7e02e3c3655d1b16059fbfb605ac464c834a0c629048a30fad2b27489"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c57921cda3a80d0f2b8aec7e25c8aa14479ea92b5b51b6876d975d925a2ea346"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41b25eaa7d15909cf3ac4c96088c1f266a9a93ec44f87f1d13d4a0e86c81b982"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f058f6963fd82eb143c692cecdc89e075fa0828db2e5b291070485390b2f1c9c"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a7647ebdfb9682b7bb97e2a5e7cb6ae735b1c25008a70b906aecca294ee96cf4"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eef9df1eefada2c09a5e7a40991b9fc6ac6ef20b1372abd48d2794a316dc0449"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e03b8895a6990c9ab2cdcd0f2fe44088ca1c65ae592b8f795c3294af00a461c3"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:ee4006268ed33370957f55bf2e6f4d263eaf4dc3cfc473d1d90baff6ed36ce4a"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c4983bf937209c57240cff65906b18bb35e64ae872da6a0db937d7b4af845dd7"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:3bb7fda7260735efe66d5107fb7e6af6a7c04c7fce9b2514e04b7a74b06bf5dd"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:72814c01533f51d68702802d74f77ea026b5ec52793c791e2da806a3844a46c3"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:70c610f6cbe4b9fce272c407dd9d07e33e6bf7b4aa1b7ffb6f6ded8e634e3592"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-win32.whl", hash = "sha256:a401b4598e5d3f4a9a811f3daf42ee2291790c7f9d74b18d75d6e21dda98a1a1"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:c0b21078a4b56965e2b12f247467b234734491897e99c1d51cee628da9786959"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:95eb302ff792e12aba9a8b8f8474ab229a83c103d74a750ec0bd1c1eea32e669"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1a100c6d595a7f316f1b6f01d20815d916e75ff98c27a01ae817439ea7726329"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6339d047dab2780cc6220f46306628e04d9750f02f983ddb37439ca47ced7149"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4b749b9cc6ee664a3300bb3a273c1ca8068c46be705b6c31cf5d276f8628a94"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a38856a971c602f98472050165cea2cdc97709240373041b69030be15047691f"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f87f746ee241d30d6ed93969de31e5ffd09a2961a051e60ae6bddde9ec3583aa"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89f1b185a01fe560bc8ae5f619e924407efca2191b56ce749ec84982fc59a32a"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1c8a2f4c69e08e89632defbfabec2feb8a8d99edc9f89ce33c4b9e36ab63037"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:2f4ac36d8e2b4cc1aa71df3dd84ff8efbe3bfb97ac41242fbcfc053c67434f46"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a386ebe437176aab38c041de1260cd3ea459c6ce5263594399880bbc398225b2"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:ccd16eb18a849fd8dcb23e23380e2f0a354e8daa0c984b8a732d9cfaba3a776d"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:e6a5bf2cba5ae1bb80b154ed68a3cfa2fa00fde979a7f50d6598d3e17d9ac20c"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:45de3f87179c1823e6d9e32156fb14c1927fcc9aba21433f088fdfb555b77c10"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-win32.whl", hash = "sha256:1000fba1057b92a65daec275aec30586c3de2401ccdcd41f8a5c1e2c87078706"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:8b2c760cfc7042b27ebdb4a43a4453bd829a5742503599144d54a032c5dc7e9e"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:855eafa5d5a2034b4621c74925d89c5efef61418570e5ef9b37717d9c796419c"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:203f0c8871d5a7987be20c72442488a0b8cfd0f43b7973771640fc593f56321f"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e857a2232ba53ae940d3456f7533ce6ca98b81917d47adc3c7fd55dad8fab858"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5e86d77b090dbddbe78867a0275cb4df08ea195e660f1f7f13435a4649e954e5"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c4fb39a81950ec280984b3a44f5bd12819953dc5fa3a7e6fa7a80db5ee853952"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2dee8e57f052ef5353cf608e0b4c871aee320dd1b87d351c28764fc0ca55f9f4"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8700f06d0ce6f128de3ccdbc1acaea1ee264d2caa9ca05daaf492fde7c2a7200"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1920d4ff15ce893210c1f0c0e9d19bfbecb7983c76b33f046c13a8ffbd570252"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:c1c76a1743432b4b60ab3358c937a3fe1341c828ae6194108a94c69028247f22"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f7560358a6811e52e9c4d142d497f1a6e10103d3a6881f18d04dbce3729c0e2c"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:c8063cf17b19661471ecbdb3df1c84f24ad2e389e326ccaf89e3fb2484d8dd7e"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:cd6dbe0238f7743d0efe563ab46294f54f9bc8f4b9bcf57c3c666cc5bc9d1299"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:1249cbbf3d3b04902ff081ffbb33ce3377fa6e4c7356f759f3cd076cc138d020"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-win32.whl", hash = "sha256:6c409c0deba34f147f77efaa67b8e4bb83d2f11c8806405f76397ae5b8c0d1c9"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:7095f6fbfaa55defb6b733cfeb14efaae7a29f0b59d8cf213be4e7ca0b857b80"},
+    {file = "charset_normalizer-3.2.0-py3-none-any.whl", hash = "sha256:8e098148dd37b4ce3baca71fb394c81dc5d9c7728c95df695d2dca218edf40e6"},
 ]
 
 [[package]]
 name = "click"
-version = "8.1.3"
+version = "8.1.6"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
-    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+    {file = "click-8.1.6-py3-none-any.whl", hash = "sha256:fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5"},
+    {file = "click-8.1.6.tar.gz", hash = "sha256:48ee849951919527a045bfe3bf7baa8a959c423134e1a5b98c05c20ba75a1cbd"},
 ]
 
 [package.dependencies]
@@ -459,6 +414,9 @@ files = [
     {file = "coverage-7.2.7.tar.gz", hash = "sha256:924d94291ca674905fe9481f12294eb11f2d3d3fd1adb20314ba89e94f44ed59"},
 ]
 
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
+
 [package.extras]
 toml = ["tomli"]
 
@@ -475,13 +433,13 @@ files = [
 
 [[package]]
 name = "distlib"
-version = "0.3.6"
+version = "0.3.7"
 description = "Distribution utilities"
 optional = false
 python-versions = "*"
 files = [
-    {file = "distlib-0.3.6-py2.py3-none-any.whl", hash = "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"},
-    {file = "distlib-0.3.6.tar.gz", hash = "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46"},
+    {file = "distlib-0.3.7-py2.py3-none-any.whl", hash = "sha256:2e24928bc811348f0feb63014e97aaae3037f2cf48712d51ae61df7fd6075057"},
+    {file = "distlib-0.3.7.tar.gz", hash = "sha256:9dafe54b34a028eafd95039d5e5d4851a13734540f1331060d31c9916e7147a8"},
 ]
 
 [[package]]
@@ -494,6 +452,20 @@ files = [
     {file = "docstring_parser-0.15-py3-none-any.whl", hash = "sha256:d1679b86250d269d06a99670924d6bce45adc00b08069dae8c47d98e89b667a9"},
     {file = "docstring_parser-0.15.tar.gz", hash = "sha256:48ddc093e8b1865899956fcc03b03e66bb7240c310fac5af81814580c55bf682"},
 ]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.1.2"
+description = "Backport of PEP 654 (exception groups)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "exceptiongroup-1.1.2-py3-none-any.whl", hash = "sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f"},
+    {file = "exceptiongroup-1.1.2.tar.gz", hash = "sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5"},
+]
+
+[package.extras]
+test = ["pytest (>=6)"]
 
 [[package]]
 name = "falcon"
@@ -534,62 +506,46 @@ docs = ["furo (>=2023.5.20)", "sphinx (>=7.0.1)", "sphinx-autodoc-typehints (>=1
 testing = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "diff-cover (>=7.5)", "pytest (>=7.3.1)", "pytest-cov (>=4.1)", "pytest-mock (>=3.10)", "pytest-timeout (>=2.1)"]
 
 [[package]]
-name = "flake8"
-version = "3.9.2"
-description = "the modular source code checker: pep8 pyflakes and co"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-files = [
-    {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
-    {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
-]
-
-[package.dependencies]
-mccabe = ">=0.6.0,<0.7.0"
-pycodestyle = ">=2.7.0,<2.8.0"
-pyflakes = ">=2.3.0,<2.4.0"
-
-[[package]]
 name = "fonttools"
-version = "4.40.0"
+version = "4.42.0"
 description = "Tools to manipulate font files"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "fonttools-4.40.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b802dcbf9bcff74672f292b2466f6589ab8736ce4dcf36f48eb994c2847c4b30"},
-    {file = "fonttools-4.40.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7f6e3fa3da923063c286320e728ba2270e49c73386e3a711aa680f4b0747d692"},
-    {file = "fonttools-4.40.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5fdf60f8a5c6bcce7d024a33f7e4bc7921f5b74e8ea13bccd204f2c8b86f3470"},
-    {file = "fonttools-4.40.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:91784e21a1a085fac07c6a407564f4a77feb471b5954c9ee55a4f9165151f6c1"},
-    {file = "fonttools-4.40.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:05171f3c546f64d78569f10adc0de72561882352cac39ec7439af12304d8d8c0"},
-    {file = "fonttools-4.40.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7449e5e306f3a930a8944c85d0cbc8429cba13503372a1a40f23124d6fb09b58"},
-    {file = "fonttools-4.40.0-cp310-cp310-win32.whl", hash = "sha256:bae8c13abbc2511e9a855d2142c0ab01178dd66b1a665798f357da0d06253e0d"},
-    {file = "fonttools-4.40.0-cp310-cp310-win_amd64.whl", hash = "sha256:425b74a608427499b0e45e433c34ddc350820b6f25b7c8761963a08145157a66"},
-    {file = "fonttools-4.40.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:00ab569b2a3e591e00425023ade87e8fef90380c1dde61be7691cb524ca5f743"},
-    {file = "fonttools-4.40.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:18ea64ac43e94c9e0c23d7a9475f1026be0e25b10dda8f236fc956188761df97"},
-    {file = "fonttools-4.40.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:022c4a16b412293e7f1ce21b8bab7a6f9d12c4ffdf171fdc67122baddb973069"},
-    {file = "fonttools-4.40.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:530c5d35109f3e0cea2535742d6a3bc99c0786cf0cbd7bb2dc9212387f0d908c"},
-    {file = "fonttools-4.40.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:5e00334c66f4e83535384cb5339526d01d02d77f142c23b2f97bd6a4f585497a"},
-    {file = "fonttools-4.40.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:eb52c10fda31159c22c7ed85074e05f8b97da8773ea461706c273e31bcbea836"},
-    {file = "fonttools-4.40.0-cp311-cp311-win32.whl", hash = "sha256:6a8d71b9a5c884c72741868e845c0e563c5d83dcaf10bb0ceeec3b4b2eb14c67"},
-    {file = "fonttools-4.40.0-cp311-cp311-win_amd64.whl", hash = "sha256:15abb3d055c1b2dff9ce376b6c3db10777cb74b37b52b78f61657634fd348a0d"},
-    {file = "fonttools-4.40.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:14037c31138fbd21847ad5e5441dfdde003e0a8f3feb5812a1a21fd1c255ffbd"},
-    {file = "fonttools-4.40.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:94c915f6716589f78bc00fbc14c5b8de65cfd11ee335d32504f1ef234524cb24"},
-    {file = "fonttools-4.40.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37467cee0f32cada2ec08bc16c9c31f9b53ea54b2f5604bf25a1246b5f50593a"},
-    {file = "fonttools-4.40.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56d4d85f5374b45b08d2f928517d1e313ea71b4847240398decd0ab3ebbca885"},
-    {file = "fonttools-4.40.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:8c4305b171b61040b1ee75d18f9baafe58bd3b798d1670078efe2c92436bfb63"},
-    {file = "fonttools-4.40.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:a954b90d1473c85a22ecf305761d9fd89da93bbd31dae86e7dea436ad2cb5dc9"},
-    {file = "fonttools-4.40.0-cp38-cp38-win32.whl", hash = "sha256:1bc4c5b147be8dbc5df9cc8ac5e93ee914ad030fe2a201cc8f02f499db71011d"},
-    {file = "fonttools-4.40.0-cp38-cp38-win_amd64.whl", hash = "sha256:8a917828dbfdb1cbe50cf40eeae6fbf9c41aef9e535649ed8f4982b2ef65c091"},
-    {file = "fonttools-4.40.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:882983279bf39afe4e945109772c2ffad2be2c90983d6559af8b75c19845a80a"},
-    {file = "fonttools-4.40.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c55f1b4109dbc3aeb496677b3e636d55ef46dc078c2a5e3f3db4e90f1c6d2907"},
-    {file = "fonttools-4.40.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec468c022d09f1817c691cf884feb1030ef6f1e93e3ea6831b0d8144c06480d1"},
-    {file = "fonttools-4.40.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d5adf4ba114f028fc3f5317a221fd8b0f4ef7a2e5524a2b1e0fd891b093791a"},
-    {file = "fonttools-4.40.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:aa83b3f151bc63970f39b2b42a06097c5a22fd7ed9f7ba008e618de4503d3895"},
-    {file = "fonttools-4.40.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:97d95b8301b62bdece1af943b88bcb3680fd385f88346a4a899ee145913b414a"},
-    {file = "fonttools-4.40.0-cp39-cp39-win32.whl", hash = "sha256:1a003608400dd1cca3e089e8c94973c6b51a4fb1ef00ff6d7641617b9242e637"},
-    {file = "fonttools-4.40.0-cp39-cp39-win_amd64.whl", hash = "sha256:7961575221e3da0841c75da53833272c520000d76f7f71274dbf43370f8a1065"},
-    {file = "fonttools-4.40.0-py3-none-any.whl", hash = "sha256:200729d12461e2038700d31f0d49ad5a7b55855dec7525074979a06b46f88505"},
-    {file = "fonttools-4.40.0.tar.gz", hash = "sha256:337b6e83d7ee73c40ea62407f2ce03b07c3459e213b6f332b94a69923b9e1cb9"},
+    {file = "fonttools-4.42.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9c456d1f23deff64ffc8b5b098718e149279abdea4d8692dba69172fb6a0d597"},
+    {file = "fonttools-4.42.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:150122ed93127a26bc3670ebab7e2add1e0983d30927733aec327ebf4255b072"},
+    {file = "fonttools-4.42.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48e82d776d2e93f88ca56567509d102266e7ab2fb707a0326f032fe657335238"},
+    {file = "fonttools-4.42.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58c1165f9b2662645de9b19a8c8bdd636b36294ccc07e1b0163856b74f10bafc"},
+    {file = "fonttools-4.42.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:2d6dc3fa91414ff4daa195c05f946e6a575bd214821e26d17ca50f74b35b0fe4"},
+    {file = "fonttools-4.42.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fae4e801b774cc62cecf4a57b1eae4097903fced00c608d9e2bc8f84cd87b54a"},
+    {file = "fonttools-4.42.0-cp310-cp310-win32.whl", hash = "sha256:b8600ae7dce6ec3ddfb201abb98c9d53abbf8064d7ac0c8a0d8925e722ccf2a0"},
+    {file = "fonttools-4.42.0-cp310-cp310-win_amd64.whl", hash = "sha256:57b68eab183fafac7cd7d464a7bfa0fcd4edf6c67837d14fb09c1c20516cf20b"},
+    {file = "fonttools-4.42.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0a1466713e54bdbf5521f2f73eebfe727a528905ff5ec63cda40961b4b1eea95"},
+    {file = "fonttools-4.42.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3fb2a69870bfe143ec20b039a1c8009e149dd7780dd89554cc8a11f79e5de86b"},
+    {file = "fonttools-4.42.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ae881e484702efdb6cf756462622de81d4414c454edfd950b137e9a7352b3cb9"},
+    {file = "fonttools-4.42.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27ec3246a088555629f9f0902f7412220c67340553ca91eb540cf247aacb1983"},
+    {file = "fonttools-4.42.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8ece1886d12bb36c48c00b2031518877f41abae317e3a55620d38e307d799b7e"},
+    {file = "fonttools-4.42.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:10dac980f2b975ef74532e2a94bb00e97a95b4595fb7f98db493c474d5f54d0e"},
+    {file = "fonttools-4.42.0-cp311-cp311-win32.whl", hash = "sha256:83b98be5d291e08501bd4fc0c4e0f8e6e05b99f3924068b17c5c9972af6fff84"},
+    {file = "fonttools-4.42.0-cp311-cp311-win_amd64.whl", hash = "sha256:e35bed436726194c5e6e094fdfb423fb7afaa0211199f9d245e59e11118c576c"},
+    {file = "fonttools-4.42.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:c36c904ce0322df01e590ba814d5d69e084e985d7e4c2869378671d79662a7d4"},
+    {file = "fonttools-4.42.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d54e600a2bcfa5cdaa860237765c01804a03b08404d6affcd92942fa7315ffba"},
+    {file = "fonttools-4.42.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01cfe02416b6d416c5c8d15e30315cbcd3e97d1b50d3b34b0ce59f742ef55258"},
+    {file = "fonttools-4.42.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f81ed9065b4bd3f4f3ce8e4873cd6a6b3f4e92b1eddefde35d332c6f414acc3"},
+    {file = "fonttools-4.42.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:685a4dd6cf31593b50d6d441feb7781a4a7ef61e19551463e14ed7c527b86f9f"},
+    {file = "fonttools-4.42.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:329341ba3d86a36e482610db56b30705384cb23bd595eac8cbb045f627778e9d"},
+    {file = "fonttools-4.42.0-cp38-cp38-win32.whl", hash = "sha256:4655c480a1a4d706152ff54f20e20cf7609084016f1df3851cce67cef768f40a"},
+    {file = "fonttools-4.42.0-cp38-cp38-win_amd64.whl", hash = "sha256:6bd7e4777bff1dcb7c4eff4786998422770f3bfbef8be401c5332895517ba3fa"},
+    {file = "fonttools-4.42.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a9b55d2a3b360e0c7fc5bd8badf1503ca1c11dd3a1cd20f2c26787ffa145a9c7"},
+    {file = "fonttools-4.42.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0df8ef75ba5791e873c9eac2262196497525e3f07699a2576d3ab9ddf41cb619"},
+    {file = "fonttools-4.42.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cd2363ea7728496827658682d049ffb2e98525e2247ca64554864a8cc945568"},
+    {file = "fonttools-4.42.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d40673b2e927f7cd0819c6f04489dfbeb337b4a7b10fc633c89bf4f34ecb9620"},
+    {file = "fonttools-4.42.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:c8bf88f9e3ce347c716921804ef3a8330cb128284eb6c0b6c4b3574f3c580023"},
+    {file = "fonttools-4.42.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:703101eb0490fae32baf385385d47787b73d9ea55253df43b487c89ec767e0d7"},
+    {file = "fonttools-4.42.0-cp39-cp39-win32.whl", hash = "sha256:f0290ea7f9945174bd4dfd66e96149037441eb2008f3649094f056201d99e293"},
+    {file = "fonttools-4.42.0-cp39-cp39-win_amd64.whl", hash = "sha256:ae7df0ae9ee2f3f7676b0ff6f4ebe48ad0acaeeeaa0b6839d15dbf0709f2c5ef"},
+    {file = "fonttools-4.42.0-py3-none-any.whl", hash = "sha256:dfe7fa7e607f7e8b58d0c32501a3a7cac148538300626d1b930082c90ae7f6bd"},
+    {file = "fonttools-4.42.0.tar.gz", hash = "sha256:614b1283dca88effd20ee48160518e6de275ce9b5456a3134d5f235523fc5065"},
 ]
 
 [package.extras]
@@ -608,18 +564,17 @@ woff = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "zopfli (>=0.1.4)"]
 
 [[package]]
 name = "freezegun"
-version = "0.3.15"
+version = "1.2.2"
 description = "Let your Python tests travel through time"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
 files = [
-    {file = "freezegun-0.3.15-py2.py3-none-any.whl", hash = "sha256:82c757a05b7c7ca3e176bfebd7d6779fd9139c7cb4ef969c38a28d74deef89b2"},
-    {file = "freezegun-0.3.15.tar.gz", hash = "sha256:e2062f2c7f95cc276a834c22f1a17179467176b624cc6f936e8bc3be5535ad1b"},
+    {file = "freezegun-1.2.2-py3-none-any.whl", hash = "sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f"},
+    {file = "freezegun-1.2.2.tar.gz", hash = "sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446"},
 ]
 
 [package.dependencies]
-python-dateutil = ">=1.0,<2.0 || >2.0"
-six = "*"
+python-dateutil = ">=2.7"
 
 [[package]]
 name = "future"
@@ -664,13 +619,13 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.31"
+version = "3.1.32"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "GitPython-3.1.31-py3-none-any.whl", hash = "sha256:f04893614f6aa713a60cbbe1e6a97403ef633103cdd0ef5eb6efe0deb98dbe8d"},
-    {file = "GitPython-3.1.31.tar.gz", hash = "sha256:8ce3bcf69adfdf7c7d503e78fd3b1c492af782d58893b650adb2ac8912ddd573"},
+    {file = "GitPython-3.1.32-py3-none-any.whl", hash = "sha256:e3d59b1c2c6ebb9dfa7a184daf3b6dd4914237e7488a1730a6d8f6f5d0b4187f"},
+    {file = "GitPython-3.1.32.tar.gz", hash = "sha256:8d9b8cb1e80b9735e8717c9362079d3ce4c6e5ddeebedd0361b228c3a67a62f6"},
 ]
 
 [package.dependencies]
@@ -693,13 +648,13 @@ requests = "*"
 
 [[package]]
 name = "identify"
-version = "2.5.24"
+version = "2.5.26"
 description = "File identification library for Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "identify-2.5.24-py2.py3-none-any.whl", hash = "sha256:986dbfb38b1140e763e413e6feb44cd731faf72d1909543178aa79b0e258265d"},
-    {file = "identify-2.5.24.tar.gz", hash = "sha256:0aac67d5b4812498056d28a9a512a483f5085cc28640b02b258a59dac34301d4"},
+    {file = "identify-2.5.26-py2.py3-none-any.whl", hash = "sha256:c22a8ead0d4ca11f1edd6c9418c3220669b3b7533ada0a0ffa6cc0ef85cf9b54"},
+    {file = "identify-2.5.26.tar.gz", hash = "sha256:7243800bce2f58404ed41b7c002e53d4d22bcf3ae1b7900c2d7aefd95394bf7f"},
 ]
 
 [package.extras]
@@ -718,13 +673,13 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "6.7.0"
+version = "6.8.0"
 description = "Read metadata from Python packages"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "importlib_metadata-6.7.0-py3-none-any.whl", hash = "sha256:cb52082e659e97afc5dac71e79de97d8681de3aa07ff18578330904a9d18e5b5"},
-    {file = "importlib_metadata-6.7.0.tar.gz", hash = "sha256:1aaf550d4f73e5d6783e7acb77aec43d49da8017410afae93822cc9cca98c4d4"},
+    {file = "importlib_metadata-6.8.0-py3-none-any.whl", hash = "sha256:3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb"},
+    {file = "importlib_metadata-6.8.0.tar.gz", hash = "sha256:dbace7892d8c0c4ac1ad096662232f831d4e64f4c4545bd53016a3e9d4654743"},
 ]
 
 [package.dependencies]
@@ -733,25 +688,25 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
 
 [[package]]
 name = "importlib-resources"
-version = "5.12.0"
+version = "6.0.1"
 description = "Read resources from Python packages"
 optional = true
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "importlib_resources-5.12.0-py3-none-any.whl", hash = "sha256:7b1deeebbf351c7578e09bf2f63fa2ce8b5ffec296e0d349139d43cca061a81a"},
-    {file = "importlib_resources-5.12.0.tar.gz", hash = "sha256:4be82589bf5c1d7999aedf2a45159d10cb3ca4f19b2271f8792bc8e6da7b22f6"},
+    {file = "importlib_resources-6.0.1-py3-none-any.whl", hash = "sha256:134832a506243891221b88b4ae1213327eea96ceb4e407a00d790bb0626f45cf"},
+    {file = "importlib_resources-6.0.1.tar.gz", hash = "sha256:4359457e42708462b9626a04657c6208ad799ceb41e5c58c57ffa0e6a098a5d4"},
 ]
 
 [package.dependencies]
 zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
 [[package]]
 name = "iniconfig"
@@ -1077,52 +1032,52 @@ files = [
 
 [[package]]
 name = "matplotlib"
-version = "3.7.1"
+version = "3.7.2"
 description = "Python plotting package"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "matplotlib-3.7.1-cp310-cp310-macosx_10_12_universal2.whl", hash = "sha256:95cbc13c1fc6844ab8812a525bbc237fa1470863ff3dace7352e910519e194b1"},
-    {file = "matplotlib-3.7.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:08308bae9e91aca1ec6fd6dda66237eef9f6294ddb17f0d0b3c863169bf82353"},
-    {file = "matplotlib-3.7.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:544764ba51900da4639c0f983b323d288f94f65f4024dc40ecb1542d74dc0500"},
-    {file = "matplotlib-3.7.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56d94989191de3fcc4e002f93f7f1be5da476385dde410ddafbb70686acf00ea"},
-    {file = "matplotlib-3.7.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e99bc9e65901bb9a7ce5e7bb24af03675cbd7c70b30ac670aa263240635999a4"},
-    {file = "matplotlib-3.7.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb7d248c34a341cd4c31a06fd34d64306624c8cd8d0def7abb08792a5abfd556"},
-    {file = "matplotlib-3.7.1-cp310-cp310-win32.whl", hash = "sha256:ce463ce590f3825b52e9fe5c19a3c6a69fd7675a39d589e8b5fbe772272b3a24"},
-    {file = "matplotlib-3.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:3d7bc90727351fb841e4d8ae620d2d86d8ed92b50473cd2b42ce9186104ecbba"},
-    {file = "matplotlib-3.7.1-cp311-cp311-macosx_10_12_universal2.whl", hash = "sha256:770a205966d641627fd5cf9d3cb4b6280a716522cd36b8b284a8eb1581310f61"},
-    {file = "matplotlib-3.7.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f67bfdb83a8232cb7a92b869f9355d677bce24485c460b19d01970b64b2ed476"},
-    {file = "matplotlib-3.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2bf092f9210e105f414a043b92af583c98f50050559616930d884387d0772aba"},
-    {file = "matplotlib-3.7.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89768d84187f31717349c6bfadc0e0d8c321e8eb34522acec8a67b1236a66332"},
-    {file = "matplotlib-3.7.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:83111e6388dec67822e2534e13b243cc644c7494a4bb60584edbff91585a83c6"},
-    {file = "matplotlib-3.7.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a867bf73a7eb808ef2afbca03bcdb785dae09595fbe550e1bab0cd023eba3de0"},
-    {file = "matplotlib-3.7.1-cp311-cp311-win32.whl", hash = "sha256:fbdeeb58c0cf0595efe89c05c224e0a502d1aa6a8696e68a73c3efc6bc354304"},
-    {file = "matplotlib-3.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:c0bd19c72ae53e6ab979f0ac6a3fafceb02d2ecafa023c5cca47acd934d10be7"},
-    {file = "matplotlib-3.7.1-cp38-cp38-macosx_10_12_universal2.whl", hash = "sha256:6eb88d87cb2c49af00d3bbc33a003f89fd9f78d318848da029383bfc08ecfbfb"},
-    {file = "matplotlib-3.7.1-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:cf0e4f727534b7b1457898c4f4ae838af1ef87c359b76dcd5330fa31893a3ac7"},
-    {file = "matplotlib-3.7.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:46a561d23b91f30bccfd25429c3c706afe7d73a5cc64ef2dfaf2b2ac47c1a5dc"},
-    {file = "matplotlib-3.7.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8704726d33e9aa8a6d5215044b8d00804561971163563e6e6591f9dcf64340cc"},
-    {file = "matplotlib-3.7.1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4cf327e98ecf08fcbb82685acaf1939d3338548620ab8dfa02828706402c34de"},
-    {file = "matplotlib-3.7.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:617f14ae9d53292ece33f45cba8503494ee199a75b44de7717964f70637a36aa"},
-    {file = "matplotlib-3.7.1-cp38-cp38-win32.whl", hash = "sha256:7c9a4b2da6fac77bcc41b1ea95fadb314e92508bf5493ceff058e727e7ecf5b0"},
-    {file = "matplotlib-3.7.1-cp38-cp38-win_amd64.whl", hash = "sha256:14645aad967684e92fc349493fa10c08a6da514b3d03a5931a1bac26e6792bd1"},
-    {file = "matplotlib-3.7.1-cp39-cp39-macosx_10_12_universal2.whl", hash = "sha256:81a6b377ea444336538638d31fdb39af6be1a043ca5e343fe18d0f17e098770b"},
-    {file = "matplotlib-3.7.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:28506a03bd7f3fe59cd3cd4ceb2a8d8a2b1db41afede01f66c42561b9be7b4b7"},
-    {file = "matplotlib-3.7.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8c587963b85ce41e0a8af53b9b2de8dddbf5ece4c34553f7bd9d066148dc719c"},
-    {file = "matplotlib-3.7.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8bf26ade3ff0f27668989d98c8435ce9327d24cffb7f07d24ef609e33d582439"},
-    {file = "matplotlib-3.7.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:def58098f96a05f90af7e92fd127d21a287068202aa43b2a93476170ebd99e87"},
-    {file = "matplotlib-3.7.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f883a22a56a84dba3b588696a2b8a1ab0d2c3d41be53264115c71b0a942d8fdb"},
-    {file = "matplotlib-3.7.1-cp39-cp39-win32.whl", hash = "sha256:4f99e1b234c30c1e9714610eb0c6d2f11809c9c78c984a613ae539ea2ad2eb4b"},
-    {file = "matplotlib-3.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:3ba2af245e36990facf67fde840a760128ddd71210b2ab6406e640188d69d136"},
-    {file = "matplotlib-3.7.1-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:3032884084f541163f295db8a6536e0abb0db464008fadca6c98aaf84ccf4717"},
-    {file = "matplotlib-3.7.1-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3a2cb34336110e0ed8bb4f650e817eed61fa064acbefeb3591f1b33e3a84fd96"},
-    {file = "matplotlib-3.7.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b867e2f952ed592237a1828f027d332d8ee219ad722345b79a001f49df0936eb"},
-    {file = "matplotlib-3.7.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:57bfb8c8ea253be947ccb2bc2d1bb3862c2bccc662ad1b4626e1f5e004557042"},
-    {file = "matplotlib-3.7.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:438196cdf5dc8d39b50a45cb6e3f6274edbcf2254f85fa9b895bf85851c3a613"},
-    {file = "matplotlib-3.7.1-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:21e9cff1a58d42e74d01153360de92b326708fb205250150018a52c70f43c290"},
-    {file = "matplotlib-3.7.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75d4725d70b7c03e082bbb8a34639ede17f333d7247f56caceb3801cb6ff703d"},
-    {file = "matplotlib-3.7.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:97cc368a7268141afb5690760921765ed34867ffb9655dd325ed207af85c7529"},
-    {file = "matplotlib-3.7.1.tar.gz", hash = "sha256:7b73305f25eab4541bd7ee0b96d87e53ae9c9f1823be5659b806cd85786fe882"},
+    {file = "matplotlib-3.7.2-cp310-cp310-macosx_10_12_universal2.whl", hash = "sha256:2699f7e73a76d4c110f4f25be9d2496d6ab4f17345307738557d345f099e07de"},
+    {file = "matplotlib-3.7.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a8035ba590658bae7562786c9cc6ea1a84aa49d3afab157e414c9e2ea74f496d"},
+    {file = "matplotlib-3.7.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2f8e4a49493add46ad4a8c92f63e19d548b2b6ebbed75c6b4c7f46f57d36cdd1"},
+    {file = "matplotlib-3.7.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71667eb2ccca4c3537d9414b1bc00554cb7f91527c17ee4ec38027201f8f1603"},
+    {file = "matplotlib-3.7.2-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:152ee0b569a37630d8628534c628456b28686e085d51394da6b71ef84c4da201"},
+    {file = "matplotlib-3.7.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:070f8dddd1f5939e60aacb8fa08f19551f4b0140fab16a3669d5cd6e9cb28fc8"},
+    {file = "matplotlib-3.7.2-cp310-cp310-win32.whl", hash = "sha256:fdbb46fad4fb47443b5b8ac76904b2e7a66556844f33370861b4788db0f8816a"},
+    {file = "matplotlib-3.7.2-cp310-cp310-win_amd64.whl", hash = "sha256:23fb1750934e5f0128f9423db27c474aa32534cec21f7b2153262b066a581fd1"},
+    {file = "matplotlib-3.7.2-cp311-cp311-macosx_10_12_universal2.whl", hash = "sha256:30e1409b857aa8a747c5d4f85f63a79e479835f8dffc52992ac1f3f25837b544"},
+    {file = "matplotlib-3.7.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:50e0a55ec74bf2d7a0ebf50ac580a209582c2dd0f7ab51bc270f1b4a0027454e"},
+    {file = "matplotlib-3.7.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ac60daa1dc83e8821eed155796b0f7888b6b916cf61d620a4ddd8200ac70cd64"},
+    {file = "matplotlib-3.7.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305e3da477dc8607336ba10bac96986d6308d614706cae2efe7d3ffa60465b24"},
+    {file = "matplotlib-3.7.2-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1c308b255efb9b06b23874236ec0f10f026673ad6515f602027cc8ac7805352d"},
+    {file = "matplotlib-3.7.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60c521e21031632aa0d87ca5ba0c1c05f3daacadb34c093585a0be6780f698e4"},
+    {file = "matplotlib-3.7.2-cp311-cp311-win32.whl", hash = "sha256:26bede320d77e469fdf1bde212de0ec889169b04f7f1179b8930d66f82b30cbc"},
+    {file = "matplotlib-3.7.2-cp311-cp311-win_amd64.whl", hash = "sha256:af4860132c8c05261a5f5f8467f1b269bf1c7c23902d75f2be57c4a7f2394b3e"},
+    {file = "matplotlib-3.7.2-cp38-cp38-macosx_10_12_universal2.whl", hash = "sha256:a1733b8e84e7e40a9853e505fe68cc54339f97273bdfe6f3ed980095f769ddc7"},
+    {file = "matplotlib-3.7.2-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:d9881356dc48e58910c53af82b57183879129fa30492be69058c5b0d9fddf391"},
+    {file = "matplotlib-3.7.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f081c03f413f59390a80b3e351cc2b2ea0205839714dbc364519bcf51f4b56ca"},
+    {file = "matplotlib-3.7.2-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1cd120fca3407a225168238b790bd5c528f0fafde6172b140a2f3ab7a4ea63e9"},
+    {file = "matplotlib-3.7.2-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a2c1590b90aa7bd741b54c62b78de05d4186271e34e2377e0289d943b3522273"},
+    {file = "matplotlib-3.7.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6d2ff3c984b8a569bc1383cd468fc06b70d7b59d5c2854ca39f1436ae8394117"},
+    {file = "matplotlib-3.7.2-cp38-cp38-win32.whl", hash = "sha256:5dea00b62d28654b71ca92463656d80646675628d0828e08a5f3b57e12869e13"},
+    {file = "matplotlib-3.7.2-cp38-cp38-win_amd64.whl", hash = "sha256:0f506a1776ee94f9e131af1ac6efa6e5bc7cb606a3e389b0ccb6e657f60bb676"},
+    {file = "matplotlib-3.7.2-cp39-cp39-macosx_10_12_universal2.whl", hash = "sha256:6515e878f91894c2e4340d81f0911857998ccaf04dbc1bba781e3d89cbf70608"},
+    {file = "matplotlib-3.7.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:71f7a8c6b124e904db550f5b9fe483d28b896d4135e45c4ea381ad3b8a0e3256"},
+    {file = "matplotlib-3.7.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:12f01b92ecd518e0697da4d97d163b2b3aa55eb3eb4e2c98235b3396d7dad55f"},
+    {file = "matplotlib-3.7.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a7e28d6396563955f7af437894a36bf2b279462239a41028323e04b85179058b"},
+    {file = "matplotlib-3.7.2-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dbcf59334ff645e6a67cd5f78b4b2cdb76384cdf587fa0d2dc85f634a72e1a3e"},
+    {file = "matplotlib-3.7.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:318c89edde72ff95d8df67d82aca03861240512994a597a435a1011ba18dbc7f"},
+    {file = "matplotlib-3.7.2-cp39-cp39-win32.whl", hash = "sha256:ce55289d5659b5b12b3db4dc9b7075b70cef5631e56530f14b2945e8836f2d20"},
+    {file = "matplotlib-3.7.2-cp39-cp39-win_amd64.whl", hash = "sha256:2ecb5be2b2815431c81dc115667e33da0f5a1bcf6143980d180d09a717c4a12e"},
+    {file = "matplotlib-3.7.2-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:fdcd28360dbb6203fb5219b1a5658df226ac9bebc2542a9e8f457de959d713d0"},
+    {file = "matplotlib-3.7.2-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0c3cca3e842b11b55b52c6fb8bd6a4088693829acbfcdb3e815fa9b7d5c92c1b"},
+    {file = "matplotlib-3.7.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ebf577c7a6744e9e1bd3fee45fc74a02710b214f94e2bde344912d85e0c9af7c"},
+    {file = "matplotlib-3.7.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:936bba394682049919dda062d33435b3be211dc3dcaa011e09634f060ec878b2"},
+    {file = "matplotlib-3.7.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:bc221ffbc2150458b1cd71cdd9ddd5bb37962b036e41b8be258280b5b01da1dd"},
+    {file = "matplotlib-3.7.2-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:35d74ebdb3f71f112b36c2629cf32323adfbf42679e2751252acd468f5001c07"},
+    {file = "matplotlib-3.7.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:717157e61b3a71d3d26ad4e1770dc85156c9af435659a25ee6407dc866cb258d"},
+    {file = "matplotlib-3.7.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:20f844d6be031948148ba49605c8b96dfe7d3711d1b63592830d650622458c11"},
+    {file = "matplotlib-3.7.2.tar.gz", hash = "sha256:a8cdb91dddb04436bd2f098b8fdf4b81352e68cf4d2c6756fcc414791076569b"},
 ]
 
 [package.dependencies]
@@ -1134,19 +1089,8 @@ kiwisolver = ">=1.0.1"
 numpy = ">=1.20"
 packaging = ">=20.0"
 pillow = ">=6.2.0"
-pyparsing = ">=2.3.1"
+pyparsing = ">=2.3.1,<3.1"
 python-dateutil = ">=2.7"
-
-[[package]]
-name = "mccabe"
-version = "0.6.1"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = "*"
-files = [
-    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
-    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
-]
 
 [[package]]
 name = "mergedeep"
@@ -1187,18 +1131,24 @@ i18n = ["babel (>=2.9.0)"]
 
 [[package]]
 name = "mkdocs-macros-plugin"
-version = "0.2.4"
+version = "1.0.4"
 description = "Unleash the power of MkDocs with macros and variables"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.8"
 files = [
-    {file = "mkdocs-macros-plugin-0.2.4.tar.gz", hash = "sha256:0574afaa3c7ca2c5428314743cb963a7f49698387cb709b04b85500370d87cef"},
+    {file = "mkdocs-macros-plugin-1.0.4.tar.gz", hash = "sha256:fc601f142b89cf98743b6b3608d5f93f24daf69b88cfa2320d503c83723c3c6d"},
+    {file = "mkdocs_macros_plugin-1.0.4-py3-none-any.whl", hash = "sha256:c8169443d17212e32df5ad68b562d901acc936d6e87f6b41139dcf13d6659890"},
 ]
 
 [package.dependencies]
 jinja2 = "*"
 mkdocs = ">=0.17"
-repackage = "*"
+python-dateutil = "*"
+pyyaml = "*"
+termcolor = "*"
+
+[package.extras]
+test = ["mkdocs-include-markdown-plugin", "mkdocs-macros-test", "mkdocs-material (>=6.2)"]
 
 [[package]]
 name = "mkdocs-material"
@@ -1354,13 +1304,13 @@ test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
 
 [[package]]
 name = "pathspec"
-version = "0.11.1"
+version = "0.11.2"
 description = "Utility library for gitignore style pattern matching of file paths."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pathspec-0.11.1-py3-none-any.whl", hash = "sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"},
-    {file = "pathspec-0.11.1.tar.gz", hash = "sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687"},
+    {file = "pathspec-0.11.2-py3-none-any.whl", hash = "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20"},
+    {file = "pathspec-0.11.2.tar.gz", hash = "sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3"},
 ]
 
 [[package]]
@@ -1449,18 +1399,18 @@ tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "pa
 
 [[package]]
 name = "platformdirs"
-version = "3.8.0"
+version = "3.10.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.8.0-py3-none-any.whl", hash = "sha256:ca9ed98ce73076ba72e092b23d3c93ea6c4e186b3f1c3dad6edd98ff6ffcca2e"},
-    {file = "platformdirs-3.8.0.tar.gz", hash = "sha256:b0cabcb11063d21a0b261d557acb0a9d2126350e63b70cdf7db6347baea456dc"},
+    {file = "platformdirs-3.10.0-py3-none-any.whl", hash = "sha256:d7c24979f292f916dc9cbf8648319032f551ea8c49a4c9bf2fb556a02070ec1d"},
+    {file = "platformdirs-3.10.0.tar.gz", hash = "sha256:b45696dab2d7cc691a3226759c0d3b00c47c8b6e293d96f6436f733303f77f6d"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.5.20)", "proselint (>=0.13)", "sphinx (>=7.0.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-cov (>=4.1)", "pytest-mock (>=3.10)"]
+docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-autodoc-typehints (>=1.24)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
 
 [[package]]
 name = "pluggy"
@@ -1501,24 +1451,21 @@ yaspin = ">=0.15.0,<3"
 
 [[package]]
 name = "pre-commit"
-version = "1.21.0"
+version = "3.3.3"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pre_commit-1.21.0-py2.py3-none-any.whl", hash = "sha256:f92a359477f3252452ae2e8d3029de77aec59415c16ae4189bcfba40b757e029"},
-    {file = "pre_commit-1.21.0.tar.gz", hash = "sha256:8f48d8637bdae6fa70cc97db9c1dd5aa7c5c8bf71968932a380628c25978b850"},
+    {file = "pre_commit-3.3.3-py2.py3-none-any.whl", hash = "sha256:10badb65d6a38caff29703362271d7dca483d01da88f9d7e05d0b97171c136cb"},
+    {file = "pre_commit-3.3.3.tar.gz", hash = "sha256:a2256f489cd913d575c145132ae196fe335da32d91a8294b7afe6622335dd023"},
 ]
 
 [package.dependencies]
-"aspy.yaml" = "*"
 cfgv = ">=2.0.0"
 identify = ">=1.0.0"
 nodeenv = ">=0.11.1"
-pyyaml = "*"
-six = "*"
-toml = "*"
-virtualenv = ">=15.2"
+pyyaml = ">=5.1"
+virtualenv = ">=20.10.0"
 
 [[package]]
 name = "proto-plus"
@@ -1539,46 +1486,24 @@ testing = ["google-api-core[grpc] (>=1.31.5)"]
 
 [[package]]
 name = "protobuf"
-version = "4.23.3"
+version = "4.24.0"
 description = ""
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "protobuf-4.23.3-cp310-abi3-win32.whl", hash = "sha256:514b6bbd54a41ca50c86dd5ad6488afe9505901b3557c5e0f7823a0cf67106fb"},
-    {file = "protobuf-4.23.3-cp310-abi3-win_amd64.whl", hash = "sha256:cc14358a8742c4e06b1bfe4be1afbdf5c9f6bd094dff3e14edb78a1513893ff5"},
-    {file = "protobuf-4.23.3-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:2991f5e7690dab569f8f81702e6700e7364cc3b5e572725098215d3da5ccc6ac"},
-    {file = "protobuf-4.23.3-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:08fe19d267608d438aa37019236db02b306e33f6b9902c3163838b8e75970223"},
-    {file = "protobuf-4.23.3-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:3b01a5274ac920feb75d0b372d901524f7e3ad39c63b1a2d55043f3887afe0c1"},
-    {file = "protobuf-4.23.3-cp37-cp37m-win32.whl", hash = "sha256:aca6e86a08c5c5962f55eac9b5bd6fce6ed98645d77e8bfc2b952ecd4a8e4f6a"},
-    {file = "protobuf-4.23.3-cp37-cp37m-win_amd64.whl", hash = "sha256:0149053336a466e3e0b040e54d0b615fc71de86da66791c592cc3c8d18150bf8"},
-    {file = "protobuf-4.23.3-cp38-cp38-win32.whl", hash = "sha256:84ea0bd90c2fdd70ddd9f3d3fc0197cc24ecec1345856c2b5ba70e4d99815359"},
-    {file = "protobuf-4.23.3-cp38-cp38-win_amd64.whl", hash = "sha256:3bcbeb2bf4bb61fe960dd6e005801a23a43578200ea8ceb726d1f6bd0e562ba1"},
-    {file = "protobuf-4.23.3-cp39-cp39-win32.whl", hash = "sha256:5cb9e41188737f321f4fce9a4337bf40a5414b8d03227e1d9fbc59bc3a216e35"},
-    {file = "protobuf-4.23.3-cp39-cp39-win_amd64.whl", hash = "sha256:29660574cd769f2324a57fb78127cda59327eb6664381ecfe1c69731b83e8288"},
-    {file = "protobuf-4.23.3-py3-none-any.whl", hash = "sha256:447b9786ac8e50ae72cae7a2eec5c5df6a9dbf9aa6f908f1b8bda6032644ea62"},
-    {file = "protobuf-4.23.3.tar.gz", hash = "sha256:7a92beb30600332a52cdadbedb40d33fd7c8a0d7f549c440347bc606fb3fe34b"},
-]
-
-[[package]]
-name = "py"
-version = "1.11.0"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-files = [
-    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
-    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
-]
-
-[[package]]
-name = "pycodestyle"
-version = "2.7.0"
-description = "Python style guide checker"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
-    {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
+    {file = "protobuf-4.24.0-cp310-abi3-win32.whl", hash = "sha256:81cb9c4621d2abfe181154354f63af1c41b00a4882fb230b4425cbaed65e8f52"},
+    {file = "protobuf-4.24.0-cp310-abi3-win_amd64.whl", hash = "sha256:6c817cf4a26334625a1904b38523d1b343ff8b637d75d2c8790189a4064e51c3"},
+    {file = "protobuf-4.24.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:ae97b5de10f25b7a443b40427033e545a32b0e9dda17bcd8330d70033379b3e5"},
+    {file = "protobuf-4.24.0-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:567fe6b0647494845d0849e3d5b260bfdd75692bf452cdc9cb660d12457c055d"},
+    {file = "protobuf-4.24.0-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:a6b1ca92ccabfd9903c0c7dde8876221dc7d8d87ad5c42e095cc11b15d3569c7"},
+    {file = "protobuf-4.24.0-cp37-cp37m-win32.whl", hash = "sha256:a38400a692fd0c6944c3c58837d112f135eb1ed6cdad5ca6c5763336e74f1a04"},
+    {file = "protobuf-4.24.0-cp37-cp37m-win_amd64.whl", hash = "sha256:5ab19ee50037d4b663c02218a811a5e1e7bb30940c79aac385b96e7a4f9daa61"},
+    {file = "protobuf-4.24.0-cp38-cp38-win32.whl", hash = "sha256:e8834ef0b4c88666ebb7c7ec18045aa0f4325481d724daa624a4cf9f28134653"},
+    {file = "protobuf-4.24.0-cp38-cp38-win_amd64.whl", hash = "sha256:8bb52a2be32db82ddc623aefcedfe1e0eb51da60e18fcc908fb8885c81d72109"},
+    {file = "protobuf-4.24.0-cp39-cp39-win32.whl", hash = "sha256:ae7a1835721086013de193311df858bc12cd247abe4ef9710b715d930b95b33e"},
+    {file = "protobuf-4.24.0-cp39-cp39-win_amd64.whl", hash = "sha256:44825e963008f8ea0d26c51911c30d3e82e122997c3c4568fd0385dd7bacaedf"},
+    {file = "protobuf-4.24.0-py3-none-any.whl", hash = "sha256:82e6e9ebdd15b8200e8423676eab38b774624d6a1ad696a60d86a2ac93f18201"},
+    {file = "protobuf-4.24.0.tar.gz", hash = "sha256:5d0ceb9de6e08311832169e601d1fc71bd8e8c779f3ee38a97a78554945ecb85"},
 ]
 
 [[package]]
@@ -1604,25 +1529,14 @@ files = [
 ]
 
 [[package]]
-name = "pyflakes"
-version = "2.3.1"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
-    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
-]
-
-[[package]]
 name = "pygments"
-version = "2.15.1"
+version = "2.16.1"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Pygments-2.15.1-py3-none-any.whl", hash = "sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1"},
-    {file = "Pygments-2.15.1.tar.gz", hash = "sha256:8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c"},
+    {file = "Pygments-2.16.1-py3-none-any.whl", hash = "sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692"},
+    {file = "Pygments-2.16.1.tar.gz", hash = "sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29"},
 ]
 
 [package.extras]
@@ -1630,13 +1544,13 @@ plugins = ["importlib-metadata"]
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.0.1"
+version = "10.1"
 description = "Extension pack for Python Markdown."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pymdown_extensions-10.0.1-py3-none-any.whl", hash = "sha256:ae66d84013c5d027ce055693e09a4628b67e9dec5bce05727e45b0918e36f274"},
-    {file = "pymdown_extensions-10.0.1.tar.gz", hash = "sha256:b44e1093a43b8a975eae17b03c3a77aad4681b3b56fce60ce746dbef1944c8cb"},
+    {file = "pymdown_extensions-10.1-py3-none-any.whl", hash = "sha256:ef25dbbae530e8f67575d222b75ff0649b1e841e22c2ae9a20bad9472c2207dc"},
+    {file = "pymdown_extensions-10.1.tar.gz", hash = "sha256:508009b211373058debb8247e168de4cbcb91b1bff7b5e961b2c3e864e00b195"},
 ]
 
 [package.dependencies]
@@ -1645,13 +1559,13 @@ pyyaml = "*"
 
 [[package]]
 name = "pyparsing"
-version = "3.1.0"
+version = "3.0.9"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
 optional = true
 python-versions = ">=3.6.8"
 files = [
-    {file = "pyparsing-3.1.0-py3-none-any.whl", hash = "sha256:d554a96d1a7d3ddaf7183104485bc19fd80543ad6ac5bdb6426719d766fb06c1"},
-    {file = "pyparsing-3.1.0.tar.gz", hash = "sha256:edb662d6fe322d6e990b1594b5feaeadf806803359e3d4d42f11e295e588f0ea"},
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
 
 [package.extras]
@@ -1659,63 +1573,60 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "6.2.5"
+version = "7.4.0"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
-    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
+    {file = "pytest-7.4.0-py3-none-any.whl", hash = "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32"},
+    {file = "pytest-7.4.0.tar.gz", hash = "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"},
 ]
 
 [package.dependencies]
-atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
-attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
-py = ">=1.8.2"
-toml = "*"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-cov"
-version = "2.12.1"
+version = "4.1.0"
 description = "Pytest plugin for measuring coverage."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.7"
 files = [
-    {file = "pytest-cov-2.12.1.tar.gz", hash = "sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7"},
-    {file = "pytest_cov-2.12.1-py2.py3-none-any.whl", hash = "sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a"},
+    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
+    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
 ]
 
 [package.dependencies]
-coverage = ">=5.2.1"
+coverage = {version = ">=5.2.1", extras = ["toml"]}
 pytest = ">=4.6"
-toml = "*"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
 name = "pytest-mock"
-version = "1.13.0"
-description = "Thin-wrapper around the mock package for easier use with py.test"
+version = "3.11.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.7"
 files = [
-    {file = "pytest-mock-1.13.0.tar.gz", hash = "sha256:e24a911ec96773022ebcc7030059b57cd3480b56d4f5d19b7c370ec635e6aed5"},
-    {file = "pytest_mock-1.13.0-py2.py3-none-any.whl", hash = "sha256:67e414b3caef7bff6fc6bd83b22b5bc39147e4493f483c2679bc9d4dc485a94d"},
+    {file = "pytest-mock-3.11.1.tar.gz", hash = "sha256:7f6b125602ac6d743e523ae0bfa71e1a697a2f5534064528c6ff84c2f7c2fc7f"},
+    {file = "pytest_mock-3.11.1-py3-none-any.whl", hash = "sha256:21c279fff83d70763b05f8874cc9cfb3fcacd6d354247a976f9529d19f9acf39"},
 ]
 
 [package.dependencies]
-pytest = ">=2.7"
+pytest = ">=5.0"
 
 [package.extras]
-dev = ["pre-commit", "tox"]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
 name = "python-dateutil"
@@ -1767,51 +1678,51 @@ files = [
 
 [[package]]
 name = "pyyaml"
-version = "6.0"
+version = "6.0.1"
 description = "YAML parser and emitter for Python"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
-    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
-    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
-    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
-    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
-    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
-    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
-    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
-    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
-    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
-    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
-    {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
-    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
-    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
-    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
-    {file = "PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
-    {file = "PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
-    {file = "PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
-    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
-    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
-    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
-    {file = "PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
-    {file = "PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
-    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
-    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
-    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
-    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
-    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
-    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
-    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
-    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
-    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
-    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
-    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
-    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
-    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
-    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
+    {file = "PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a"},
+    {file = "PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
+    {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
+    {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
+    {file = "PyYAML-6.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
+    {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-win32.whl", hash = "sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-win32.whl", hash = "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867"},
+    {file = "PyYAML-6.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
+    {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
+    {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
+    {file = "PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
+    {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
 ]
 
 [[package]]
@@ -1916,16 +1827,6 @@ files = [
 
 [package.dependencies]
 cffi = {version = "*", markers = "implementation_name == \"pypy\""}
-
-[[package]]
-name = "repackage"
-version = "0.7.3"
-description = "Repackaging, call a non-registered package in any directory (with relative call). Used either by modules moved into to a subdirectory or to prepare the import of a non-registered package (in any relative path)."
-optional = false
-python-versions = "*"
-files = [
-    {file = "repackage-0.7.3.tar.gz", hash = "sha256:350fdbb4a297866e9161e80757dd4582a336b0b7259e58926d96b0644c47d204"},
-]
 
 [[package]]
 name = "requests"
@@ -2088,13 +1989,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.3"
+version = "2.0.4"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "urllib3-2.0.3-py3-none-any.whl", hash = "sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1"},
-    {file = "urllib3-2.0.3.tar.gz", hash = "sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825"},
+    {file = "urllib3-2.0.4-py3-none-any.whl", hash = "sha256:de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4"},
+    {file = "urllib3-2.0.4.tar.gz", hash = "sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11"},
 ]
 
 [package.extras]
@@ -2105,23 +2006,23 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.23.1"
+version = "20.24.2"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.23.1-py3-none-any.whl", hash = "sha256:34da10f14fea9be20e0fd7f04aba9732f84e593dac291b757ce42e3368a39419"},
-    {file = "virtualenv-20.23.1.tar.gz", hash = "sha256:8ff19a38c1021c742148edc4f81cb43d7f8c6816d2ede2ab72af5b84c749ade1"},
+    {file = "virtualenv-20.24.2-py3-none-any.whl", hash = "sha256:43a3052be36080548bdee0b42919c88072037d50d56c28bd3f853cbe92b953ff"},
+    {file = "virtualenv-20.24.2.tar.gz", hash = "sha256:fd8a78f46f6b99a67b7ec5cf73f92357891a7b3a40fd97637c27f854aae3b9e0"},
 ]
 
 [package.dependencies]
-distlib = ">=0.3.6,<1"
-filelock = ">=3.12,<4"
-platformdirs = ">=3.5.1,<4"
+distlib = ">=0.3.7,<1"
+filelock = ">=3.12.2,<4"
+platformdirs = ">=3.9.1,<4"
 
 [package.extras]
 docs = ["furo (>=2023.5.20)", "proselint (>=0.13)", "sphinx (>=7.0.1)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
-test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.3.1)", "pytest-env (>=0.8.1)", "pytest-freezer (>=0.4.6)", "pytest-mock (>=3.10)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=67.8)", "time-machine (>=2.9)"]
+test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
 [[package]]
 name = "watchdog"
@@ -2190,13 +2091,13 @@ requests = "*"
 
 [[package]]
 name = "yaspin"
-version = "2.3.0"
+version = "2.4.0"
 description = "Yet Another Terminal Spinner"
 optional = false
 python-versions = ">=3.7.2,<4.0.0"
 files = [
-    {file = "yaspin-2.3.0-py3-none-any.whl", hash = "sha256:17b5548479b3d5b30adec7a87ffcdcddb403d14a2bb86fbcee97f37951e13427"},
-    {file = "yaspin-2.3.0.tar.gz", hash = "sha256:547afd1a9700ac3a29a9f5591c70343bef186ed5dfb5e545a9bb0c77e561a1c9"},
+    {file = "yaspin-2.4.0-py3-none-any.whl", hash = "sha256:9b204e3176afd76197939faf9c3ac304b4edd3dbff38d2a3039d08f1c5c4703c"},
+    {file = "yaspin-2.4.0.tar.gz", hash = "sha256:0a7aa4f88e2afff938899cc6160c886dbd439463d2ec06b7d2367b776635b78b"},
 ]
 
 [package.dependencies]
@@ -2204,18 +2105,18 @@ termcolor = ">=2.2,<3.0"
 
 [[package]]
 name = "zipp"
-version = "3.15.0"
+version = "3.16.2"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "zipp-3.15.0-py3-none-any.whl", hash = "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"},
-    {file = "zipp-3.15.0.tar.gz", hash = "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b"},
+    {file = "zipp-3.16.2-py3-none-any.whl", hash = "sha256:679e51dd4403591b2d6838a48de3d283f3d188412a9782faadf845f298736ba0"},
+    {file = "zipp-3.16.2.tar.gz", hash = "sha256:ebc15946aa78bd63458992fc81ec3b6f7b1e92d51c35e6de1c3804e73b799147"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
 [extras]
 examples = ["asciimatics", "inputs", "matplotlib", "pandas", "webdavclient3"]
@@ -2223,4 +2124,4 @@ examples = ["asciimatics", "inputs", "matplotlib", "pandas", "webdavclient3"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "373d8e5044fa76468877e8df618605d1094e7e521aa1e12e832fa0af330dffbe"
+content-hash = "494c5533ebef116550cae2f1ed418611b6ed458fc34dcaf7baa3b15592f44dee"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,11 +97,11 @@ features = ["content.tabs.link"]
     [[tool.portray.mkdocs.nav.Logs]]
     "Listing and downloading log files" = "docs/logs/listing-and-downloading.md"
     [[tool.portray.mkdocs.nav.Logs]]
-    "Log file format" = "docs/logs/log-file-format.md"
-    [[tool.portray.mkdocs.nav.Logs]]
     "Plotting log files" = "docs/logs/plotting.md"
     [[tool.portray.mkdocs.nav.Logs]]
     "Runtime logs" = "docs/logs/runtime-logs.md"
+    [[tool.portray.mkdocs.nav.Logs]]
+    "Legacy log file format" = "docs/logs/legacy-log-file-format.md"
 
 [[tool.portray.mkdocs.nav]]
 "Configure drone parameters" = "docs/configuration.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,16 +31,15 @@ pyzmq = "^25.0.0"
 proto-plus = "^1.22.2"
 
 [tool.poetry.dev-dependencies]
-pytest = "^6.2.5"
-pytest-mock = "^1.10.4"
-portray = "^1.7.0"
-pre-commit = "^1.18.3"
-black = "^23.1"
-mkdocs-macros-plugin = "^0.2.4"
-flake8 = "^3.7.8"
-pytest-cov = "^2.8.1"
-requests-mock = "^1.7.0"
-freezegun = "^0.3.15"
+pytest = "^7.4"
+pytest-mock = "^3.11"
+portray = "^1.8"
+pre-commit = "^3.3"
+black = "^23.7"
+mkdocs-macros-plugin = "^1.0"
+pytest-cov = "^4.1"
+requests-mock = "^1.11"
+freezegun = "^1.2"
 
 [tool.poetry.extras]
 examples = ["inputs", "asciimatics", "pandas", "matplotlib", "webdavclient3"]
@@ -64,12 +63,17 @@ markdown_extensions = ["admonition",
                        "pymdownx.tilde",
                        ]
 
+[[tool.portray.extra_markdown_extensions]]
+[tool.portray.extra_markdown_extensions."pymdownx.tabbed"]
+alternate_style = true
+
 [tool.portray.mkdocs.theme]
 favicon = "docs/media/blueye_b.svg"
 logo = "docs/media/blueye_b.svg"
 name = "material"
 palette = {primary = "white", accent = "blue"}
 custom_dir = "docs/mkdocs_templates"
+features = ["content.tabs.link"]
 
 [[tool.portray.mkdocs.nav]]
 "About the Blueye Drones" = "README.md"
@@ -123,6 +127,7 @@ markers = "connected_to_drone: a mark for test that can only be run when connect
 
 addopts = "--cov=blueye --cov-report=xml:coverage.xml --cov-report=html --cov-append"
 
+filterwarnings = ["ignore::DeprecationWarning:blueye","ignore::DeprecationWarning:pkg_resources"]
 
 [build-system]
 requires = ["poetry>=1.3.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.0.0"
 description = "SDK for controlling a Blueye underwater drone"
 authors = ["Sindre Hansen <sindre.hansen@blueye.no>",
            "Johannes Schrimpf <johannes.schrimpf@blueye.no>",
-           "Aksel Lenes <aksel.lenes@blueye.no"]
+           "Aksel Lenes <aksel.lenes@blueye.no>"]
 packages = [
   { include = "blueye" }
 ]

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -89,6 +89,11 @@ def test_logs_len_return_two(Logs_object_with_two_logs):
     assert len(Logs_object_with_two_logs) == 2
 
 
+def test_logs_filter(Logs_object_with_two_logs):
+    assert len(Logs_object_with_two_logs.filter(lambda log: log.is_dive == True)) == 2
+    assert len(Logs_object_with_two_logs.filter(lambda log: log.max_depth_magnitude > 50)) == 1
+
+
 @pytest.fixture
 def legacy_log_list_with_two_logs(requests_mock, mocker):
     dummy_json = json.dumps(

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -3,11 +3,11 @@ from datetime import datetime
 
 import pytest
 
-from blueye.sdk.logs import LogFile, Logs
+from blueye.sdk.logs import LegacyLogFile, LegacyLogs
 
 
 @pytest.fixture
-def log_list_with_two_logs(requests_mock, mocker):
+def legacy_log_list_with_two_logs(requests_mock, mocker):
     dummy_json = json.dumps(
         [
             {
@@ -28,7 +28,7 @@ def log_list_with_two_logs(requests_mock, mocker):
     requests_mock.get(f"http://192.168.1.101/logcsv", content=str.encode(dummy_json))
     mocked_drone = mocker.patch("blueye.sdk.Drone", autospec=True, _ip="192.168.1.101")
     mocked_drone.connected = True
-    return Logs(mocked_drone)
+    return LegacyLogs(mocked_drone)
 
 
 @pytest.mark.parametrize(
@@ -41,8 +41,8 @@ def log_list_with_two_logs(requests_mock, mocker):
         (1024**3, "1.0 GiB"),
     ],
 )
-def test_human_readable_filesizes(binsize, expected_output):
-    logfile = LogFile(0, "name", "2019-01-01T00:00:00.000000", binsize, "192.168.1.101")
+def test_legacy_human_readable_filesizes(binsize, expected_output):
+    logfile = LegacyLogFile(0, "name", "2019-01-01T00:00:00.000000", binsize, "192.168.1.101")
     assert logfile._human_readable_filesize() == expected_output
 
 
@@ -50,14 +50,14 @@ def test_human_readable_filesizes(binsize, expected_output):
     "isoformat_string, expected_datetime",
     [("2019-01-01T00:00:00.000000", datetime(2019, 1, 1, 0, 0, 0, 0))],
 )
-def test_timestamp_isoformat_conversion(isoformat_string, expected_datetime):
-    logfile = LogFile(0, "", isoformat_string, 0, "192.168.1.101")
+def test_legacy_timestamp_isoformat_conversion(isoformat_string, expected_datetime):
+    logfile = LegacyLogFile(0, "", isoformat_string, 0, "192.168.1.101")
     assert logfile.timestamp == expected_datetime
 
 
-def test_default_download_path(requests_mock, mocker):
+def test_legacy_default_download_path(requests_mock, mocker):
     logname = "log.csv"
-    dummylog = LogFile(0, logname, "2019-01-01T00:00:00.000000", 0, "192.168.1.101")
+    dummylog = LegacyLogFile(0, logname, "2019-01-01T00:00:00.000000", 0, "192.168.1.101")
 
     dummy_csv_content = b"1,2,3"
     requests_mock.get(f"http://192.168.1.101/logcsv/{logname}", content=dummy_csv_content)
@@ -71,8 +71,8 @@ def test_default_download_path(requests_mock, mocker):
     mocked_filehandle.write.assert_called_once_with(dummy_csv_content)
 
 
-def test_logfile_formatting_with_header():
-    log = LogFile(1000, "log1.csv", "2019-01-01T00:00:00.000000", 1024, "192.168.1.101")
+def test_legacy_logfile_formatting_with_header():
+    log = LegacyLogFile(1000, "log1.csv", "2019-01-01T00:00:00.000000", 1024, "192.168.1.101")
     expected_output = (
         "Name      Time                Max depth    Size\n"
         + "log1.csv  01. Jan 2019 00:00  1.00 m       1.0 KiB"
@@ -80,61 +80,61 @@ def test_logfile_formatting_with_header():
     assert f"{log:with_header}" == expected_output
 
 
-def test_logfile_formatting_without_header():
-    log = LogFile(1000, "log1.csv", "2019-01-01T00:00:00.000000", 1024, "192.168.1.101")
+def test_legacy_logfile_formatting_without_header():
+    log = LegacyLogFile(1000, "log1.csv", "2019-01-01T00:00:00.000000", 1024, "192.168.1.101")
     expected_output = "log1.csv  01. Jan 2019 00:00  1.00 m  1.0 KiB"
     assert f"{log}" == expected_output
 
 
-def test_loglist_formatting(log_list_with_two_logs):
+def test_legacy_loglist_formatting(legacy_log_list_with_two_logs):
     expected_output = (
         "Name      Time                Max depth    Size\n"
         + "log1.csv  01. Jan 2019 00:00  1.00 m       1.0 KiB\n"
         + "log2.csv  02. Jan 2019 00:00  2.00 m       2.0 KiB"
     )
-    assert f"{log_list_with_two_logs}" == expected_output
+    assert f"{legacy_log_list_with_two_logs}" == expected_output
 
 
-def test_log_list_is_subscriptable(log_list_with_two_logs):
-    assert log_list_with_two_logs[0].name == "log1.csv"
-    assert log_list_with_two_logs[1].name == "log2.csv"
+def test_legacy_log_list_is_subscriptable(legacy_log_list_with_two_logs):
+    assert legacy_log_list_with_two_logs[0].name == "log1.csv"
+    assert legacy_log_list_with_two_logs[1].name == "log2.csv"
 
 
-def test_log_list_is_accessible_by_key(log_list_with_two_logs):
-    assert log_list_with_two_logs["log1.csv"]
+def test_legacy_log_list_is_accessible_by_key(legacy_log_list_with_two_logs):
+    assert legacy_log_list_with_two_logs["log1.csv"]
 
 
-def test_log_list_is_iterable(log_list_with_two_logs):
+def test_legacy_log_list_is_iterable(legacy_log_list_with_two_logs):
     expected_names = "log1.csvlog2.csv"
     names = ""
-    for log in log_list_with_two_logs:
+    for log in legacy_log_list_with_two_logs:
         names += log.name
     assert names == expected_names
 
 
-def test_logs_raises_KeyError(log_list_with_two_logs):
+def test_legacy_logs_raises_KeyError(legacy_log_list_with_two_logs):
     with pytest.raises(KeyError):
-        log_list_with_two_logs["non_existing_log_name"]
+        legacy_log_list_with_two_logs["non_existing_log_name"]
 
 
-def test_logs_raises_IndexError(log_list_with_two_logs):
+def test_legacy_logs_raises_IndexError(legacy_log_list_with_two_logs):
     with pytest.raises(IndexError):
-        log_list_with_two_logs[3]
+        legacy_log_list_with_two_logs[3]
 
 
-def test_index_is_downloaded_on_first_access(log_list_with_two_logs):
+def test_legacy_index_is_downloaded_on_first_access(legacy_log_list_with_two_logs):
     """Tests that logs are not downloaded before someone attempts to access the logs. And that the
     logs are downloaded after an access is attempted.
     """
-    assert log_list_with_two_logs._logs == {}
-    _ = log_list_with_two_logs[0]
-    assert len(log_list_with_two_logs[::]) == 2
+    assert legacy_log_list_with_two_logs._logs == {}
+    _ = legacy_log_list_with_two_logs[0]
+    assert len(legacy_log_list_with_two_logs[::]) == 2
 
 
 @pytest.mark.parametrize("divisor", [1, 10])
-def test_divisor_parameter_is_passed_to_request(requests_mock, mocker, divisor):
+def test_legacy_divisor_parameter_is_passed_to_request(requests_mock, mocker, divisor):
     logname = "log.csv"
-    dummylog = LogFile(0, logname, "2019-01-01T00:00:00.000000", 0, "192.168.1.101")
+    dummylog = LegacyLogFile(0, logname, "2019-01-01T00:00:00.000000", 0, "192.168.1.101")
 
     dummy_csv_content = b"1,2,3"
     requests_mock.get(

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -3,7 +3,86 @@ from datetime import datetime
 
 import pytest
 
-from blueye.sdk.logs import LegacyLogFile, LegacyLogs, human_readable_filesize
+from blueye.sdk.logs import LegacyLogFile, LegacyLogs, Logs, human_readable_filesize
+
+
+@pytest.fixture
+def Logs_object_with_two_logs(requests_mock, mocker):
+    dummy_json = json.dumps(
+        [
+            {
+                "binlog_size": 1024,
+                "has_binlog": True,
+                "has_dive_info": True,
+                "is_dive": True,
+                "is_open": False,
+                "log_number": 1,
+                "name": "BYEDP123456_aabbccddeeff1234_00001",
+                "videos": [
+                    "/videos/video_BYEDP123456_2023-08-02_122432.mp4",
+                    "/videos/video_BYEDP123456_2023-08-02_122444_cam2.mp4",
+                ],
+            },
+            {
+                "binlog_size": 2048,
+                "has_binlog": True,
+                "has_dive_info": True,
+                "is_dive": True,
+                "is_open": False,
+                "log_number": 2,
+                "name": "BYEDP123456_aabbccddeeff1234_00002",
+                "videos": [
+                    "/videos/video_BYEDP123456_2023-08-03_122432.mp4",
+                    "/videos/video_BYEDP123456_2023-08-03_122444_cam2.mp4",
+                ],
+            },
+        ]
+    )
+    requests_mock.get("http://192.168.1.101/logs", content=str.encode(dummy_json))
+
+    log1_json = json.dumps(
+        {
+            "blunux_version": "3.2.63-honister-master",
+            "is_dive": True,
+            "is_valid": True,
+            "log_name": "BYEDP123456_aabbccddeeff1234_00001.bez",
+            "max_depth_magnitude": 100,
+            "model_name": "Blueye X3",
+            "start_time": 1690979463,
+            "videos": [
+                "/videos/video_BYEDP123456_2023-08-02_123249.mp4",
+                "/videos/video_BYEDP123456_2023-08-02_123255_cam2.mp4",
+            ],
+        }
+    )
+    log2_json = json.dumps(
+        {
+            "blunux_version": "3.2.63-honister-master",
+            "is_dive": True,
+            "is_valid": True,
+            "log_name": "BYEDP123456_aabbccddeeff1234_00001.bez",
+            "max_depth_magnitude": 10,
+            "model_name": "Blueye X3",
+            "start_time": 1691065863,
+            "videos": [
+                "/videos/video_BYEDP123456_2023-08-03_123249.mp4",
+                "/videos/video_BYEDP123456_2023-08-03_123255_cam2.mp4",
+            ],
+        }
+    )
+    requests_mock.get(
+        "http://192.168.1.101/logs/BYEDP123456_aabbccddeeff1234_00001/dive_info",
+        content=str.encode(log1_json),
+    )
+    requests_mock.get(
+        "http://192.168.1.101/logs/BYEDP123456_aabbccddeeff1234_00002/dive_info",
+        content=str.encode(log2_json),
+    )
+    mocked_drone = mocker.patch(
+        "blueye.sdk.Drone", autospec=True, _ip="192.168.1.101", software_version_short="3.2.63"
+    )
+    mocked_drone.connected = True
+    return Logs(mocked_drone)
 
 
 @pytest.fixture

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -85,6 +85,10 @@ def Logs_object_with_two_logs(requests_mock, mocker):
     return Logs(mocked_drone)
 
 
+def test_logs_len_return_two(Logs_object_with_two_logs):
+    assert len(Logs_object_with_two_logs) == 2
+
+
 @pytest.fixture
 def legacy_log_list_with_two_logs(requests_mock, mocker):
     dummy_json = json.dumps(

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 import pytest
 
-from blueye.sdk.logs import LegacyLogFile, LegacyLogs
+from blueye.sdk.logs import LegacyLogFile, LegacyLogs, human_readable_filesize
 
 
 @pytest.fixture
@@ -41,9 +41,8 @@ def legacy_log_list_with_two_logs(requests_mock, mocker):
         (1024**3, "1.0 GiB"),
     ],
 )
-def test_legacy_human_readable_filesizes(binsize, expected_output):
-    logfile = LegacyLogFile(0, "name", "2019-01-01T00:00:00.000000", binsize, "192.168.1.101")
-    assert logfile._human_readable_filesize() == expected_output
+def test_human_readable_filesizes(binsize, expected_output):
+    assert human_readable_filesize(binsize) == expected_output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR add support for the new binary log format introduced with Blunux v3.0. 

Fixes #75, #126, #128, #140

Breaking changes:
- Old `Logs` class has been renamed to `LegacyLogs` 
- Old `LogFile` class has been renamed to `LegacyLogFile`

Todo:
- [x] Document logs endpoint
