### PR TITLE
Initiate the Drone obj as observer

### DIFF
--- a/examples/foxglove_bridge_ws.py
+++ b/examples/foxglove_bridge_ws.py
@@ -100,7 +100,7 @@ def get_protobuf_descriptors(namespace):
 
 async def main():
     # Initialize the drone
-    myDrone = Drone()
+    myDrone = Drone(connect_as_observer=True)
     myDrone.telemetry.add_msg_callback([], parse_message, raw=True)
 
     # Specify the server's host, port, and a human-readable name


### PR DESCRIPTION
We want to run the foxglove bridge as observer so it is possible to connect with a control app after it is started.
