### PR TITLE
Add observer mode

### DIFF
--- a/blueye/sdk/connection.py
+++ b/blueye/sdk/connection.py
@@ -345,9 +345,13 @@ class ReqRepClient(threading.Thread):
         return self._send_request_get_response(request, blueye.protocol.SyncTimeRep, timeout)
 
     def connect_client(
-        self, client_info: blueye.protocol.ClientInfo = None, timeout: float = 0.05
+        self,
+        client_info: blueye.protocol.ClientInfo = None,
+        is_observer: bool = False,
+        timeout: float = 0.05,
     ) -> blueye.protocol.ConnectClientRep:
         client = client_info or self._get_client_info()
+        client.is_observer = is_observer
         request = blueye.protocol.ConnectClientReq(client_info=client)
         return self._send_request_get_response(request, blueye.protocol.ConnectClientRep, timeout)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,3 +112,14 @@ def mocked_drone(
     if hasattr(request, "param"):
         drone.software_version_short = request.param
     return drone
+
+
+@pytest.fixture
+def mocked_drone_not_connected(
+    mocker,
+    mocked_requests,
+    mocked_ctrl_client,
+    mocked_watchdog_publisher,
+    mocked_req_rep_client,
+):
+    return blueye.sdk.Drone(auto_connect=False)

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -311,3 +311,15 @@ def test_dive_time_returns_expected_value(mocked_drone):
 
 def test_dive_time_returns_none_on_missing_telemetry(mocked_drone):
     assert mocked_drone.dive_time is None
+
+
+def test_connect_as_observer(mocked_drone_not_connected):
+    mocked_drone_not_connected.connect(connect_as_observer=True)
+    mocked_drone_not_connected._req_rep_client.connect_client.assert_called_with(
+        client_info=None, is_observer=True
+    )
+
+
+def test_connect_as_observer_ignores_diconnect_other_clients(mocked_drone_not_connected):
+    mocked_drone_not_connected.connect(disconnect_other_clients=True, connect_as_observer=True)
+    mocked_drone_not_connected._req_rep_client.disconnect_client.assert_not_called()


### PR DESCRIPTION
This PR allows the SDK to signal to the drone that it does not want to be promoted to a client in control.

Fixes #160, Fixes #167 