### PR TITLE
Catch ZMQ connection errors

### DIFF
--- a/blueye/sdk/drone.py
+++ b/blueye/sdk/drone.py
@@ -306,8 +306,11 @@ class Drone:
         self._ctrl_client.start()
         self._watchdog_publisher.start()
 
-        self.ping()
-        connect_resp = self._req_rep_client.connect_client(client_info=client_info)
+        try:
+            self.ping()
+            connect_resp = self._req_rep_client.connect_client(client_info=client_info)
+        except blueye.protocol.exceptions.ResponseTimeout as e:
+            raise ConnectionError("Could not establish connection with drone") from e
         logger.info(f"Connection successful, client id: {connect_resp.client_id}")
         logger.info(f"Client id in control: {connect_resp.client_id_in_control}")
         logger.info(f"There are {len(connect_resp.connected_clients)-1} other clients connected")

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -33,6 +33,12 @@ class TestPose:
         assert pose["yaw"] == new_angle
 
 
+def test_zmq_connection_error(mocked_drone):
+    mocked_drone._req_rep_client.ping.side_effect = bp.exceptions.ResponseTimeout
+    with pytest.raises(ConnectionError):
+        mocked_drone.connect()
+
+
 def test_feature_list(mocked_drone):
     mocked_drone._update_drone_info()
     assert mocked_drone.features == ["lasers", "harpoon"]


### PR DESCRIPTION
These should only occur if the Django server is up and not the ZMQ server, but they do occur, so it's nice to catch them and reraise as ConnectionErrors. 