### PR TITLE
Fix unit for water density

### DIFF
--- a/blueye/sdk/constants.py
+++ b/blueye/sdk/constants.py
@@ -5,9 +5,9 @@ This file contains constants used by the SDK.
 
 class WaterDensities:
     """
-    Various typical densities for salt water (in kilograms/liter)
+    Various typical densities for salt water (in grams/liter)
     """
 
-    fresh = 0.997
-    brackish = 1.011
-    salty = 1.025
+    fresh = 997.0
+    brackish = 1011.0
+    salty = 1025.0

--- a/blueye/sdk/drone.py
+++ b/blueye/sdk/drone.py
@@ -38,7 +38,7 @@ class Config:
     def water_density(self):
         """Get or set the current water density for increased pressure sensor accuracy
 
-        Older software versions will assume a water density of 1.025 kilograms per liter.
+        Older software versions will assume a water density of 1025 grams per liter.
 
         The WaterDensities class contains typical densities for salty-, brackish-, and fresh water
         (these are the same values that the Blueye app uses).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,16 +37,16 @@ from blueye.sdk import Drone, WaterDensities
 myDrone = Drone()
 
 # Salt water
-myDrone.config.water_density = WaterDensities.salty  # 1.025 kg/L
+myDrone.config.water_density = WaterDensities.salty  # 1025 g/L
 
 # Brackish water
-myDrone.config.water_density = WaterDensities.brackish  # 1.011 kg/L
+myDrone.config.water_density = WaterDensities.brackish  # 1011 g/L
 
 # Fresh water
-myDrone.config.water_density = WaterDensities.fresh  # 0.997 kg/L
+myDrone.config.water_density = WaterDensities.fresh  # 997 g/L
 
 # Can also be set to arbitrary values
-myDrone.config.water_density = 1.234
+myDrone.config.water_density = 1234
 ```
 
 ### Configure camera parameters

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -209,12 +209,12 @@ class TestTilt:
 
 class TestConfig:
     def test_water_density_property_returns_correct_value(self, mocked_drone: Drone):
-        mocked_drone.config._water_density = 1.0
-        assert mocked_drone.config.water_density == 1.0
+        mocked_drone.config._water_density = 1000.0
+        assert mocked_drone.config.water_density == 1000.0
 
     def test_setting_density(self, mocked_drone: Drone):
         old_value = mocked_drone.config.water_density
-        new_value = old_value + 0.010
+        new_value = old_value + 10
         mocked_drone.config.water_density = new_value
         assert mocked_drone.config.water_density == new_value
         mocked_drone._ctrl_client.set_water_density.assert_called_once()


### PR DESCRIPTION
Misleading comment in the Protocol led to using the wrong unit when porting to protocol v3.

See https://github.com/BluEye-Robotics/ProtocolDefinitions/pull/139

