### PR TITLE
Dynamically list peripherals

### DIFF
--- a/blueye/sdk/connection.py
+++ b/blueye/sdk/connection.py
@@ -163,6 +163,10 @@ class CtrlClient(threading.Thread):
         msg = blueye.protocol.LightsCtrl(lights={"value": value})
         self._messages_to_send.put(msg)
 
+    def set_guest_port_lights(self, value: float):
+        msg = blueye.protocol.GuestportLightsCtrl(lights={"value": value})
+        self._messages_to_send.put(msg)
+
     def set_water_density(self, value: float):
         msg = blueye.protocol.WaterDensityCtrl(density={"value": value})
         self._messages_to_send.put(msg)

--- a/blueye/sdk/connection.py
+++ b/blueye/sdk/connection.py
@@ -6,7 +6,7 @@ import platform
 import queue
 import threading
 import uuid
-from typing import Callable, Dict, List, NamedTuple, Tuple
+from typing import Any, Callable, Dict, List, NamedTuple, Tuple
 
 import blueye.protocol
 import proto
@@ -54,6 +54,7 @@ class Callback(NamedTuple):
     function: Callable[[str, proto.message.Message], None]
     pass_raw_data: bool
     uuid_hex: str
+    kwargs: Dict[str, Any]
 
 
 class TelemetryClient(threading.Thread):
@@ -87,10 +88,10 @@ class TelemetryClient(threading.Thread):
         for callback in self._callbacks:
             if msg_type in callback.message_filter or callback.message_filter == []:
                 if callback.pass_raw_data:
-                    callback.function(msg_type_name, msg_payload)
+                    callback.function(msg_type_name, msg_payload, **callback.kwargs)
                 else:
                     msg_deserialized = msg_type.deserialize(msg_payload)
-                    callback.function(msg_type_name, msg_deserialized)
+                    callback.function(msg_type_name, msg_deserialized, **callback.kwargs)
 
     def run(self):
         poller = zmq.Poller()
@@ -107,9 +108,10 @@ class TelemetryClient(threading.Thread):
         msg_filter: List[proto.message.Message],
         callback_function: Callable[[str, proto.message.Message], None],
         raw: bool,
+        **kwargs,
     ):
         uuid_hex = uuid.uuid1().hex
-        self._callbacks.append(Callback(msg_filter, callback_function, raw, uuid_hex))
+        self._callbacks.append(Callback(msg_filter, callback_function, raw, uuid_hex, kwargs))
         return uuid_hex
 
     def remove_callback(self, callback_id):

--- a/blueye/sdk/drone.py
+++ b/blueye/sdk/drone.py
@@ -94,6 +94,7 @@ class Telemetry:
         msg_filter: List[proto.message.Message],
         callback: Callable[[str, proto.message.Message], None],
         raw: bool = False,
+        **kwargs,
     ) -> str:
         """Register a telemetry message callback
 
@@ -108,13 +109,15 @@ class Telemetry:
                     not block the telemetry communication. It is called with two arguments, the
                     message type name and the message object
         * raw: Pass the raw data instead of the deserialized message to the callback function
+        * kwargs: Additional keyword arguments to pass to the callback function
 
         *Returns*:
 
         * uuid: Callback id. Can be used to remove callback in the future
-
         """
-        uuid_hex = self._parent_drone._telemetry_watcher.add_callback(msg_filter, callback, raw=raw)
+        uuid_hex = self._parent_drone._telemetry_watcher.add_callback(
+            msg_filter, callback, raw, **kwargs
+        )
         return uuid_hex
 
     def remove_msg_callback(self, callback_id: str) -> Optional[str]:

--- a/blueye/sdk/drone.py
+++ b/blueye/sdk/drone.py
@@ -16,6 +16,7 @@ from .battery import Battery
 from .camera import Camera
 from .connection import CtrlClient, ReqRepClient, TelemetryClient, WatchdogPublisher
 from .constants import WaterDensities
+from .guestport import Peripheral, device_to_peripheral
 from .logs import LegacyLogs, Logs
 from .motion import Motion
 
@@ -186,6 +187,11 @@ class Drone:
         self._telemetry_watcher = _NoConnectionClient()
         self._req_rep_client = _NoConnectionClient()
         self._ctrl_client = _NoConnectionClient()
+
+        self.peripherals: Optional[List[Peripheral]] = None
+        """This list holds the peripherals connected to the drone. If it is `None`, then no
+        Guestport telemetry message has been recieved yet."""
+
         if auto_connect is True:
             self.connect(timeout=timeout, disconnect_other_clients=disconnect_other_clients)
 
