### PR TITLE
Lengthen default connection timeout

### DIFF
--- a/blueye/sdk/drone.py
+++ b/blueye/sdk/drone.py
@@ -180,7 +180,7 @@ class Drone:
         self,
         ip="192.168.1.101",
         auto_connect=True,
-        timeout=3,
+        timeout=10,
         disconnect_other_clients=False,
     ):
         self._ip = ip


### PR DESCRIPTION
On the first connection to the drone after a boot the it can be slower to respond to the drone info HTTP request, sometimes as slow as 6s. This is due to lack of caches in the webserver.