@@ -225,6 +231,21 @@ class Drone:
         self.software_version_short = self.software_version.split("-")[0]
         self.serial_number = response["serial_number"]
         self.uuid = response["hardware_id"]
+
+    @staticmethod
+    def _drone_info_callback(msg_type: str, msg: blueye.protocol.DroneInfoTel, drone: Drone):
+        # Check if the GuestPortInfo has been initialized
+        if msg.drone_info.gp._pb.ByteSize() != 0:
+            drone._create_peripherals_from_drone_info(msg.drone_info.gp)
+
+        # Remove the callback after the first message has been received
+        drone.telemetry.remove_msg_callback(drone._drone_info_cb_id)
+
+    def _create_peripherals_from_drone_info(self, gp_info: blueye.protocol.GuestPortInfo):
+        self.peripherals = []
+        for port in (gp_info.gp1, gp_info.gp2, gp_info.gp3):
+            for device in port.device_list.devices:
+                self.peripherals.append(device_to_peripheral(self, port.guest_port_number, device))
 
     def connect(
         self,
@@ -277,6 +298,13 @@ class Drone:
         self.connected = True
         if disconnect_other_clients and not self.in_control:
             self.take_control()
+        self._drone_info_cb_id = self.telemetry.add_msg_callback(
+            [blueye.protocol.DroneInfoTel],
+            Drone._drone_info_callback,
+            False,
+            drone=self,
+        )
+
         if self.in_control:
             # The drone runs from a read-only filesystem, and as such does not keep any state,
             # therefore when we connect to it we should send the current time

--- a/blueye/sdk/drone.py
+++ b/blueye/sdk/drone.py
@@ -16,7 +16,7 @@ from .battery import Battery
 from .camera import Camera
 from .connection import CtrlClient, ReqRepClient, TelemetryClient, WatchdogPublisher
 from .constants import WaterDensities
-from .guestport import Peripheral, device_to_peripheral
+from .guestport import GuestPortCamera, GuestPortLight, Peripheral, device_to_peripheral
 from .logs import LegacyLogs, Logs
 from .motion import Motion
 
@@ -245,7 +245,12 @@ class Drone:
         self.peripherals = []
         for port in (gp_info.gp1, gp_info.gp2, gp_info.gp3):
             for device in port.device_list.devices:
-                self.peripherals.append(device_to_peripheral(self, port.guest_port_number, device))
+                peripheral = device_to_peripheral(self, port.guest_port_number, device)
+                self.peripherals.append(peripheral)
+                if isinstance(peripheral, GuestPortLight):
+                    self.external_light = peripheral
+                elif isinstance(peripheral, GuestPortCamera):
+                    self.external_camera = peripheral
 
     def connect(
         self,

--- a/blueye/sdk/guestport.py
+++ b/blueye/sdk/guestport.py
@@ -34,7 +34,7 @@ class Peripheral:
                 )
 
 
-class GuestportCamera(Camera, Peripheral):
+class GuestPortCamera(Camera, Peripheral):
     def __init__(
         self, parent_drone: "Drone", port_number: bp.GuestPortNumber, device: bp.GuestPortDevice
     ):
@@ -60,7 +60,7 @@ def device_to_peripheral(
 ) -> Peripheral:
     logger.debug(f"Found a {device.name} at port {port_number}")
     if device.device_id == bp.GuestPortDeviceID.GUEST_PORT_DEVICE_ID_BLUEYE_CAM:
-        peripheral = GuestportCamera(parent_drone, port_number, device)
+        peripheral = GuestPortCamera(parent_drone, port_number, device)
     elif (
         device.device_id == bp.GuestPortDeviceID.GUEST_PORT_DEVICE_ID_BLUEYE_LIGHT
         or device.device_id == bp.GuestPortDeviceID.GUEST_PORT_DEVICE_ID_BLUEYE_LIGHT_PAIR

--- a/blueye/sdk/guestport.py
+++ b/blueye/sdk/guestport.py
@@ -23,6 +23,7 @@ class Peripheral:
         self.serial_number: str = device.serial_number
         self.depth_rating: float = device.depth_rating
         self.required_blunux_version: str = device.required_blunux_version
+        self.device_id: bp.GuestPortDeviceID = device.device_id
         if self.required_blunux_version != "":
             if version.parse(self.required_blunux_version) > version.parse(
                 parent_drone.software_version_short

--- a/blueye/sdk/guestport.py
+++ b/blueye/sdk/guestport.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 import blueye.protocol as bp
 from packaging import version
 
+from .camera import Camera
+
 if TYPE_CHECKING:
     from .drone import Drone
 
@@ -32,9 +34,20 @@ class Peripheral:
                 )
 
 
+class GuestportCamera(Camera, Peripheral):
+    def __init__(
+        self, parent_drone: "Drone", port_number: bp.GuestPortNumber, device: bp.GuestPortDevice
+    ):
+        Camera.__init__(self, parent_drone, is_guestport_camera=True)
+        Peripheral.__init__(self, parent_drone, port_number, device)
+
+
 def device_to_peripheral(
     parent_drone: "Drone", port_number: bp.GuestPortNumber, device: bp.GuestPortDevice
 ) -> Peripheral:
     logger.debug(f"Found a {device.name} at port {port_number}")
-    peripheral = Peripheral(parent_drone, port_number, device)
+    if device.device_id == bp.GuestPortDeviceID.GUEST_PORT_DEVICE_ID_BLUEYE_CAM:
+        peripheral = GuestportCamera(parent_drone, port_number, device)
+    else:
+        peripheral = Peripheral(parent_drone, port_number, device)
     return peripheral

--- a/blueye/sdk/guestport.py
+++ b/blueye/sdk/guestport.py
@@ -1,0 +1,40 @@
+import logging
+from typing import TYPE_CHECKING
+
+import blueye.protocol as bp
+from packaging import version
+
+if TYPE_CHECKING:
+    from .drone import Drone
+
+logger = logging.getLogger(__name__)
+
+
+class Peripheral:
+    def __init__(
+        self, parent_drone: "Drone", port_number: bp.GuestPortNumber, device: bp.GuestPortDevice
+    ):
+        self.parent_drone = parent_drone
+        self.port_number: bp.GuestPortNumber = port_number
+        self.name: str = device.name
+        self.manufacturer: str = device.manufacturer
+        self.serial_number: str = device.serial_number
+        self.depth_rating: float = device.depth_rating
+        self.required_blunux_version: str = device.required_blunux_version
+        if self.required_blunux_version != "":
+            if version.parse(self.required_blunux_version) > version.parse(
+                parent_drone.software_version_short
+            ):
+                logger.warning(
+                    f"Peripheral {self.name} requires Blunux version "
+                    f"{self.required_blunux_version}, but the drone is running "
+                    f"{parent_drone.software_version_short}"
+                )
+
+
+def device_to_peripheral(
+    parent_drone: "Drone", port_number: bp.GuestPortNumber, device: bp.GuestPortDevice
+) -> Peripheral:
+    logger.debug(f"Found a {device.name} at port {port_number}")
+    peripheral = Peripheral(parent_drone, port_number, device)
+    return peripheral

--- a/tests/test_peripherals.py
+++ b/tests/test_peripherals.py
@@ -1,0 +1,21 @@
+import blueye.protocol as bp
+
+import blueye.sdk
+
+
+def test_peripheral_attribute_setter(mocked_drone):
+    gp_cam = bp.GuestPortDevice({"device_id": bp.GuestPortDeviceID.GUEST_PORT_DEVICE_ID_BLUEYE_CAM})
+    gp_light = bp.GuestPortDevice(
+        {"device_id": bp.GuestPortDeviceID.GUEST_PORT_DEVICE_ID_BLUEYE_LIGHT}
+    )
+    gp_info = bp.GuestPortInfo()
+    gp_info.gp1 = bp.GuestPortConnectorInfo()
+    gp_info.gp1.device_list = bp.GuestPortDeviceList()
+    gp_info.gp1.device_list.devices.append(gp_light)
+    gp_info.gp3 = bp.GuestPortConnectorInfo()
+    gp_info.gp3.device_list = bp.GuestPortDeviceList()
+    gp_info.gp3.device_list.devices.append(gp_cam)
+
+    mocked_drone._create_peripherals_from_drone_info(gp_info)
+    assert isinstance(mocked_drone.external_camera, blueye.sdk.guestport.GuestPortCamera)
+    assert isinstance(mocked_drone.external_light, blueye.sdk.guestport.GuestPortLight)


### PR DESCRIPTION
This PR adds a function that checks which peripherals are attached to the connected drone, and stores them in a list on the Drone object. 

Example:
```python
from blueye.sdk import Drone

x3 = Drone()  # A drone with external lights and camera
x3.peripherals[0].set_intensity(0.5) # Setting external lights to 50%
x3.peripherals[1].is_recording = True # Starts the recording on the external camera

# The following also works for external lights and cameras
x3.external_light.set_intensity(0)
x3.external_camera.is_recording = False
```
