### PR TITLE
Drop Python 3.9 and update dependencies

### DIFF
--- a/.github/workflows/PublishRelease.yml
+++ b/.github/workflows/PublishRelease.yml
@@ -16,9 +16,9 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v2.1.4
+        uses: abatilo/actions-poetry@v3.0.2
         with:
-          poetry-version: "1.3.2"
+          poetry-version: "2.0.1"
       - name: Install dependencies
         run: poetry install
       - name: Build HTTP documentation

--- a/.github/workflows/PublishRelease.yml
+++ b/.github/workflows/PublishRelease.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install Poetry

--- a/.github/workflows/PublishRelease.yml
+++ b/.github/workflows/PublishRelease.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.13"
       - name: Install Poetry
         uses: abatilo/actions-poetry@v3.0.2
         with:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -19,9 +19,9 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v2.1.4
+        uses: abatilo/actions-poetry@v3.0.2
         with:
-          poetry-version: "1.3.2"
+          poetry-version: "2.0.1"
       - name: Install dependencies
         run: poetry install
       - name: Run tests
@@ -47,9 +47,9 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v2.1.4
+        uses: abatilo/actions-poetry@v3.0.2
         with:
-          poetry-version: "1.3.2"
+          poetry-version: "2.0.1"
       - name: poetry install
         run: poetry install
       - name: Check formatting

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python: ["3.9", "3.10", "3.11", "3.12"]
+        python: ["3.10", "3.11", "3.12", "3.13"]
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python }}
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install Poetry
         uses: abatilo/actions-poetry@v3.0.2
         with:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -13,9 +13,9 @@ jobs:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Install Poetry
@@ -27,7 +27,7 @@ jobs:
       - name: Run tests
         run: poetry run pytest -k "not connected_to_drone" --cov-report=xml --cov blueye
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: OS,PYTHON
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: Install Poetry

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,18 +24,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,9 +20,9 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v2.1.4
+        uses: abatilo/actions-poetry@v3.0.2
         with:
-          poetry-version: "1.3.2"
+          poetry-version: "2.0.1"
       - name: Install dependencies
         run: poetry install
       - name: Build HTTP documentation

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,7 +29,7 @@ jobs:
         run: npx @redocly/cli build-docs http-api.yml --output docs/http-api.html
       - name: Build documentation
         run: poetry run mkdocs build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: docs
           path: site
@@ -61,7 +61,7 @@ jobs:
         run: git checkout gh-pages
       - name: Push to gh-pages
         if: github.ref == 'refs/heads/master' || github.event_name == 'release'
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@v0.8.0
         with:
           github_token: ${{ secrets.GIT_TOKEN }}
           branch: gh-pages

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.13"
       - name: Install Poetry
         uses: abatilo/actions-poetry@v3.0.2
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev: stable
     hooks:
     - id: black
-      language_version: python3.9
+      language_version: python3.13

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # blueye.sdk
 [![Tests](https://github.com/BluEye-Robotics/blueye.sdk/workflows/Tests/badge.svg)](https://github.com/BluEye-Robotics/blueye.sdk/actions)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
-[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/BluEye-Robotics/blueye.sdk.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/BluEye-Robotics/blueye.sdk/context:python)
 [![codecov](https://codecov.io/gh/BluEye-Robotics/blueye.sdk/branch/master/graph/badge.svg)](https://codecov.io/gh/BluEye-Robotics/blueye.sdk)
 [![PyPi-version](https://img.shields.io/pypi/v/blueye.sdk.svg?maxAge=3600)](https://pypi.org/project/blueye.sdk/)
 [![python-versions](https://img.shields.io/pypi/pyversions/blueye.sdk.svg?longCache=True)](https://pypi.org/project/blueye.sdk/)

--- a/docs/protobuf-protocol.md
+++ b/docs/protobuf-protocol.md
@@ -1,4 +1,8 @@
 # Protocol Documentation
+
+
+<a name="aquatroll-proto"></a>
+
 ## aquatroll.proto
 Aquatroll
 
@@ -13,19 +17,14 @@ In-Situ Parameter Block
 Up to NUMBER_OF_SENSOR_PARAMETERS blocks may be part of a sensor
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| measured_value | [float](#float) |  |  |
-| parameter_id | [AquaTrollParameter](#blueye-protocol-AquaTrollParameter) |  |  |
-| units_id | [AquaTrollUnit](#blueye-protocol-AquaTrollUnit) |  |  |
-| data_quality_ids | [AquaTrollQuality](#blueye-protocol-AquaTrollQuality) | repeated |  |
-| off_line_sentinel_value | [float](#float) |  |  |
-| available_units | [AquaTrollUnit](#blueye-protocol-AquaTrollUnit) | repeated |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| measured_value | [ float](#float) |  |
+| parameter_id | [ AquaTrollParameter](#blueye-protocol-AquaTrollParameter) |  |
+| units_id | [ AquaTrollUnit](#blueye-protocol-AquaTrollUnit) |  |
+| data_quality_ids | [repeated AquaTrollQuality](#blueye-protocol-AquaTrollQuality) |  |
+| off_line_sentinel_value | [ float](#float) |  |
+| available_units | [repeated AquaTrollUnit](#blueye-protocol-AquaTrollUnit) |  |
 
 <a name="blueye-protocol-AquaTrollProbeMetadata"></a>
 
@@ -33,36 +32,31 @@ Up to NUMBER_OF_SENSOR_PARAMETERS blocks may be part of a sensor
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| timestamp | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
-| status | [bool](#bool) |  |  |
-| register_map_template_version | [uint32](#uint32) |  |  |
-| device_id | [AquaTrollDevice](#blueye-protocol-AquaTrollDevice) |  |  |
-| device_serial_number | [uint32](#uint32) |  |  |
-| manufacture_date | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
-| firmware_version | [uint32](#uint32) |  |  |
-| boot_code_version | [uint32](#uint32) |  |  |
-| hardware_version | [uint32](#uint32) |  |  |
-| max_data_logs | [uint32](#uint32) |  |  |
-| total_data_log_memory | [uint32](#uint32) |  |  |
-| total_battery_ticks | [uint32](#uint32) |  |  |
-| last_battery_change | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
-| device_name | [string](#string) |  |  |
-| site_name | [string](#string) |  |  |
-| latitude_coordinate | [double](#double) |  |  |
-| longitude_coordinate | [double](#double) |  |  |
-| altitude_coordinate | [double](#double) |  |  |
-| current_time_utc | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
-| device_status_flags | [AquaTrollDeviceStatus](#blueye-protocol-AquaTrollDeviceStatus) | repeated |  |
-| used_battery_ticks | [uint32](#uint32) |  |  |
-| used_data_log_memory | [uint32](#uint32) |  |  |
-| sensors | [AquaTrollSensor](#blueye-protocol-AquaTrollSensor) | repeated |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| timestamp | [ google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |
+| status | [ bool](#bool) |  |
+| register_map_template_version | [ uint32](#uint32) |  |
+| device_id | [ AquaTrollDevice](#blueye-protocol-AquaTrollDevice) |  |
+| device_serial_number | [ uint32](#uint32) |  |
+| manufacture_date | [ google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |
+| firmware_version | [ uint32](#uint32) |  |
+| boot_code_version | [ uint32](#uint32) |  |
+| hardware_version | [ uint32](#uint32) |  |
+| max_data_logs | [ uint32](#uint32) |  |
+| total_data_log_memory | [ uint32](#uint32) |  |
+| total_battery_ticks | [ uint32](#uint32) |  |
+| last_battery_change | [ google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |
+| device_name | [ string](#string) |  |
+| site_name | [ string](#string) |  |
+| latitude_coordinate | [ double](#double) |  |
+| longitude_coordinate | [ double](#double) |  |
+| altitude_coordinate | [ double](#double) |  |
+| current_time_utc | [ google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |
+| device_status_flags | [repeated AquaTrollDeviceStatus](#blueye-protocol-AquaTrollDeviceStatus) |  |
+| used_battery_ticks | [ uint32](#uint32) |  |
+| used_data_log_memory | [ uint32](#uint32) |  |
+| sensors | [repeated AquaTrollSensor](#blueye-protocol-AquaTrollSensor) |  |
 
 <a name="blueye-protocol-AquaTrollSensorMetadata"></a>
 
@@ -75,35 +69,30 @@ Refer to Section 7 Sensor Common Registers in the In-Situ Modbus
 Communication Protocol
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| timestamp | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
-| sensor_id | [AquaTrollSensor](#blueye-protocol-AquaTrollSensor) |  |  |
-| sensor_serial_number | [uint32](#uint32) |  |  |
-| sensor_status_flags | [AquaTrollSensorStatus](#blueye-protocol-AquaTrollSensorStatus) | repeated |  |
-| last_factory_calibration | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
-| next_factory_calibration | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
-| last_user_calibration | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
-| next_user_calibration | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
-| warm_up_time_in_milliseconds | [uint32](#uint32) |  |  |
-| fast_sample_rate_in_milliseconds | [uint32](#uint32) |  |  |
-| number_of_sensor_parameters | [uint32](#uint32) |  |  |
-| alarm_and_warning_parameter_number | [uint32](#uint32) |  |  |
-| alarm_and_warning_enable_bits | [uint32](#uint32) |  |  |
-| high_alarm_set_value | [float](#float) |  |  |
-| high_alarm_clear_value | [float](#float) |  |  |
-| high_warning_set_value | [float](#float) |  |  |
-| high_warning_clear_value | [float](#float) |  |  |
-| low_warning_clear_value | [float](#float) |  |  |
-| low_warning_set_value | [float](#float) |  |  |
-| low_alarm_clear_value | [float](#float) |  |  |
-| low_alarm_set_value | [float](#float) |  |  |
-| parameter_blocks | [AquaTrollParameterBlock](#blueye-protocol-AquaTrollParameterBlock) | repeated |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| timestamp | [ google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |
+| sensor_id | [ AquaTrollSensor](#blueye-protocol-AquaTrollSensor) |  |
+| sensor_serial_number | [ uint32](#uint32) |  |
+| sensor_status_flags | [repeated AquaTrollSensorStatus](#blueye-protocol-AquaTrollSensorStatus) |  |
+| last_factory_calibration | [ google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |
+| next_factory_calibration | [ google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |
+| last_user_calibration | [ google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |
+| next_user_calibration | [ google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |
+| warm_up_time_in_milliseconds | [ uint32](#uint32) |  |
+| fast_sample_rate_in_milliseconds | [ uint32](#uint32) |  |
+| number_of_sensor_parameters | [ uint32](#uint32) |  |
+| alarm_and_warning_parameter_number | [ uint32](#uint32) |  |
+| alarm_and_warning_enable_bits | [ uint32](#uint32) |  |
+| high_alarm_set_value | [ float](#float) |  |
+| high_alarm_clear_value | [ float](#float) |  |
+| high_warning_set_value | [ float](#float) |  |
+| high_warning_clear_value | [ float](#float) |  |
+| low_warning_clear_value | [ float](#float) |  |
+| low_warning_set_value | [ float](#float) |  |
+| low_alarm_clear_value | [ float](#float) |  |
+| low_alarm_set_value | [ float](#float) |  |
+| parameter_blocks | [repeated AquaTrollParameterBlock](#blueye-protocol-AquaTrollParameterBlock) |  |
 
 <a name="blueye-protocol-AquaTrollSensorMetadataArray"></a>
 
@@ -111,15 +100,10 @@ Communication Protocol
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| timestamp | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
-| sensors | [AquaTrollSensorMetadata](#blueye-protocol-AquaTrollSensorMetadata) | repeated |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| timestamp | [ google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |
+| sensors | [repeated AquaTrollSensorMetadata](#blueye-protocol-AquaTrollSensorMetadata) |  |
 
 <a name="blueye-protocol-AquaTrollSensorParameters"></a>
 
@@ -127,15 +111,10 @@ Communication Protocol
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| sensor_id | [AquaTrollSensor](#blueye-protocol-AquaTrollSensor) |  |  |
-| parameter_blocks | [AquaTrollParameterBlock](#blueye-protocol-AquaTrollParameterBlock) | repeated |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| sensor_id | [ AquaTrollSensor](#blueye-protocol-AquaTrollSensor) |  |
+| parameter_blocks | [repeated AquaTrollParameterBlock](#blueye-protocol-AquaTrollParameterBlock) |  |
 
 <a name="blueye-protocol-AquaTrollSensorParametersArray"></a>
 
@@ -143,15 +122,10 @@ Communication Protocol
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| timestamp | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
-| sensors | [AquaTrollSensorParameters](#blueye-protocol-AquaTrollSensorParameters) | repeated |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| timestamp | [ google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |
+| sensors | [repeated AquaTrollSensorParameters](#blueye-protocol-AquaTrollSensorParameters) |  |
 
 <a name="blueye-protocol-SetAquaTrollConnectionStatus"></a>
 
@@ -159,14 +133,9 @@ Communication Protocol
 Request to change the In-Situ Aqua Troll connection status
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| connected | [bool](#bool) |  | True to connect, false to disconnect |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| connected | [ bool](#bool) | True to connect, false to disconnect |
 
 <a name="blueye-protocol-SetAquaTrollParameterUnit"></a>
 
@@ -174,17 +143,12 @@ Request to change the In-Situ Aqua Troll connection status
 Request to set an In-Situ Aqua Troll parameter unit
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| sensor_id | [AquaTrollSensor](#blueye-protocol-AquaTrollSensor) |  | Sensor id, f. ex. &#34;SENSOR_CONDUCTIVITY_SENSOR&#34; |
-| parameter_id | [AquaTrollParameter](#blueye-protocol-AquaTrollParameter) |  | Parameter name, f. ex. &#34;PARAMETER_TEMPERATURE&#34; |
-| unit_id | [AquaTrollUnit](#blueye-protocol-AquaTrollUnit) |  | Unit, f. ex. &#34;UNIT_TEMP_CELSIUS&#34; |
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| sensor_id | [ AquaTrollSensor](#blueye-protocol-AquaTrollSensor) | Sensor id, f. ex. "SENSOR_CONDUCTIVITY_SENSOR" |
+| parameter_id | [ AquaTrollParameter](#blueye-protocol-AquaTrollParameter) | Parameter name, f. ex. "PARAMETER_TEMPERATURE" |
+| unit_id | [ AquaTrollUnit](#blueye-protocol-AquaTrollUnit) | Unit, f. ex. "UNIT_TEMP_CELSIUS" |
 
-
-
-
-
- 
 
 
 <a name="blueye-protocol-AquaTrollDevice"></a>
@@ -526,16 +490,9 @@ Type IDs
 | TYPE_TIME | 9 |  |
 
 
- 
-
- 
-
- 
-
 
 
 <a name="control-proto"></a>
-<p align="right"><a href="#top">Top</a></p>
 
 ## control.proto
 Control
@@ -549,9 +506,15 @@ These messages define control messages accepted by the Blueye drone.
 Activated the guest port power
 
 
+<a name="blueye-protocol-ActivateMultibeamCtrl"></a>
+
+### ActivateMultibeamCtrl
+Activate multibeam
 
 
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| config | [ MultibeamConfig](#blueye-protocol-MultibeamConfig) | Message with the multibeam ping configuration to set on connect |
 
 <a name="blueye-protocol-AutoAltitudeCtrl"></a>
 
@@ -559,14 +522,9 @@ Activated the guest port power
 Issue a command to set auto altitude to a desired state.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| state | [AutoAltitudeState](#blueye-protocol-AutoAltitudeState) |  | State of the altitude controller |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| state | [ AutoAltitudeState](#blueye-protocol-AutoAltitudeState) | State of the altitude controller |
 
 <a name="blueye-protocol-AutoDepthCtrl"></a>
 
@@ -574,14 +532,9 @@ Issue a command to set auto altitude to a desired state.
 Issue a command to set auto depth to a desired state.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| state | [AutoDepthState](#blueye-protocol-AutoDepthState) |  | State of the depth controller |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| state | [ AutoDepthState](#blueye-protocol-AutoDepthState) | State of the depth controller |
 
 <a name="blueye-protocol-AutoHeadingCtrl"></a>
 
@@ -589,14 +542,9 @@ Issue a command to set auto depth to a desired state.
 Issue a command to set auto heading to a desired state.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| state | [AutoHeadingState](#blueye-protocol-AutoHeadingState) |  | State of the heading controller |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| state | [ AutoHeadingState](#blueye-protocol-AutoHeadingState) | State of the heading controller |
 
 <a name="blueye-protocol-AutoPilotHeaveCtrl"></a>
 
@@ -604,14 +552,9 @@ Issue a command to set auto heading to a desired state.
 Issue a command to set Auto Pilot for vertiacl movement to a desired state.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| state | [AutoPilotHeaveState](#blueye-protocol-AutoPilotHeaveState) |  | State of the auto pilot heave controller |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| state | [ AutoPilotHeaveState](#blueye-protocol-AutoPilotHeaveState) | State of the auto pilot heave controller |
 
 <a name="blueye-protocol-AutoPilotSurgeYawCtrl"></a>
 
@@ -619,23 +562,14 @@ Issue a command to set Auto Pilot for vertiacl movement to a desired state.
 Issue a command to set Auto Pilot for cruising and turning to a desired state.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| state | [AutoPilotSurgeYawState](#blueye-protocol-AutoPilotSurgeYawState) |  | State of the auto pilot surge yaw controller |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| state | [ AutoPilotSurgeYawState](#blueye-protocol-AutoPilotSurgeYawState) | State of the auto pilot surge yaw controller |
 
 <a name="blueye-protocol-CalibrateDvlGyroCtrl"></a>
 
 ### CalibrateDvlGyroCtrl
 Issue a command to calibrate the DVL gyro.
-
-
-
-
 
 
 <a name="blueye-protocol-CancelCalibrationCtrl"></a>
@@ -644,18 +578,10 @@ Issue a command to calibrate the DVL gyro.
 Issue a command to cancel compass calibration.
 
 
-
-
-
-
 <a name="blueye-protocol-ClearMissionCtrl"></a>
 
 ### ClearMissionCtrl
 Clear the loaded mission.
-
-
-
-
 
 
 <a name="blueye-protocol-DeactivateGuestPortsCtrl"></a>
@@ -664,8 +590,19 @@ Clear the loaded mission.
 Deactivate the guest port power
 
 
+<a name="blueye-protocol-DeactivateMultibeamCtrl"></a>
+
+### DeactivateMultibeamCtrl
+Deactivate multibeam
 
 
+<a name="blueye-protocol-EndDiveCtrl"></a>
+
+### EndDiveCtrl
+Message sent when the user hits the end dive button in the app.
+
+The message does not do anything, but is included in the log files so we can see
+at which point the user exited the dive view.
 
 
 <a name="blueye-protocol-FinishCalibrationCtrl"></a>
@@ -674,24 +611,15 @@ Deactivate the guest port power
 Issue a command to finish compass calibration.
 
 
-
-
-
-
 <a name="blueye-protocol-GenericServoCtrl"></a>
 
 ### GenericServoCtrl
 Issue a command to set a generic servo value.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| servo | [GenericServo](#blueye-protocol-GenericServo) |  | Message with the desired servo value. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| servo | [ GenericServo](#blueye-protocol-GenericServo) | Message with the desired servo value. |
 
 <a name="blueye-protocol-GripperCtrl"></a>
 
@@ -699,14 +627,9 @@ Issue a command to set a generic servo value.
 Issue a command to control the gripper.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| gripper_velocities | [GripperVelocities](#blueye-protocol-GripperVelocities) |  | The desired gripping and rotation velocity. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| gripper_velocities | [ GripperVelocities](#blueye-protocol-GripperVelocities) | The desired gripping and rotation velocity. |
 
 <a name="blueye-protocol-GuestportLightsCtrl"></a>
 
@@ -714,14 +637,9 @@ Issue a command to control the gripper.
 Issue a command to set the guest port light intensity.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| lights | [Lights](#blueye-protocol-Lights) |  | Message with the desired light intensity. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| lights | [ Lights](#blueye-protocol-Lights) | Message with the desired light intensity. |
 
 <a name="blueye-protocol-LaserCtrl"></a>
 
@@ -729,14 +647,9 @@ Issue a command to set the guest port light intensity.
 Issue a command to set the laser intensity.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| laser | [Laser](#blueye-protocol-Laser) |  | Message with the desired laser intensity. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| laser | [ Laser](#blueye-protocol-Laser) | Message with the desired laser intensity. |
 
 <a name="blueye-protocol-LightsCtrl"></a>
 
@@ -744,14 +657,9 @@ Issue a command to set the laser intensity.
 Issue a command to set the main light intensity.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| lights | [Lights](#blueye-protocol-Lights) |  | Message with the desired light intensity. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| lights | [ Lights](#blueye-protocol-Lights) | Message with the desired light intensity. |
 
 <a name="blueye-protocol-MotionInputCtrl"></a>
 
@@ -759,14 +667,9 @@ Issue a command to set the main light intensity.
 Issue a command to move the drone in the surge, sway, heave, or yaw direction.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| motion_input | [MotionInput](#blueye-protocol-MotionInput) |  | Message with the desired movement in each direction. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| motion_input | [ MotionInput](#blueye-protocol-MotionInput) | Message with the desired movement in each direction. |
 
 <a name="blueye-protocol-MultibeamServoCtrl"></a>
 
@@ -774,23 +677,14 @@ Issue a command to move the drone in the surge, sway, heave, or yaw direction.
 Issue a command to set multibeam servo angle.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| servo | [MultibeamServo](#blueye-protocol-MultibeamServo) |  | Message with the desired servo angle. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| servo | [ MultibeamServo](#blueye-protocol-MultibeamServo) | Message with the desired servo angle. |
 
 <a name="blueye-protocol-PauseMissionCtrl"></a>
 
 ### PauseMissionCtrl
 Issue a command to pause the loaded mission.
-
-
-
-
 
 
 <a name="blueye-protocol-PilotGPSPositionCtrl"></a>
@@ -799,14 +693,9 @@ Issue a command to pause the loaded mission.
 Issue a command with the GPS position of the pilot.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| position | [LatLongPosition](#blueye-protocol-LatLongPosition) |  | The GPS position of the pilot. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| position | [ LatLongPosition](#blueye-protocol-LatLongPosition) | The GPS position of the pilot. |
 
 <a name="blueye-protocol-PingerConfigurationCtrl"></a>
 
@@ -814,14 +703,9 @@ Issue a command with the GPS position of the pilot.
 Issue a command to set the pinger configuration.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| configuration | [PingerConfiguration](#blueye-protocol-PingerConfiguration) |  | Message with the pinger configuration to set. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| configuration | [ PingerConfiguration](#blueye-protocol-PingerConfiguration) | Message with the pinger configuration to set. |
 
 <a name="blueye-protocol-RecordCtrl"></a>
 
@@ -829,23 +713,14 @@ Issue a command to set the pinger configuration.
 Issue a command to start video recording.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| record_on | [RecordOn](#blueye-protocol-RecordOn) |  | Message specifying which cameras to record. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| record_on | [ RecordOn](#blueye-protocol-RecordOn) | Message specifying which cameras to record. |
 
 <a name="blueye-protocol-ResetOdometerCtrl"></a>
 
 ### ResetOdometerCtrl
 Issue a command to reset the odometer.
-
-
-
-
 
 
 <a name="blueye-protocol-ResetPositionCtrl"></a>
@@ -854,14 +729,9 @@ Issue a command to reset the odometer.
 Issue a command to reset the position estimate.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| settings | [ResetPositionSettings](#blueye-protocol-ResetPositionSettings) |  | Reset settings. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| settings | [ ResetPositionSettings](#blueye-protocol-ResetPositionSettings) | Reset settings. |
 
 <a name="blueye-protocol-RestartGuestPortsCtrl"></a>
 
@@ -869,23 +739,14 @@ Issue a command to reset the position estimate.
 Restart the guest ports by turning power on and off
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| restart_info | [GuestPortRestartInfo](#blueye-protocol-GuestPortRestartInfo) |  | Message with information about how long to keep the guest ports off. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| restart_info | [ GuestPortRestartInfo](#blueye-protocol-GuestPortRestartInfo) | Message with information about how long to keep the guest ports off. |
 
 <a name="blueye-protocol-RunMissionCtrl"></a>
 
 ### RunMissionCtrl
 Issue a command to start and pause the loaded mission.
-
-
-
-
 
 
 <a name="blueye-protocol-SetAquaTrollConnectionStatusCtrl"></a>
@@ -894,14 +755,9 @@ Issue a command to start and pause the loaded mission.
 Request to change the In-Situ Aqua Troll connection status
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| connection_status | [SetAquaTrollConnectionStatus](#blueye-protocol-SetAquaTrollConnectionStatus) |  | Message with information about which parameter to set and the unit to set it to. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| connection_status | [ SetAquaTrollConnectionStatus](#blueye-protocol-SetAquaTrollConnectionStatus) | Message with information about which parameter to set and the unit to set it to. |
 
 <a name="blueye-protocol-SetAquaTrollParameterUnitCtrl"></a>
 
@@ -909,14 +765,19 @@ Request to change the In-Situ Aqua Troll connection status
 Request to set an In-Situ Aqua Troll parameter unit
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| parameter_info | [SetAquaTrollParameterUnit](#blueye-protocol-SetAquaTrollParameterUnit) |  | Message with information about which parameter to set and the unit to set it to. |
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| parameter_info | [ SetAquaTrollParameterUnit](#blueye-protocol-SetAquaTrollParameterUnit) | Message with information about which parameter to set and the unit to set it to. |
+
+<a name="blueye-protocol-SetMultibeamConfigCtrl"></a>
+
+### SetMultibeamConfigCtrl
+Update multibeam settings
 
 
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| config | [ MultibeamConfig](#blueye-protocol-MultibeamConfig) | Message with the multibeam ping configuration to set. |
 
 <a name="blueye-protocol-StartCalibrationCtrl"></a>
 
@@ -924,8 +785,13 @@ Request to set an In-Situ Aqua Troll parameter unit
 Issue a command to start compass calibration.
 
 
+<a name="blueye-protocol-StartDiveCtrl"></a>
 
+### StartDiveCtrl
+Message sent when the user hits the start dive button in the app.
 
+The message does not do anything, but is included in the log files so we can see
+at which point the user entered the dive view.
 
 
 <a name="blueye-protocol-StationKeepingCtrl"></a>
@@ -934,14 +800,9 @@ Issue a command to start compass calibration.
 Issue a command to set station keeping to a desired state.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| state | [StationKeepingState](#blueye-protocol-StationKeepingState) |  | State of the station keeping controller |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| state | [ StationKeepingState](#blueye-protocol-StationKeepingState) | State of the station keeping controller |
 
 <a name="blueye-protocol-SystemTimeCtrl"></a>
 
@@ -949,23 +810,14 @@ Issue a command to set station keeping to a desired state.
 Issue a command to set the system time on the drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| system_time | [SystemTime](#blueye-protocol-SystemTime) |  | Message with the system time to set. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| system_time | [ SystemTime](#blueye-protocol-SystemTime) | Message with the system time to set. |
 
 <a name="blueye-protocol-TakePictureCtrl"></a>
 
 ### TakePictureCtrl
 Issue a command to take a picture.
-
-
-
-
 
 
 <a name="blueye-protocol-TiltStabilizationCtrl"></a>
@@ -974,14 +826,9 @@ Issue a command to take a picture.
 Issue a command to enable or disable tilt stabilization.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| state | [TiltStabilizationState](#blueye-protocol-TiltStabilizationState) |  | Message with the tilt stabilization state to set. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| state | [ TiltStabilizationState](#blueye-protocol-TiltStabilizationState) | Message with the tilt stabilization state to set. |
 
 <a name="blueye-protocol-TiltVelocityCtrl"></a>
 
@@ -989,14 +836,9 @@ Issue a command to enable or disable tilt stabilization.
 Issue a command to tilt the drone camera.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| velocity | [TiltVelocity](#blueye-protocol-TiltVelocity) |  | Message with the desired tilt velocity (direction and speed). |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| velocity | [ TiltVelocity](#blueye-protocol-TiltVelocity) | Message with the desired tilt velocity (direction and speed). |
 
 <a name="blueye-protocol-WatchdogCtrl"></a>
 
@@ -1007,15 +849,10 @@ If a watchdog message is not received every second, the drone will turn off ligh
 functions to indicate that connection with the client has been lost.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| connection_duration | [ConnectionDuration](#blueye-protocol-ConnectionDuration) |  | Message with the number of seconds the client has been connected. |
-| client_id | [uint32](#uint32) |  | The ID of the client, received in the ConnectClientRep response. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| connection_duration | [ ConnectionDuration](#blueye-protocol-ConnectionDuration) | Message with the number of seconds the client has been connected. |
+| client_id | [ uint32](#uint32) | The ID of the client, received in the ConnectClientRep response. |
 
 <a name="blueye-protocol-WaterDensityCtrl"></a>
 
@@ -1023,14 +860,9 @@ functions to indicate that connection with the client has been lost.
 Issue a command to set the water density.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| density | [WaterDensity](#blueye-protocol-WaterDensity) |  | Message with the water density to set. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| density | [ WaterDensity](#blueye-protocol-WaterDensity) | Message with the water density to set. |
 
 <a name="blueye-protocol-WeatherVaningCtrl"></a>
 
@@ -1038,26 +870,14 @@ Issue a command to set the water density.
 Issue a command to set station keeping with weather vaning to a desired state.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| state | [WeatherVaningState](#blueye-protocol-WeatherVaningState) |  | State of the weather vaning controller |
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| state | [ WeatherVaningState](#blueye-protocol-WeatherVaningState) | State of the weather vaning controller |
 
-
-
-
-
- 
-
- 
-
- 
-
- 
 
 
 
 <a name="message_formats-proto"></a>
-<p align="right"><a href="#top">Top</a></p>
 
 ## message_formats.proto
 Common messages
@@ -1071,15 +891,10 @@ These are used for logging as well as building requests and responses.
 Drone altitude over seabed, typically obtained from a DVL.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| value | [float](#float) |  | Drone altitude over seabed (m) |
-| is_valid | [bool](#bool) |  | If altitude is valid or not |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| value | [ float](#float) | Drone altitude over seabed (m) |
+| is_valid | [ bool](#bool) | If altitude is valid or not |
 
 <a name="blueye-protocol-Attitude"></a>
 
@@ -1087,16 +902,11 @@ Drone altitude over seabed, typically obtained from a DVL.
 The attitude of the drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| roll | [float](#float) |  | Roll angle (-180°..180°) |
-| pitch | [float](#float) |  | Pitch angle (-180°..180°) |
-| yaw | [float](#float) |  | Yaw angle (-180°..180°) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| roll | [ float](#float) | Roll angle (-180°..180°) |
+| pitch | [ float](#float) | Pitch angle (-180°..180°) |
+| yaw | [ float](#float) | Yaw angle (-180°..180°) |
 
 <a name="blueye-protocol-AutoAltitudeState"></a>
 
@@ -1104,14 +914,9 @@ The attitude of the drone.
 Auto altitude state.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| enabled | [bool](#bool) |  | If auto altitude is enabled |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| enabled | [ bool](#bool) | If auto altitude is enabled |
 
 <a name="blueye-protocol-AutoDepthState"></a>
 
@@ -1119,14 +924,9 @@ Auto altitude state.
 Auto depth state.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| enabled | [bool](#bool) |  | If auto depth is enabled |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| enabled | [ bool](#bool) | If auto depth is enabled |
 
 <a name="blueye-protocol-AutoHeadingState"></a>
 
@@ -1134,14 +934,9 @@ Auto depth state.
 Auto heading state.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| enabled | [bool](#bool) |  | If auto heading is enabled |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| enabled | [ bool](#bool) | If auto heading is enabled |
 
 <a name="blueye-protocol-AutoPilotHeaveState"></a>
 
@@ -1149,14 +944,9 @@ Auto heading state.
 Auto pilot heave state.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| enabled | [bool](#bool) |  | If auto pilot heave is enabled |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| enabled | [ bool](#bool) | If auto pilot heave is enabled |
 
 <a name="blueye-protocol-AutoPilotSurgeYawState"></a>
 
@@ -1164,14 +954,9 @@ Auto pilot heave state.
 Auto pilot surge yaw state.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| enabled | [bool](#bool) |  | If auto pilot surge yaw is enabled |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| enabled | [ bool](#bool) | If auto pilot surge yaw is enabled |
 
 <a name="blueye-protocol-Battery"></a>
 
@@ -1179,16 +964,11 @@ Auto pilot surge yaw state.
 Essential battery information.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| voltage | [float](#float) |  | Battery voltage (V) |
-| level | [float](#float) |  | Battery level (0..1) |
-| temperature | [float](#float) |  | Battery temperature (°C) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| voltage | [ float](#float) | Battery voltage (V) |
+| level | [ float](#float) | Battery level (0..1) |
+| temperature | [ float](#float) | Battery temperature (°C) |
 
 <a name="blueye-protocol-BatteryBQ40Z50"></a>
 
@@ -1199,38 +979,33 @@ Detailed information about all aspects of the connected Blueye Smart Battery,
 using the BQ40Z50 BMS.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| voltage | [BatteryBQ40Z50.Voltage](#blueye-protocol-BatteryBQ40Z50-Voltage) |  | Voltage of the battery cells |
-| temperature | [BatteryBQ40Z50.Temperature](#blueye-protocol-BatteryBQ40Z50-Temperature) |  | Temperature of the battery cells |
-| status | [BatteryBQ40Z50.BatteryStatus](#blueye-protocol-BatteryBQ40Z50-BatteryStatus) |  | Battery status flags |
-| current | [float](#float) |  | Measured current from the coulomb counter (A) |
-| average_current | [float](#float) |  | Average current (A) |
-| relative_state_of_charge | [float](#float) |  | Predicted remaining battery capacity as a factor of full_charge_capacity (0..1) |
-| absolute_state_of_charge | [float](#float) |  | Predicted remaining battery capacity (0..1) |
-| calculated_state_of_charge | [float](#float) |  | Calculated state of charge (0..1) |
-| remaining_capacity | [float](#float) |  | Predicted remaining battery capacity (Ah) |
-| full_charge_capacity | [float](#float) |  | Predicted battery capacity when fully charged (Ah) |
-| runtime_to_empty | [uint32](#uint32) |  | Predicted remaining battery capacity based on the present rate of discharge (s) |
-| average_time_to_empty | [uint32](#uint32) |  | Predicted remaining battery capacity based on average_current (s) |
-| average_time_to_full | [uint32](#uint32) |  | Predicted time-to-full charge based on average_current (s) |
-| charging_current | [float](#float) |  | Desired charging current (A) |
-| charging_voltage | [float](#float) |  | Desired charging voltage (V) |
-| cycle_count | [uint32](#uint32) |  | Number of charging cycles |
-| design_capacity | [float](#float) |  | Design capacity (Ah) |
-| manufacture_date | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | Manufacture date |
-| serial_number | [uint32](#uint32) |  | Serial number |
-| manufacturer_name | [string](#string) |  | Manufacturer name |
-| device_name | [string](#string) |  | Device name |
-| device_chemistry | [string](#string) |  | Battery chemistry |
-| lifetimes | [BatteryBQ40Z50.BatteryLifetimes](#blueye-protocol-BatteryBQ40Z50-BatteryLifetimes) |  | Battery lifetimes |
-| safety_events | [BatteryBQ40Z50.BatterySafetyEvents](#blueye-protocol-BatteryBQ40Z50-BatterySafetyEvents) |  | Battery safety events |
-| charging_events | [BatteryBQ40Z50.BatteryChargingEvents](#blueye-protocol-BatteryBQ40Z50-BatteryChargingEvents) |  | Battery charging events |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| voltage | [ BatteryBQ40Z50.Voltage](#blueye-protocol-BatteryBQ40Z50-Voltage) | Voltage of the battery cells |
+| temperature | [ BatteryBQ40Z50.Temperature](#blueye-protocol-BatteryBQ40Z50-Temperature) | Temperature of the battery cells |
+| status | [ BatteryBQ40Z50.BatteryStatus](#blueye-protocol-BatteryBQ40Z50-BatteryStatus) | Battery status flags |
+| current | [ float](#float) | Measured current from the coulomb counter (A) |
+| average_current | [ float](#float) | Average current (A) |
+| relative_state_of_charge | [ float](#float) | Predicted remaining battery capacity as a factor of full_charge_capacity (0..1) |
+| absolute_state_of_charge | [ float](#float) | Predicted remaining battery capacity (0..1) |
+| calculated_state_of_charge | [ float](#float) | Calculated state of charge (0..1) |
+| remaining_capacity | [ float](#float) | Predicted remaining battery capacity (Ah) |
+| full_charge_capacity | [ float](#float) | Predicted battery capacity when fully charged (Ah) |
+| runtime_to_empty | [ uint32](#uint32) | Predicted remaining battery capacity based on the present rate of discharge (s) |
+| average_time_to_empty | [ uint32](#uint32) | Predicted remaining battery capacity based on average_current (s) |
+| average_time_to_full | [ uint32](#uint32) | Predicted time-to-full charge based on average_current (s) |
+| charging_current | [ float](#float) | Desired charging current (A) |
+| charging_voltage | [ float](#float) | Desired charging voltage (V) |
+| cycle_count | [ uint32](#uint32) | Number of charging cycles |
+| design_capacity | [ float](#float) | Design capacity (Ah) |
+| manufacture_date | [ google.protobuf.Timestamp](#google-protobuf-Timestamp) | Manufacture date |
+| serial_number | [ uint32](#uint32) | Serial number |
+| manufacturer_name | [ string](#string) | Manufacturer name |
+| device_name | [ string](#string) | Device name |
+| device_chemistry | [ string](#string) | Battery chemistry |
+| lifetimes | [ BatteryBQ40Z50.BatteryLifetimes](#blueye-protocol-BatteryBQ40Z50-BatteryLifetimes) | Battery lifetimes |
+| safety_events | [ BatteryBQ40Z50.BatterySafetyEvents](#blueye-protocol-BatteryBQ40Z50-BatterySafetyEvents) | Battery safety events |
+| charging_events | [ BatteryBQ40Z50.BatteryChargingEvents](#blueye-protocol-BatteryBQ40Z50-BatteryChargingEvents) | Battery charging events |
 
 <a name="blueye-protocol-BatteryBQ40Z50-BatteryChargingEvents"></a>
 
@@ -1238,15 +1013,10 @@ using the BQ40Z50 BMS.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| charge_termination_events_count | [uint32](#uint32) |  | Total number of valid charge termination events (events) |
-| charge_termination_last_event | [uint32](#uint32) |  | Last valid charge termination in cycle count cycles (cycles) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| charge_termination_events_count | [ uint32](#uint32) | Total number of valid charge termination events (events) |
+| charge_termination_last_event | [ uint32](#uint32) | Last valid charge termination in cycle count cycles (cycles) |
 
 <a name="blueye-protocol-BatteryBQ40Z50-BatteryLifetimes"></a>
 
@@ -1254,26 +1024,21 @@ using the BQ40Z50 BMS.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| max_cell_voltages | [BatteryBQ40Z50.BatteryLifetimes.CellVoltages](#blueye-protocol-BatteryBQ40Z50-BatteryLifetimes-CellVoltages) |  | Maximum reported cell voltages |
-| min_cell_voltages | [BatteryBQ40Z50.BatteryLifetimes.CellVoltages](#blueye-protocol-BatteryBQ40Z50-BatteryLifetimes-CellVoltages) |  | Minimum reported cell voltages |
-| max_delta_cell_voltage | [float](#float) |  | Max delta between cells (V) |
-| max_charge_current | [float](#float) |  | Max reported current in the charge direction (A) |
-| max_discharge_current | [float](#float) |  | Max reported current in the discharge direction (A) |
-| max_avg_discharge_current | [float](#float) |  | Max reported average current in the discharge direction (A) |
-| max_avg_discharge_power | [float](#float) |  | Max reported power in discharge direction (W) |
-| max_cell_temperature | [float](#float) |  | Max reported cell temperature (°C) |
-| min_cell_temperature | [float](#float) |  | Min reported cell temperature (°C) |
-| max_delta_cell_temperature | [float](#float) |  | Max reported temperature delta for TSx inputs configured as cell temperature (°C) |
-| max_temperature_internal_sensor | [float](#float) |  | Max reported internal temperature sensor temperature (°C) |
-| min_temperature_internal_sensor | [float](#float) |  | Min reported internal temperature sensor temperature (°C) |
-| max_temperature_fet | [float](#float) |  | Max reported FET temperature (°C) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| max_cell_voltages | [ BatteryBQ40Z50.BatteryLifetimes.CellVoltages](#blueye-protocol-BatteryBQ40Z50-BatteryLifetimes-CellVoltages) | Maximum reported cell voltages |
+| min_cell_voltages | [ BatteryBQ40Z50.BatteryLifetimes.CellVoltages](#blueye-protocol-BatteryBQ40Z50-BatteryLifetimes-CellVoltages) | Minimum reported cell voltages |
+| max_delta_cell_voltage | [ float](#float) | Max delta between cells (V) |
+| max_charge_current | [ float](#float) | Max reported current in the charge direction (A) |
+| max_discharge_current | [ float](#float) | Max reported current in the discharge direction (A) |
+| max_avg_discharge_current | [ float](#float) | Max reported average current in the discharge direction (A) |
+| max_avg_discharge_power | [ float](#float) | Max reported power in discharge direction (W) |
+| max_cell_temperature | [ float](#float) | Max reported cell temperature (°C) |
+| min_cell_temperature | [ float](#float) | Min reported cell temperature (°C) |
+| max_delta_cell_temperature | [ float](#float) | Max reported temperature delta for TSx inputs configured as cell temperature (°C) |
+| max_temperature_internal_sensor | [ float](#float) | Max reported internal temperature sensor temperature (°C) |
+| min_temperature_internal_sensor | [ float](#float) | Min reported internal temperature sensor temperature (°C) |
+| max_temperature_fet | [ float](#float) | Max reported FET temperature (°C) |
 
 <a name="blueye-protocol-BatteryBQ40Z50-BatteryLifetimes-CellVoltages"></a>
 
@@ -1281,17 +1046,12 @@ using the BQ40Z50 BMS.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| cell_1 | [float](#float) |  | Voltage for cell number 1 (V) |
-| cell_2 | [float](#float) |  | Voltage for cell number 2 (V) |
-| cell_3 | [float](#float) |  | Voltage for cell number 3 (V) |
-| cell_4 | [float](#float) |  | Voltage for cell number 4 (V) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| cell_1 | [ float](#float) | Voltage for cell number 1 (V) |
+| cell_2 | [ float](#float) | Voltage for cell number 2 (V) |
+| cell_3 | [ float](#float) | Voltage for cell number 3 (V) |
+| cell_4 | [ float](#float) | Voltage for cell number 4 (V) |
 
 <a name="blueye-protocol-BatteryBQ40Z50-BatterySafetyEvents"></a>
 
@@ -1299,37 +1059,32 @@ using the BQ40Z50 BMS.
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| cov_events_count | [uint32](#uint32) |  | Number of cell overvoltage (COV) events (events) |
-| cov_last_event | [uint32](#uint32) |  | Last COV event in cycle count cycles (cycles) |
-| cuv_events_count | [uint32](#uint32) |  | Number of cell undervoltage (CUV) events (events) |
-| cuv_last_event | [uint32](#uint32) |  | Last CUV event in cycle count cycles (cycles) |
-| ocd1_events_count | [uint32](#uint32) |  | Number of Overcurrent in Discharge 1 (OCD1) events (events) |
-| ocd1_last_event | [uint32](#uint32) |  | Last OCD1 event in cycle count cycles (cycles) |
-| ocd2_events_count | [uint32](#uint32) |  | Number of Overcurrent in Discharge 2 (OCD2) events (events) |
-| ocd2_last_event | [uint32](#uint32) |  | Last OCD2 event in cycle count cycles (cycles) |
-| occ1_events_count | [uint32](#uint32) |  | Number of Overcurrent in Charge 1 (OCC1) events (events) |
-| occ1_last_event | [uint32](#uint32) |  | Last OCC1 event in cycle count cycles (cycles) |
-| occ2_events_count | [uint32](#uint32) |  | Number of Overcurrent in Charge 2 (OCC2) events (events) |
-| occ2_last_event | [uint32](#uint32) |  | Last OCC2 event in cycle count cycles (cycles) |
-| aold_events_count | [uint32](#uint32) |  | Number of Overload in discharge (AOLD) events (events) |
-| aold_last_event | [uint32](#uint32) |  | Last AOLD event in cycle count cycles (cycles) |
-| ascd_events_count | [uint32](#uint32) |  | Number of Short Circuit in Discharge (ASCD) events (events) |
-| ascd_last_event | [uint32](#uint32) |  | Last ASCD event in cycle count cycles (cycles) |
-| ascc_events_count | [uint32](#uint32) |  | Number of Short Circuit in Charge (ASCC) events (events) |
-| ascc_last_event | [uint32](#uint32) |  | Last ASCC event in cycle count cycles (cycles) |
-| otc_events_count | [uint32](#uint32) |  | Number of Overtemperature in Charge (OTC) events (events) |
-| otc_last_event | [uint32](#uint32) |  | Last OTC event in cycle count cycles (cycles) |
-| otd_events_count | [uint32](#uint32) |  | Number of Overtemperature in Discharge (OTD) events (events) |
-| otd_last_event | [uint32](#uint32) |  | Last OTD event in cycle count cycles (cycles) |
-| otf_events_count | [uint32](#uint32) |  | Number of Overtemperature in FET (OTF) events (events) |
-| otf_last_event | [uint32](#uint32) |  | Last OTF event in cycle count cycles (cycles) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| cov_events_count | [ uint32](#uint32) | Number of cell over voltage (COV) events (events) |
+| cov_last_event | [ uint32](#uint32) | Last COV event in cycle count cycles (cycles) |
+| cuv_events_count | [ uint32](#uint32) | Number of cell under voltage (CUV) events (events) |
+| cuv_last_event | [ uint32](#uint32) | Last CUV event in cycle count cycles (cycles) |
+| ocd1_events_count | [ uint32](#uint32) | Number of over current in Discharge 1 (OCD1) events (events) |
+| ocd1_last_event | [ uint32](#uint32) | Last OCD1 event in cycle count cycles (cycles) |
+| ocd2_events_count | [ uint32](#uint32) | Number of over current in Discharge 2 (OCD2) events (events) |
+| ocd2_last_event | [ uint32](#uint32) | Last OCD2 event in cycle count cycles (cycles) |
+| occ1_events_count | [ uint32](#uint32) | Number of over current in Charge 1 (OCC1) events (events) |
+| occ1_last_event | [ uint32](#uint32) | Last OCC1 event in cycle count cycles (cycles) |
+| occ2_events_count | [ uint32](#uint32) | Number of over current in Charge 2 (OCC2) events (events) |
+| occ2_last_event | [ uint32](#uint32) | Last OCC2 event in cycle count cycles (cycles) |
+| aold_events_count | [ uint32](#uint32) | Number of Overload in discharge (AOLD) events (events) |
+| aold_last_event | [ uint32](#uint32) | Last AOLD event in cycle count cycles (cycles) |
+| ascd_events_count | [ uint32](#uint32) | Number of Short Circuit in Discharge (ASCD) events (events) |
+| ascd_last_event | [ uint32](#uint32) | Last ASCD event in cycle count cycles (cycles) |
+| ascc_events_count | [ uint32](#uint32) | Number of Short Circuit in Charge (ASCC) events (events) |
+| ascc_last_event | [ uint32](#uint32) | Last ASCC event in cycle count cycles (cycles) |
+| otc_events_count | [ uint32](#uint32) | Number of over temperature in Charge (OTC) events (events) |
+| otc_last_event | [ uint32](#uint32) | Last OTC event in cycle count cycles (cycles) |
+| otd_events_count | [ uint32](#uint32) | Number of over temperature in Discharge (OTD) events (events) |
+| otd_last_event | [ uint32](#uint32) | Last OTD event in cycle count cycles (cycles) |
+| otf_events_count | [ uint32](#uint32) | Number of over temperature in FET (OTF) events (events) |
+| otf_last_event | [ uint32](#uint32) | Last OTF event in cycle count cycles (cycles) |
 
 <a name="blueye-protocol-BatteryBQ40Z50-BatteryStatus"></a>
 
@@ -1337,24 +1092,19 @@ using the BQ40Z50 BMS.
 Battery status from BQ40Z50 ref data sheet 0x16.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| overcharged_alarm | [bool](#bool) |  |  |
-| terminate_charge_alarm | [bool](#bool) |  |  |
-| over_temperature_alarm | [bool](#bool) |  |  |
-| terminate_discharge_alarm | [bool](#bool) |  |  |
-| remaining_capacity_alarm | [bool](#bool) |  |  |
-| remaining_time_alarm | [bool](#bool) |  |  |
-| initialization | [bool](#bool) |  |  |
-| discharging_or_relax | [bool](#bool) |  |  |
-| fully_charged | [bool](#bool) |  |  |
-| fully_discharged | [bool](#bool) |  |  |
-| error | [BatteryBQ40Z50.BatteryStatus.BatteryError](#blueye-protocol-BatteryBQ40Z50-BatteryStatus-BatteryError) |  | Battery error codes |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| overcharged_alarm | [ bool](#bool) |  |
+| terminate_charge_alarm | [ bool](#bool) |  |
+| over_temperature_alarm | [ bool](#bool) |  |
+| terminate_discharge_alarm | [ bool](#bool) |  |
+| remaining_capacity_alarm | [ bool](#bool) |  |
+| remaining_time_alarm | [ bool](#bool) |  |
+| initialization | [ bool](#bool) |  |
+| discharging_or_relax | [ bool](#bool) |  |
+| fully_charged | [ bool](#bool) |  |
+| fully_discharged | [ bool](#bool) |  |
+| error | [ BatteryBQ40Z50.BatteryStatus.BatteryError](#blueye-protocol-BatteryBQ40Z50-BatteryStatus-BatteryError) | Battery error codes |
 
 <a name="blueye-protocol-BatteryBQ40Z50-Temperature"></a>
 
@@ -1362,18 +1112,13 @@ Battery status from BQ40Z50 ref data sheet 0x16.
 Battery temperature.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| average | [float](#float) |  | Average temperature accross cells (°C) |
-| cell_1 | [float](#float) |  | Cell 1 temperature (°C) |
-| cell_2 | [float](#float) |  | Cell 2 temperature (°C) |
-| cell_3 | [float](#float) |  | Cell 3 temperature (°C) |
-| cell_4 | [float](#float) |  | Cell 4 temperature (°C) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| average | [ float](#float) | Average temperature accross cells (°C) |
+| cell_1 | [ float](#float) | Cell 1 temperature (°C) |
+| cell_2 | [ float](#float) | Cell 2 temperature (°C) |
+| cell_3 | [ float](#float) | Cell 3 temperature (°C) |
+| cell_4 | [ float](#float) | Cell 4 temperature (°C) |
 
 <a name="blueye-protocol-BatteryBQ40Z50-Voltage"></a>
 
@@ -1381,18 +1126,13 @@ Battery temperature.
 Battery voltage levels.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| total | [float](#float) |  | Battery pack voltage level (V) |
-| cell_1 | [float](#float) |  | Cell 1 voltage level (V) |
-| cell_2 | [float](#float) |  | Vell 2 voltage level (V) |
-| cell_3 | [float](#float) |  | Cell 3 voltage level (V) |
-| cell_4 | [float](#float) |  | Cell 4 voltage level (V) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| total | [ float](#float) | Battery pack voltage level (V) |
+| cell_1 | [ float](#float) | Cell 1 voltage level (V) |
+| cell_2 | [ float](#float) | Vell 2 voltage level (V) |
+| cell_3 | [ float](#float) | Cell 3 voltage level (V) |
+| cell_4 | [ float](#float) | Cell 4 voltage level (V) |
 
 <a name="blueye-protocol-BinlogRecord"></a>
 
@@ -1405,16 +1145,26 @@ and an Any message wrapping the custom Blueye message.
 See separate documentation for the logfile format for more details.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| payload | [google.protobuf.Any](#google-protobuf-Any) |  | The log entry payload. |
-| unix_timestamp | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | Unix timestamp in UTC. |
-| clock_monotonic | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | Posix CLOCK_MONOTONIC timestamp. |
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| payload | [ google.protobuf.Any](#google-protobuf-Any) | The log entry payload. |
+| unix_timestamp | [ google.protobuf.Timestamp](#google-protobuf-Timestamp) | Unix timestamp in UTC. |
+| clock_monotonic | [ google.protobuf.Timestamp](#google-protobuf-Timestamp) | Posix CLOCK_MONOTONIC timestamp. |
+
+<a name="blueye-protocol-CPUInfo"></a>
+
+### CPUInfo
+CPU information
+
+Contains information about the CPU load and memory usage of the drone.
 
 
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| cpu_load | [ float](#float) | CPU load (0..1) |
+| memory_bus_load | [ float](#float) | Memory bus load (0..1) |
+| main_queue_load | [ float](#float) | Main queue load (0..1) |
+| guestport_queue_load | [ float](#float) | Guestport queue load (0..1) |
 
 <a name="blueye-protocol-CPUTemperature"></a>
 
@@ -1422,14 +1172,9 @@ See separate documentation for the logfile format for more details.
 CPU temperature.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| value | [float](#float) |  | CPU temperature (°C) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| value | [ float](#float) | CPU temperature (°C) |
 
 <a name="blueye-protocol-CalibrationState"></a>
 
@@ -1437,21 +1182,16 @@ CPU temperature.
 Compass calibration state.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| status | [CalibrationState.Status](#blueye-protocol-CalibrationState-Status) |  | Current calibration status |
-| progress_x_positive | [float](#float) |  | Progress for the positive X axis (0..1) |
-| progress_x_negative | [float](#float) |  | Progress for the negative X axis (0..1) |
-| progress_y_positive | [float](#float) |  | Progress for the positive Y axis (0..1) |
-| progress_y_negative | [float](#float) |  | Progress for the negative X axis (0..1) |
-| progress_z_positive | [float](#float) |  | Progress for the positive Z axis (0..1) |
-| progress_z_negative | [float](#float) |  | Progress for the negative Z axis (0..1) |
-| progress_thruster | [float](#float) |  | Progress for the thruster calibration (0..1) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| status | [ CalibrationState.Status](#blueye-protocol-CalibrationState-Status) | Current calibration status |
+| progress_x_positive | [ float](#float) | Progress for the positive X axis (0..1) |
+| progress_x_negative | [ float](#float) | Progress for the negative X axis (0..1) |
+| progress_y_positive | [ float](#float) | Progress for the positive Y axis (0..1) |
+| progress_y_negative | [ float](#float) | Progress for the negative X axis (0..1) |
+| progress_z_positive | [ float](#float) | Progress for the positive Z axis (0..1) |
+| progress_z_negative | [ float](#float) | Progress for the negative Z axis (0..1) |
+| progress_thruster | [ float](#float) | Progress for the thruster calibration (0..1) |
 
 <a name="blueye-protocol-CameraParameters"></a>
 
@@ -1459,22 +1199,17 @@ Compass calibration state.
 Camera parameters.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| h264_bitrate | [int32](#int32) |  | Bitrate of the h264 stream (bit/sec) |
-| mjpg_bitrate | [int32](#int32) |  | Bitrate of the MJPG stream used for still pictures (bit/sec) |
-| exposure | [int32](#int32) |  | Shutter speed (1/10000 * s), -1 for automatic exposure |
-| white_balance | [int32](#int32) |  | White balance temperature (2800..9300), -1 for automatic white balance |
-| hue | [int32](#int32) |  | Hue (-40..40), 0 as default |
-| gain | [float](#float) |  | Iso gain (0..1) |
-| resolution | [Resolution](#blueye-protocol-Resolution) |  | Stream, recording and image resolution |
-| framerate | [Framerate](#blueye-protocol-Framerate) |  | Stream and recording framerate |
-| camera | [Camera](#blueye-protocol-Camera) |  | Which camera the parameters belong to. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| h264_bitrate | [ int32](#int32) | Bitrate of the h264 stream (bit/sec) |
+| mjpg_bitrate | [ int32](#int32) | Bitrate of the MJPG stream used for still pictures (bit/sec) |
+| exposure | [ int32](#int32) | Shutter speed  (1/10000 * s), -1 for automatic exposure |
+| white_balance | [ int32](#int32) | White balance temperature (2800..9300), -1 for automatic white balance |
+| hue | [ int32](#int32) | Hue (-40..40), 0 as default |
+| gain | [ float](#float) | Iso gain (0..1) |
+| resolution | [ Resolution](#blueye-protocol-Resolution) | Stream, recording and image resolution |
+| framerate | [ Framerate](#blueye-protocol-Framerate) | Stream and recording framerate |
+| camera | [ Camera](#blueye-protocol-Camera) | Which camera the parameters belong to. |
 
 <a name="blueye-protocol-CanisterHumidity"></a>
 
@@ -1484,14 +1219,9 @@ Canister humidity.
 Humidity measured in the top or bottom canister of the drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| humidity | [float](#float) |  | Air humidity (%) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| humidity | [ float](#float) | Air humidity (%) |
 
 <a name="blueye-protocol-CanisterTemperature"></a>
 
@@ -1501,14 +1231,9 @@ Canister temperature.
 Temperature measured in the top or bottom canister of the drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| temperature | [float](#float) |  | Temperature (°C) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| temperature | [ float](#float) | Temperature (°C) |
 
 <a name="blueye-protocol-ClientInfo"></a>
 
@@ -1516,20 +1241,15 @@ Temperature measured in the top or bottom canister of the drone.
 Information about a remote client.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| type | [string](#string) |  | The type of client (such as Blueye App, Observer App, SDK, etc) |
-| version | [string](#string) |  | Client software version string |
-| device_type | [string](#string) |  | Device type, such as mobile, tablet, or computer |
-| platform | [string](#string) |  | Platform, such as iOS, Android, Linux, etc |
-| platform_version | [string](#string) |  | Platform software version string |
-| name | [string](#string) |  | Name of the client |
-| is_observer | [bool](#bool) |  | If the client should be connected as an observer or not |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| type | [ string](#string) | The type of client (such as Blueye App, Observer App, SDK, etc) |
+| version | [ string](#string) | Client software version string |
+| device_type | [ string](#string) | Device type, such as mobile, tablet, or computer |
+| platform | [ string](#string) | Platform, such as iOS, Android, Linux, etc |
+| platform_version | [ string](#string) | Platform software version string |
+| name | [ string](#string) | Name of the client |
+| is_observer | [ bool](#bool) | If the client should be connected as an observer or not |
 
 <a name="blueye-protocol-ConnectedClient"></a>
 
@@ -1537,15 +1257,10 @@ Information about a remote client.
 Information about a connected client with an id assigned by the drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| client_id | [uint32](#uint32) |  | The assigned client id |
-| client_info | [ClientInfo](#blueye-protocol-ClientInfo) |  | Client information. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| client_id | [ uint32](#uint32) | The assigned client id |
+| client_info | [ ClientInfo](#blueye-protocol-ClientInfo) | Client information. |
 
 <a name="blueye-protocol-ConnectionDuration"></a>
 
@@ -1553,14 +1268,9 @@ Information about a connected client with an id assigned by the drone.
 Connection duration of a remote client.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| value | [int32](#int32) |  | time since connected to drone (s) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| value | [ int32](#int32) | time since connected to drone (s) |
 
 <a name="blueye-protocol-ControlForce"></a>
 
@@ -1568,17 +1278,12 @@ Connection duration of a remote client.
 Control Force is used for showing the requested control force in each direction in Newtons.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| surge | [float](#float) |  | Force in surge (N) |
-| sway | [float](#float) |  | Force in sway (N) |
-| heave | [float](#float) |  | Force in heave (N) |
-| yaw | [float](#float) |  | Moment in yaw (Nm) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| surge | [ float](#float) | Force in surge (N) |
+| sway | [ float](#float) | Force in sway (N) |
+| heave | [ float](#float) | Force in heave (N) |
+| yaw | [ float](#float) | Moment in yaw (Nm) |
 
 <a name="blueye-protocol-ControlMode"></a>
 
@@ -1586,20 +1291,15 @@ Control Force is used for showing the requested control force in each direction 
 Control mode from drone supervisor
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| auto_depth | [bool](#bool) |  | If auto depth is enabled |
-| auto_heading | [bool](#bool) |  | If auto heading is enabled |
-| auto_altitude | [bool](#bool) |  | If auto altitude is enabled |
-| station_keeping | [bool](#bool) |  | If station keeping is enabled |
-| weather_vaning | [bool](#bool) |  | If weather vaning is enabled |
-| auto_pilot_surge_yaw | [bool](#bool) |  | If auto pilot surge yaw is enabled |
-| auto_pilot_heave | [bool](#bool) |  | If auto pilot heave is enabled |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| auto_depth | [ bool](#bool) | If auto depth is enabled |
+| auto_heading | [ bool](#bool) | If auto heading is enabled |
+| auto_altitude | [ bool](#bool) | If auto altitude is enabled |
+| station_keeping | [ bool](#bool) | If station keeping is enabled |
+| weather_vaning | [ bool](#bool) | If weather vaning is enabled |
+| auto_pilot_surge_yaw | [ bool](#bool) | If auto pilot surge yaw is enabled |
+| auto_pilot_heave | [ bool](#bool) | If auto pilot heave is enabled |
 
 <a name="blueye-protocol-ControllerHealth"></a>
 
@@ -1607,17 +1307,12 @@ Control mode from drone supervisor
 Controller health is used for showing the state of the controller with an relative error and load from 0 to 1.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| depth_error | [float](#float) |  | Depth error in meters (m) |
-| depth_health | [float](#float) |  | Depth controller load (0..1) |
-| heading_error | [float](#float) |  | Heading error in degrees (°) |
-| heading_health | [float](#float) |  | Heading controller load (0..1) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| depth_error | [ float](#float) | Depth error in meters (m) |
+| depth_health | [ float](#float) | Depth controller load (0..1) |
+| heading_error | [ float](#float) | Heading error in degrees (°) |
+| heading_health | [ float](#float) | Heading controller load (0..1) |
 
 <a name="blueye-protocol-CpProbe"></a>
 
@@ -1625,15 +1320,10 @@ Controller health is used for showing the state of the controller with an relati
 Reading from a Cathodic Protection Potential probe.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| measurement | [float](#float) |  | Potential measurement (V) |
-| is_measurement_valid | [bool](#bool) |  | Indicating if the measurement is valid |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| measurement | [ float](#float) | Potential measurement (V) |
+| is_measurement_valid | [ bool](#bool) | Indicating if the measurement is valid |
 
 <a name="blueye-protocol-Depth"></a>
 
@@ -1641,14 +1331,9 @@ Reading from a Cathodic Protection Potential probe.
 Water depth of the drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| value | [float](#float) |  | Drone depth below surface (m) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| value | [ float](#float) | Drone depth below surface (m) |
 
 <a name="blueye-protocol-DiveTime"></a>
 
@@ -1658,14 +1343,9 @@ Amount of time the drone has been submerged.
 The drone starts incrementing this value when the depth is above 250 mm.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| value | [int32](#int32) |  | Number of seconds the drone has been submerged |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| value | [ int32](#int32) | Number of seconds the drone has been submerged |
 
 <a name="blueye-protocol-DroneInfo"></a>
 
@@ -1677,24 +1357,50 @@ internal components in the drone. Primarily used for diagnostics, or to
 determine the origin of a logfile.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| blunux_version | [string](#string) |  | Blunux version string |
-| serial_number | [bytes](#bytes) |  | Drone serial number |
-| hardware_id | [bytes](#bytes) |  | Main computer unique identifier |
-| model | [Model](#blueye-protocol-Model) |  | Drone model |
-| mb_serial | [bytes](#bytes) |  | Motherboard serial number |
-| bb_serial | [bytes](#bytes) |  | Backbone serial number |
-| ds_serial | [bytes](#bytes) |  | Drone stack serial number |
-| mb_uid | [bytes](#bytes) |  | Motherboard unique identifier |
-| bb_uid | [bytes](#bytes) |  | Backbone unique identifier |
-| gp | [GuestPortInfo](#blueye-protocol-GuestPortInfo) |  | GuestPortInfo |
-| depth_sensor | [PressureSensorType](#blueye-protocol-PressureSensorType) |  | Type of depth sensor that is connected to the drone |
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| blunux_version | [ string](#string) | Blunux version string |
+| serial_number | [ bytes](#bytes) | Drone serial number |
+| hardware_id | [ bytes](#bytes) | Main computer unique identifier |
+| model | [ Model](#blueye-protocol-Model) | Drone model |
+| mb_serial | [ bytes](#bytes) | Motherboard serial number |
+| bb_serial | [ bytes](#bytes) | Backbone serial number |
+| ds_serial | [ bytes](#bytes) | Drone stack serial number |
+| mb_uid | [ bytes](#bytes) | Motherboard unique identifier |
+| bb_uid | [ bytes](#bytes) | Backbone unique identifier |
+| gp | [ GuestPortInfo](#blueye-protocol-GuestPortInfo) | GuestPortInfo |
+| depth_sensor | [ PressureSensorType](#blueye-protocol-PressureSensorType) | Type of depth sensor that is connected to the drone |
+
+<a name="blueye-protocol-DvlTransducer"></a>
+
+### DvlTransducer
+DVL raw transducer data.
 
 
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| id | [ int32](#int32) | Transducer ID, 3 beams for Nucleus DVL, 4 beams for DVL A50 |
+| velocity | [ float](#float) | Velocity (m/s) |
+| distance | [ float](#float) | Distance (m) |
+| beam_valid | [ bool](#bool) | Beam validity |
+| rssi | [ float](#float) | Received signal strength indicator: strength of the signal received by this transducer (dBm) |
+| nsd | [ float](#float) | Noise spectral density: strength of the background noise received by this transducer (dBm) |
+
+<a name="blueye-protocol-DvlVelocity"></a>
+
+### DvlVelocity
+DVL raw velocity data.
 
 
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| sensor_id | [ NavigationSensorID](#blueye-protocol-NavigationSensorID) | Sensor id |
+| status | [ int32](#int32) | Vendor-specific status of the DVL |
+| delta_time | [ float](#float) | Time since last velocity measurement (ms) |
+| fom | [ float](#float) | Figure of merit, a measure of the accuracy of the velocities (m/s) |
+| velocity | [ Vector3](#blueye-protocol-Vector3) | Velocity, x forward, y left, z down (m/s) |
+| is_water_tracking | [ bool](#bool) | Water tracking status |
+| transducers | [repeated DvlTransducer](#blueye-protocol-DvlTransducer) | List of transducers |
 
 <a name="blueye-protocol-ErrorFlags"></a>
 
@@ -1702,73 +1408,67 @@ determine the origin of a logfile.
 Known error states for the drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| pmu_comm_ack | [bool](#bool) |  | Acknowledge message not received for a message published to internal micro controller |
-| pmu_comm_stream | [bool](#bool) |  | Error in communication with internal micro controller |
-| depth_read | [bool](#bool) |  | Error reading depth sensor value |
-| depth_spike | [bool](#bool) |  | Sudden spike in value read from depth sensor |
-| inner_pressure_read | [bool](#bool) |  | Error reading inner pressure of the drone |
-| inner_pressure_spike | [bool](#bool) |  | Sudden spike in inner preassure |
-| compass_calibration | [bool](#bool) |  | Compass needs calibration |
-| tilt_calibration | [bool](#bool) |  | Error during calibration of tilt endpoints |
-| gp1_read | [bool](#bool) |  | Guest port 1 read error |
-| gp2_read | [bool](#bool) |  | Guest port 2 read error |
-| gp3_read | [bool](#bool) |  | Guest port 3 read error |
-| gp1_not_flashed | [bool](#bool) |  | Guest port 1 not flashed |
-| gp2_not_flashed | [bool](#bool) |  | Guest port 2 not flashed |
-| gp3_not_flashed | [bool](#bool) |  | Guest port 3 not flashed |
-| gp1_unknown_device | [bool](#bool) |  | Unknown device on guest port 1 |
-| gp2_unknown_device | [bool](#bool) |  | Unknown device on guest port 2 |
-| gp3_unknown_device | [bool](#bool) |  | Unknown device on guest port 3 |
-| gp1_device_connection | [bool](#bool) |  | Guest port 1 connection error |
-| gp2_device_connection | [bool](#bool) |  | Guest port 2 connection error |
-| gp3_device_connection | [bool](#bool) |  | Guest port 3 connection error |
-| gp1_device | [bool](#bool) |  | Guest port 1 device error |
-| gp2_device | [bool](#bool) |  | Guest port 2 device error |
-| gp3_device | [bool](#bool) |  | Guest port 3 device error |
-| drone_serial_not_set | [bool](#bool) |  | Drone serial number not set |
-| drone_serial | [bool](#bool) |  | Drone serial number error |
-| mb_eeprom_read | [bool](#bool) |  | MB eeprom read error |
-| bb_eeprom_read | [bool](#bool) |  | BB eeprom read error |
-| mb_eeprom_not_flashed | [bool](#bool) |  | MB eeprom not flashed |
-| bb_eeprom_not_flashed | [bool](#bool) |  | BB eeprom not flashed |
-| main_camera_connection | [bool](#bool) |  | We don&#39;t get buffers from the main camera |
-| main_camera_firmware | [bool](#bool) |  | The main camera firmware is wrong |
-| guestport_camera_connection | [bool](#bool) |  | We don&#39;t get buffers from the guestport camera |
-| guestport_camera_firmware | [bool](#bool) |  | The guestport camera firmware is wrong |
-| mb_serial | [bool](#bool) |  | MB serial number error |
-| bb_serial | [bool](#bool) |  | BB serial number error |
-| ds_serial | [bool](#bool) |  | DS serial number error |
-| gp_current_read | [bool](#bool) |  | Error reading GP current |
-| gp_current | [bool](#bool) |  | Max GP current exceeded |
-| gp1_bat_current | [bool](#bool) |  | Max battery current exceeded on GP1 |
-| gp2_bat_current | [bool](#bool) |  | Max battery current exceeded on GP2 |
-| gp3_bat_current | [bool](#bool) |  | Max battery current exceeded on GP3 |
-| gp_20v_current | [bool](#bool) |  | Max 20V current exceeded on GP |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| pmu_comm_ack | [ bool](#bool) | Acknowledge message not received for a message published to internal micro controller |
+| pmu_comm_stream | [ bool](#bool) | Error in communication with internal micro controller |
+| depth_read | [ bool](#bool) | Error reading depth sensor value |
+| depth_spike | [ bool](#bool) | Sudden spike in value read from depth sensor |
+| inner_pressure_read | [ bool](#bool) | Error reading inner pressure of the drone |
+| inner_pressure_spike | [ bool](#bool) | Sudden spike in inner preassure |
+| compass_calibration | [ bool](#bool) | Compass needs calibration |
+| tilt_calibration | [ bool](#bool) | Error during calibration of tilt endpoints |
+| gp1_read | [ bool](#bool) | Guest port 1 read error |
+| gp2_read | [ bool](#bool) | Guest port 2 read error |
+| gp3_read | [ bool](#bool) | Guest port 3 read error |
+| gp1_not_flashed | [ bool](#bool) | Guest port 1 not flashed |
+| gp2_not_flashed | [ bool](#bool) | Guest port 2 not flashed |
+| gp3_not_flashed | [ bool](#bool) | Guest port 3 not flashed |
+| gp1_unknown_device | [ bool](#bool) | Unknown device on guest port 1 |
+| gp2_unknown_device | [ bool](#bool) | Unknown device on guest port 2 |
+| gp3_unknown_device | [ bool](#bool) | Unknown device on guest port 3 |
+| gp1_device_connection | [ bool](#bool) | Guest port 1 connection error |
+| gp2_device_connection | [ bool](#bool) | Guest port 2 connection error |
+| gp3_device_connection | [ bool](#bool) | Guest port 3 connection error |
+| gp1_device | [ bool](#bool) | Guest port 1 device error |
+| gp2_device | [ bool](#bool) | Guest port 2 device error |
+| gp3_device | [ bool](#bool) | Guest port 3 device error |
+| drone_serial_not_set | [ bool](#bool) | Drone serial number not set |
+| drone_serial | [ bool](#bool) | Drone serial number error |
+| mb_eeprom_read | [ bool](#bool) | MB eeprom read error |
+| bb_eeprom_read | [ bool](#bool) | BB eeprom read error |
+| mb_eeprom_not_flashed | [ bool](#bool) | MB eeprom not flashed |
+| bb_eeprom_not_flashed | [ bool](#bool) | BB eeprom not flashed |
+| main_camera_connection | [ bool](#bool) | We don't get buffers from the main camera |
+| main_camera_firmware | [ bool](#bool) | The main camera firmware is wrong |
+| guestport_camera_connection | [ bool](#bool) | We don't get buffers from the guestport camera |
+| guestport_camera_firmware | [ bool](#bool) | The guestport camera firmware is wrong |
+| mb_serial | [ bool](#bool) | MB serial number error |
+| bb_serial | [ bool](#bool) | BB serial number error |
+| ds_serial | [ bool](#bool) | DS serial number error |
+| gp_current_read | [ bool](#bool) | Error reading GP current |
+| gp_current | [ bool](#bool) | Max GP current exceeded |
+| gp1_bat_current | [ bool](#bool) | Max battery current exceeded on GP1 |
+| gp2_bat_current | [ bool](#bool) | Max battery current exceeded on GP2 |
+| gp3_bat_current | [ bool](#bool) | Max battery current exceeded on GP3 |
+| gp_20v_current | [ bool](#bool) | Max 20V current exceeded on GP |
+| dvl_thermal_protection_mode | [ bool](#bool) | DVL is in thermal protection mode |
+| dvl_no_power | [ bool](#bool) | GP protection has been triggered at boot or faulty DVL |
+| usb_disconnect | [ bool](#bool) | USB disconnect |
+| video_urb_error | [ bool](#bool) | Video URB error |
 
 <a name="blueye-protocol-ForwardDistance"></a>
 
 ### ForwardDistance
-Distance to an object infront of the drone
+Distance to an object in front of the drone
 
 Typically obtained from a 1D pinger.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| value | [float](#float) |  | Distance in front of drone (m) |
-| is_valid | [bool](#bool) |  | If distance reading is valid or not |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| value | [ float](#float) | Distance in front of drone (m) |
+| is_valid | [ bool](#bool) | If distance reading is valid or not |
 
 <a name="blueye-protocol-GenericServo"></a>
 
@@ -1776,15 +1476,10 @@ Typically obtained from a 1D pinger.
 Servo message used to represent the angle of the servo.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| value | [float](#float) |  | Servo value (0..1) |
-| guest_port_number | [GuestPortNumber](#blueye-protocol-GuestPortNumber) |  | Guest port the servo is on |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| value | [ float](#float) | Servo value (0..1) |
+| guest_port_number | [ GuestPortNumber](#blueye-protocol-GuestPortNumber) | Guest port the servo is on |
 
 <a name="blueye-protocol-GripperVelocities"></a>
 
@@ -1792,15 +1487,10 @@ Servo message used to represent the angle of the servo.
 Gripper velocity values.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| grip_velocity | [float](#float) |  | The gripping velocity (-1.0..1.0) |
-| rotate_velocity | [float](#float) |  | The rotating velocity (-1.0..1.0) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| grip_velocity | [ float](#float) | The gripping velocity (-1.0..1.0) |
+| rotate_velocity | [ float](#float) | The rotating velocity (-1.0..1.0) |
 
 <a name="blueye-protocol-GuestPortConnectorInfo"></a>
 
@@ -1808,16 +1498,11 @@ Gripper velocity values.
 GuestPort connector information.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| device_list | [GuestPortDeviceList](#blueye-protocol-GuestPortDeviceList) |  | List of devices on this connector |
-| error | [GuestPortError](#blueye-protocol-GuestPortError) |  | Guest port connector error |
-| guest_port_number | [GuestPortNumber](#blueye-protocol-GuestPortNumber) |  | Guest port the connector is connected to |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| <small><strong>oneof</strong> <code>connected_device</code></small><br>device_list | [ GuestPortDeviceList](#blueye-protocol-GuestPortDeviceList) | List of devices on this connector |
+| <small><strong>oneof</strong> <code>connected_device</code></small><br>error | [ GuestPortError](#blueye-protocol-GuestPortError) | Guest port connector error |
+| guest_port_number | [ GuestPortNumber](#blueye-protocol-GuestPortNumber) | Guest port the connector is connected to |
 
 <a name="blueye-protocol-GuestPortCurrent"></a>
 
@@ -1825,17 +1510,12 @@ GuestPort connector information.
 GuestPort current readings.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| gp1_bat | [double](#double) |  | Current on GP1 battery voltage (A) |
-| gp2_bat | [double](#double) |  | Current on GP2 battery voltage (A) |
-| gp3_bat | [double](#double) |  | Current on GP3 battery voltage (A) |
-| gp_20v | [double](#double) |  | Current on common 20V supply (A) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| gp1_bat | [ double](#double) | Current on GP1 battery voltage (A) |
+| gp2_bat | [ double](#double) | Current on GP2 battery voltage (A) |
+| gp3_bat | [ double](#double) | Current on GP3 battery voltage (A) |
+| gp_20v | [ double](#double) | Current on common 20V supply (A) |
 
 <a name="blueye-protocol-GuestPortDevice"></a>
 
@@ -1843,20 +1523,15 @@ GuestPort current readings.
 GuestPort device.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| device_id | [GuestPortDeviceID](#blueye-protocol-GuestPortDeviceID) |  | Blueye device identifier |
-| manufacturer | [string](#string) |  | Manufacturer name |
-| name | [string](#string) |  | Device name |
-| serial_number | [string](#string) |  | Serial number |
-| depth_rating | [float](#float) |  | Depth rating (m) |
-| required_blunux_version | [string](#string) |  | Required Blunux version (x.y.z) |
-| detach_status | [GuestPortDetachStatus](#blueye-protocol-GuestPortDetachStatus) |  | Detach status based on detection pin |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| device_id | [ GuestPortDeviceID](#blueye-protocol-GuestPortDeviceID) | Blueye device identifier |
+| manufacturer | [ string](#string) | Manufacturer name |
+| name | [ string](#string) | Device name |
+| serial_number | [ string](#string) | Serial number |
+| depth_rating | [ float](#float) | Depth rating (m) |
+| required_blunux_version | [ string](#string) | Required Blunux version (x.y.z) |
+| detach_status | [ GuestPortDetachStatus](#blueye-protocol-GuestPortDetachStatus) | Detach status based on detection pin |
 
 <a name="blueye-protocol-GuestPortDeviceList"></a>
 
@@ -1864,14 +1539,9 @@ GuestPort device.
 List of guest port devices.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| devices | [GuestPortDevice](#blueye-protocol-GuestPortDevice) | repeated | List of guest port devices |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| devices | [repeated GuestPortDevice](#blueye-protocol-GuestPortDevice) | List of guest port devices |
 
 <a name="blueye-protocol-GuestPortInfo"></a>
 
@@ -1879,16 +1549,11 @@ List of guest port devices.
 GuestPort information.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| gp1 | [GuestPortConnectorInfo](#blueye-protocol-GuestPortConnectorInfo) |  | GuestPortConnectorInfo 1 |
-| gp2 | [GuestPortConnectorInfo](#blueye-protocol-GuestPortConnectorInfo) |  | GuestPortConnectorInfo 2 |
-| gp3 | [GuestPortConnectorInfo](#blueye-protocol-GuestPortConnectorInfo) |  | GuestPortConnectorInfo 3 |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| gp1 | [ GuestPortConnectorInfo](#blueye-protocol-GuestPortConnectorInfo) | GuestPortConnectorInfo 1 |
+| gp2 | [ GuestPortConnectorInfo](#blueye-protocol-GuestPortConnectorInfo) | GuestPortConnectorInfo 2 |
+| gp3 | [ GuestPortConnectorInfo](#blueye-protocol-GuestPortConnectorInfo) | GuestPortConnectorInfo 3 |
 
 <a name="blueye-protocol-GuestPortRestartInfo"></a>
 
@@ -1896,14 +1561,9 @@ GuestPort information.
 GuestPort restart information.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| power_off_duration | [double](#double) |  | Duration to keep the guest ports off (s) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| power_off_duration | [ double](#double) | Duration to keep the guest ports off (s) |
 
 <a name="blueye-protocol-Imu"></a>
 
@@ -1915,17 +1575,12 @@ y - right
 z - down
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| accelerometer | [Vector3](#blueye-protocol-Vector3) |  | Acceleration (g) |
-| gyroscope | [Vector3](#blueye-protocol-Vector3) |  | Angular velocity (rad/s) |
-| magnetometer | [Vector3](#blueye-protocol-Vector3) |  | Magnetic field (μT) |
-| temperature | [float](#float) |  | Temperature (°C) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| accelerometer | [ Vector3](#blueye-protocol-Vector3) | Acceleration (g) |
+| gyroscope | [ Vector3](#blueye-protocol-Vector3) | Angular velocity (rad/s) |
+| magnetometer | [ Vector3](#blueye-protocol-Vector3) | Magnetic field (μT) |
+| temperature | [ float](#float) | Temperature (°C) |
 
 <a name="blueye-protocol-IperfStatus"></a>
 
@@ -1933,15 +1588,10 @@ z - down
 Connection speed between drone and Surface Unit.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| sent | [float](#float) |  | Transfer rate from drone to Surface Unit (Mbit/s) |
-| received | [float](#float) |  | Transfer rate from Surface Unit to drone (Mbit/s) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| sent | [ float](#float) | Transfer rate from drone to Surface Unit (Mbit/s) |
+| received | [ float](#float) | Transfer rate from Surface Unit to drone (Mbit/s) |
 
 <a name="blueye-protocol-Laser"></a>
 
@@ -1953,14 +1603,9 @@ a value of 0 turns the laser off, and any value above 0
 turns the laser on.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| value | [float](#float) |  | Laser intensity, any value above 0 turns the laser on (0..1) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| value | [ float](#float) | Laser intensity, any value above 0 turns the laser on (0..1) |
 
 <a name="blueye-protocol-LatLongPosition"></a>
 
@@ -1968,15 +1613,10 @@ turns the laser on.
 Latitude and longitude position in WGS 84 decimal degrees format.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| latitude | [double](#double) |  | Latitude (°) |
-| longitude | [double](#double) |  | Longitude (°) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| latitude | [ double](#double) | Latitude (°) |
+| longitude | [ double](#double) | Longitude (°) |
 
 <a name="blueye-protocol-Lights"></a>
 
@@ -1984,14 +1624,9 @@ Latitude and longitude position in WGS 84 decimal degrees format.
 Lights message used to represent the intensity of the main light or external lights.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| value | [float](#float) |  | Light intensity (0..1) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| value | [ float](#float) | Light intensity (0..1) |
 
 <a name="blueye-protocol-MedusaSpectrometerData"></a>
 
@@ -1999,20 +1634,15 @@ Lights message used to represent the intensity of the main light or external lig
 Medusa gamma ray sensor spectrometer data
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| drone_time | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | Time stamp when the data is received |
-| sensor_time | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | Time stamp the sensor reports |
-| realtime | [float](#float) |  | Time the sensor actually measured (s) |
-| livetime | [float](#float) |  | Time the measurement took (s) |
-| total | [uint32](#uint32) |  | Total counts inside the spectrum |
-| countrate | [uint32](#uint32) |  | Counts per second inside the spectrum (rounded) |
-| cosmics | [uint32](#uint32) |  | Detected counts above the last channel |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| drone_time | [ google.protobuf.Timestamp](#google-protobuf-Timestamp) | Time stamp when the data is received |
+| sensor_time | [ google.protobuf.Timestamp](#google-protobuf-Timestamp) | Time stamp the sensor reports |
+| realtime | [ float](#float) | Time the sensor actually measured (s) |
+| livetime | [ float](#float) | Time the measurement took (s) |
+| total | [ uint32](#uint32) | Total counts inside the spectrum |
+| countrate | [ uint32](#uint32) | Counts per second inside the spectrum (rounded) |
+| cosmics | [ uint32](#uint32) | Detected counts above the last channel |
 
 <a name="blueye-protocol-MotionInput"></a>
 
@@ -2024,21 +1654,85 @@ Typically these values map to the left and right joystick for motion,
 and the left and right trigger for the slow and boost modifiers.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| surge | [float](#float) |  | Forward (positive) and backwards (negative) movement. (-1..1) |
-| sway | [float](#float) |  | Right (positive) and left (negative) lateral movement (-1..1) |
-| heave | [float](#float) |  | Descend (positive) and ascend (negative) movement (-1..1) |
-| roll | [float](#float) |  | Roll left (negative) or right (positive). (-1..1) |
-| pitch | [float](#float) |  | Pitch down (negative) or up (positive). (-1..1) |
-| yaw | [float](#float) |  | Left (positive) and right (negative) movement (-1..1) |
-| slow | [float](#float) |  | Multiplier used to reduce the speed of the motion (0..1) |
-| boost | [float](#float) |  | Multiplier used to increase the speed of the motion (0..1) |
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| surge | [ float](#float) | Forward (positive) and backwards (negative) movement. (-1..1) |
+| sway | [ float](#float) | Right (positive) and left (negative) lateral movement (-1..1) |
+| heave | [ float](#float) | Descend (positive) and ascend (negative) movement (-1..1) |
+| roll | [ float](#float) | Roll left (negative) or right (positive). (-1..1) |
+| pitch | [ float](#float) | Pitch down (negative) or up (positive). (-1..1) |
+| yaw | [ float](#float) | Left (positive) and right (negative) movement (-1..1) |
+| slow | [ float](#float) | Multiplier used to reduce the speed of the motion (0..1) |
+| boost | [ float](#float) | Multiplier used to increase the speed of the motion (0..1) |
+
+<a name="blueye-protocol-MultibeamConfig"></a>
+
+### MultibeamConfig
+Configuration message for sonar devices
 
 
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| frequency_mode | [ MultibeamFrequencyMode](#blueye-protocol-MultibeamFrequencyMode) | Frequency mode used by the sonar if supported |
+| ping_rate | [ MultibeamConfig.PingRate](#blueye-protocol-MultibeamConfig-PingRate) | Sets the maximum ping rate. |
+| gamma_correction | [ double](#double) | Gamma correction (0..1.0) |
+| gain_assist | [ bool](#bool) | Enable gain assist |
+| maximum_number_of_beams | [ MultibeamConfig.MaximumNumberOfBeams](#blueye-protocol-MultibeamConfig-MaximumNumberOfBeams) | Maximum number of beams. Used to throttle bandwidth. |
+| range | [ double](#double) | The range demand (m) |
+| gain | [ double](#double) | The gain demand (0..1) |
+| salinity | [ double](#double) | Set water salinity (ppt). Defaults to zero in fresh water |
+| device_id | [ GuestPortDeviceID](#blueye-protocol-GuestPortDeviceID) | Device ID of the sonar |
+| bandwidth_limit | [ uint32](#uint32) | Network bandwidth limit (Mbit/s). Applies only to Oculus devices. |
+
+<a name="blueye-protocol-MultibeamDiscovery"></a>
+
+### MultibeamDiscovery
+Discovery message for sonar devices
 
 
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| enabled | [ bool](#bool) | If the sonar driver is enabled |
+| ip | [ string](#string) | IP address of the sonar |
+| mask | [ string](#string) | Subnet mask of the sonar |
+| serial_number | [ string](#string) | Serial number of the sonar |
+| fw_version | [ string](#string) | Firmware version of the sonar |
+| connected_ip | [ string](#string) | IP address of the connected device |
+| device_id | [ GuestPortDeviceID](#blueye-protocol-GuestPortDeviceID) | Device ID of the sonar |
 
+<a name="blueye-protocol-MultibeamFrameOffset"></a>
+
+### MultibeamFrameOffset
+Frame offset for multibeam recordings index cache
+
+
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| duration | [ google.protobuf.Duration](#google-protobuf-Duration) | Duration from the start of the recording |
+| offset | [ int64](#int64) | Offset in bytes from the start of the file |
+
+<a name="blueye-protocol-MultibeamPing"></a>
+
+### MultibeamPing
+Multibeam sonar ping
+
+Contains all the information for rendering a multibeam sonar frame
+
+
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| range | [ double](#double) | Maximum range value (m) |
+| gain | [ double](#double) | Percentage of gain (0 to 1) |
+| frequency | [ double](#double) | Ping acoustic frequency (Hz) |
+| speed_of_sound_used | [ double](#double) | Speed of sound used by the sonar for range calculations (m/s) |
+| frequency_mode | [ MultibeamFrequencyMode](#blueye-protocol-MultibeamFrequencyMode) | Frequency mode used by the sonar for this frame |
+| number_of_ranges | [ uint32](#uint32) | Height of the ping image data. |
+| number_of_beams | [ uint32](#uint32) | Width of the ping image data. |
+| step | [ uint32](#uint32) | Size in bytes of each row in the ping data image. |
+| bearings | [repeated float](#float) | Bearing angle of each column of the sonar data<br>(in 100th of a degree, multiply by 0.01 to get a value in degrees).<br>The sonar image is not sampled uniformly in the bearing direction. |
+| ping_data | [ bytes](#bytes) | Ping data (row major, 2D, grayscale image) |
+| device_id | [ GuestPortDeviceID](#blueye-protocol-GuestPortDeviceID) | Device ID of the sonar |
+| frame_generation_timestamp | [ google.protobuf.Timestamp](#google-protobuf-Timestamp) | Timestamp when the frame was generated |
 
 <a name="blueye-protocol-MultibeamServo"></a>
 
@@ -2046,14 +1740,19 @@ and the left and right trigger for the slow and boost modifiers.
 Servo message used to represent the angle of the servo.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| angle | [float](#float) |  | Servo degrees (-30..30) |
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| angle | [ float](#float) | Servo degrees (-30..30) |
+
+<a name="blueye-protocol-MutltibeamRecordingIndex"></a>
+
+### MutltibeamRecordingIndex
+Multibeam recording index cache
 
 
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| frame_offsets | [repeated MultibeamFrameOffset](#blueye-protocol-MultibeamFrameOffset) | List of frame offsets |
 
 <a name="blueye-protocol-NStreamers"></a>
 
@@ -2061,15 +1760,10 @@ Servo message used to represent the angle of the servo.
 Number of spectators connected to video stream.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| main | [int32](#int32) |  | The number of clients to the main camera stream |
-| guestport | [int32](#int32) |  | The number of clients to the guestport camera stream |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| main | [ int32](#int32) | The number of clients to the main camera stream |
+| guestport | [ int32](#int32) | The number of clients to the guestport camera stream |
 
 <a name="blueye-protocol-NavigationSensorStatus"></a>
 
@@ -2077,15 +1771,16 @@ Number of spectators connected to video stream.
 Navigation sensor used in the position observer with validity state
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| sensor_id | [NavigationSensorID](#blueye-protocol-NavigationSensorID) |  | Sensor id |
-| is_valid | [bool](#bool) |  | Sensor validity |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| sensor_id | [ NavigationSensorID](#blueye-protocol-NavigationSensorID) | Sensor id |
+| is_valid | [ bool](#bool) | Sensor validity |
+| northing | [ float](#float) | Position from reset point (m) |
+| easting | [ float](#float) | Position from reset point (m) |
+| heading | [ float](#float) | Heading from sensor (-pi..pi) |
+| fom | [ float](#float) | Figure of merit |
+| std | [ float](#float) | Standard deviation |
+| global_position | [ LatLongPosition](#blueye-protocol-LatLongPosition) | Global position from sensor |
 
 <a name="blueye-protocol-Notification"></a>
 
@@ -2093,17 +1788,12 @@ Navigation sensor used in the position observer with validity state
 Notification is used for displaying info, warnings, and errors to the user.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| type | [NotificationType](#blueye-protocol-NotificationType) |  | Notification to be displayed to the user |
-| level | [NotificationLevel](#blueye-protocol-NotificationLevel) |  | Level of the notification, info, warning or error |
-| value | [google.protobuf.Any](#google-protobuf-Any) |  | Optional value to be displayed in the message |
-| timestamp | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | Timestamp of the notification |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| type | [ NotificationType](#blueye-protocol-NotificationType) | Notification to be displayed to the user |
+| level | [ NotificationLevel](#blueye-protocol-NotificationLevel) | Level of the notification, info, warning or error |
+| value | [ google.protobuf.Any](#google-protobuf-Any) | Optional value to be displayed in the message |
+| timestamp | [ google.protobuf.Timestamp](#google-protobuf-Timestamp) | Timestamp of the notification |
 
 <a name="blueye-protocol-OverlayParameters"></a>
 
@@ -2113,36 +1803,52 @@ Overlay parameters.
 All available parameters that can be used to configure telemetry overlay on video recordings.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| temperature_enabled | [bool](#bool) |  | If temperature should be included |
-| depth_enabled | [bool](#bool) |  | If depth should be included |
-| heading_enabled | [bool](#bool) |  | If heading should be included |
-| tilt_enabled | [bool](#bool) |  | If camera tilt angle should be included |
-| thickness_enabled | [bool](#bool) |  | If camera tilt angle should be included |
-| date_enabled | [bool](#bool) |  | If date should be included |
-| distance_enabled | [bool](#bool) |  | If distance should be included |
-| altitude_enabled | [bool](#bool) |  | If altitude should be included |
-| cp_probe_enabled | [bool](#bool) |  | If cp-probe should be included |
-| medusa_enabled | [bool](#bool) |  | If medusa measurement should be included |
-| drone_location_enabled | [bool](#bool) |  | If the drone location coordinates should be included |
-| logo_type | [LogoType](#blueye-protocol-LogoType) |  | Which logo should be used |
-| depth_unit | [DepthUnit](#blueye-protocol-DepthUnit) |  | Which unit should be used for depth: Meter, Feet or None |
-| temperature_unit | [TemperatureUnit](#blueye-protocol-TemperatureUnit) |  | Which unit should be used for temperature: Celcius or Fahrenheit |
-| thickness_unit | [ThicknessUnit](#blueye-protocol-ThicknessUnit) |  | Which unit should be used for thickness: Millimeters or Inches |
-| timezone_offset | [int32](#int32) |  | Timezone offset from UTC (min) |
-| margin_width | [int32](#int32) |  | Horizontal margins of text elements (px) |
-| margin_height | [int32](#int32) |  | Vertical margins of text elements (px) |
-| font_size | [FontSize](#blueye-protocol-FontSize) |  | Font size of text elements |
-| title | [string](#string) |  | Optional title |
-| subtitle | [string](#string) |  | Optional subtitle |
-| date_format | [string](#string) |  | Posix strftime format string for time stamp |
-| shading | [float](#float) |  | Pixel intensity to subtract from text background (0..1), 0: transparent, 1: black |
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| temperature_enabled | [ bool](#bool) | If temperature should be included |
+| depth_enabled | [ bool](#bool) | If depth should be included |
+| heading_enabled | [ bool](#bool) | If heading should be included |
+| tilt_enabled | [ bool](#bool) | If camera tilt angle should be included |
+| thickness_enabled | [ bool](#bool) | If camera tilt angle should be included |
+| date_enabled | [ bool](#bool) | If date should be included |
+| distance_enabled | [ bool](#bool) | If distance should be included |
+| altitude_enabled | [ bool](#bool) | If altitude should be included |
+| cp_probe_enabled | [ bool](#bool) | If cp-probe should be included |
+| medusa_enabled | [ bool](#bool) | If medusa measurement should be included |
+| drone_location_enabled | [ bool](#bool) | If the drone location coordinates should be included |
+| logo_type | [ LogoType](#blueye-protocol-LogoType) | Which logo should be used |
+| depth_unit | [ DepthUnit](#blueye-protocol-DepthUnit) | Which unit should be used for depth: Meter, Feet or None |
+| temperature_unit | [ TemperatureUnit](#blueye-protocol-TemperatureUnit) | Which unit should be used for temperature: Celsius or Fahrenheit |
+| thickness_unit | [ ThicknessUnit](#blueye-protocol-ThicknessUnit) | Which unit should be used for thickness: Millimeters or Inches |
+| timezone_offset | [ int32](#int32) | Timezone offset from UTC (min) |
+| margin_width | [ int32](#int32) | Horizontal margins of text elements (px) |
+| margin_height | [ int32](#int32) | Vertical margins of text elements (px) |
+| font_size | [ FontSize](#blueye-protocol-FontSize) | Font size of text elements |
+| title | [ string](#string) | Optional title |
+| subtitle | [ string](#string) | Optional subtitle |
+| date_format | [ string](#string) | Posix strftime format string for time stamp |
+| shading | [ float](#float) | Pixel intensity to subtract from text background (0..1), 0: transparent, 1: black |
+
+<a name="blueye-protocol-PersistentStorageSettings"></a>
+
+### PersistentStorageSettings
+PersistentStorageSettings defines settings for writing various types of data in the persistent storage on the drone
+
+Some of the data is written during factory calibration (acc calibration), while other data is written during user
+calubration or during normal operation.
 
 
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| videos | [ bool](#bool) | Indicates if videos should be written to the video partition. |
+| images | [ bool](#bool) | Indicates if images should be written to the video partition. |
+| binlog | [ bool](#bool) | Indicates if binary logs with telemetry data should be written to the data partition. |
+| multibeam | [ bool](#bool) | Indicates if multibeam data should be written to the video partition. |
+| webserver_log | [ bool](#bool) | Indicates if webserver logs should be written to the data partition. |
+| control_system_log | [ bool](#bool) | Indicates if control system logs should be written to the data partition. |
+| gyro_calibration | [ bool](#bool) | Indicates if gyro calibration data should be written to the data partition. |
+| compass_calibration | [ bool](#bool) | Indicates if compass calibration data should be written to the data partition. |
+| acc_calibration | [ bool](#bool) | Indicates if accelerometer calibration data should be written to the data partition. |
 
 <a name="blueye-protocol-PingerConfiguration"></a>
 
@@ -2152,14 +1858,9 @@ Pinger configuration.
 Used to specify the configuration the BR 1D-Pinger.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| mounting_direction | [PingerConfiguration.MountingDirection](#blueye-protocol-PingerConfiguration-MountingDirection) |  | Mounting direction of the pinger |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| mounting_direction | [ PingerConfiguration.MountingDirection](#blueye-protocol-PingerConfiguration-MountingDirection) | Mounting direction of the pinger |
 
 <a name="blueye-protocol-PositionEstimate"></a>
 
@@ -2167,24 +1868,22 @@ Used to specify the configuration the BR 1D-Pinger.
 Position estimate from the Extended Kalman filter based observer if a DVL is connected.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| northing | [float](#float) |  | Position from reset point (m) |
-| easting | [float](#float) |  | Position from reset point (m) |
-| heading | [float](#float) |  | Gyro based heading estimate (continous radians) |
-| surge_rate | [float](#float) |  | Velocity in surge (m/s) |
-| sway_rate | [float](#float) |  | Velocity in sway (m/s) |
-| yaw_rate | [float](#float) |  | Rotaion rate in yaw (rad/s) |
-| ocean_current | [float](#float) |  | Estimated ocean current (m/s) |
-| odometer | [float](#float) |  | Travelled distance since reset (m) |
-| is_valid | [bool](#bool) |  | If the estimate can be trusted |
-| global_position | [LatLongPosition](#blueye-protocol-LatLongPosition) |  | Best estimate of the global position in decimal degrees |
-| navigation_sensors | [NavigationSensorStatus](#blueye-protocol-NavigationSensorStatus) | repeated | List of available sensors with status |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| northing | [ float](#float) | Position from reset point (m) |
+| easting | [ float](#float) | Position from reset point (m) |
+| heading | [ float](#float) | Continuous heading estimate (rad) |
+| surge_rate | [ float](#float) | Velocity in surge (m/s) |
+| sway_rate | [ float](#float) | Velocity in sway (m/s) |
+| yaw_rate | [ float](#float) | Rotaion rate in yaw (rad/s) |
+| ocean_current | [ float](#float) | Estimated ocean current (m/s) |
+| odometer | [ float](#float) | Travelled distance since reset (m) |
+| is_valid | [ bool](#bool) | If the estimate can be trusted |
+| global_position | [ LatLongPosition](#blueye-protocol-LatLongPosition) | Best estimate of the global position in decimal degrees |
+| navigation_sensors | [repeated NavigationSensorStatus](#blueye-protocol-NavigationSensorStatus) | List of available sensors with status |
+| speed_over_ground | [ float](#float) | Speed over ground (m/s) |
+| course_over_ground | [ float](#float) | Course over ground (°) |
+| time_since_reset_sec | [ int32](#int32) | Time since reset (s) |
 
 <a name="blueye-protocol-RecordOn"></a>
 
@@ -2192,15 +1891,11 @@ Position estimate from the Extended Kalman filter based observer if a DVL is con
 Which cameras are supposed to be recording
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| main | [bool](#bool) |  | Record the main camera |
-| guestport | [bool](#bool) |  | Record external camera |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| main | [ bool](#bool) | Record the main camera |
+| guestport | [ bool](#bool) | Record external camera |
+| multibeam | [ bool](#bool) | Record multibeam |
 
 <a name="blueye-protocol-RecordState"></a>
 
@@ -2208,40 +1903,35 @@ Which cameras are supposed to be recording
 Camera recording state.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| main_is_recording | [bool](#bool) |  | If the main camera is recording |
-| main_seconds | [int32](#int32) |  | Main record time (s) |
-| guestport_is_recording | [bool](#bool) |  | If the guestport camera is recording |
-| guestport_seconds | [int32](#int32) |  | Guestport record time (s) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| main_is_recording | [ bool](#bool) | If the main camera is recording |
+| main_seconds | [ int32](#int32) | Main record time (s) |
+| main_fps | [ float](#float) | Main record fps |
+| guestport_is_recording | [ bool](#bool) | If the guestport camera is recording |
+| guestport_seconds | [ int32](#int32) | Guestport record time (s) |
+| guestport_fps | [ float](#float) | Guestport record fps |
+| multibeam_is_recording | [ bool](#bool) | If the multibeam is recording |
+| multibeam_seconds | [ int32](#int32) | Multibeam record time (s) |
+| multibeam_fps | [ float](#float) | Multibeam record fps |
 
 <a name="blueye-protocol-Reference"></a>
 
 ### Reference
 Reference for the control system.
 Note that the internal heading reference is not relative to North, use
-(ControlHealth.heading_error &#43; pose.yaw) instead.
+(ControlHealth.heading_error + pose.yaw) instead.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| surge | [float](#float) |  | Reference from joystick surge input (0..1) |
-| sway | [float](#float) |  | Reference from joystick sway input (0..1) |
-| heave | [float](#float) |  | Reference from joystick heave input (0..1) |
-| yaw | [float](#float) |  | Reference from joystick yaw input (0..1) |
-| depth | [float](#float) |  | Reference drone depth below surface (m) |
-| heading | [float](#float) |  | Reference used in auto heading mode, gyro based (°) |
-| altitude | [float](#float) |  | Reference used in auto altitude mode (m) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| surge | [ float](#float) | Reference from joystick surge input (0..1) |
+| sway | [ float](#float) | Reference from joystick sway input (0..1) |
+| heave | [ float](#float) | Reference from joystick heave input (0..1) |
+| yaw | [ float](#float) | Reference from joystick yaw input (0..1) |
+| depth | [ float](#float) | Reference drone depth below surface (m) |
+| heading | [ float](#float) | Reference used in auto heading mode, gyro based (°) |
+| altitude | [ float](#float) | Reference used in auto altitude mode (m) |
 
 <a name="blueye-protocol-ResetPositionSettings"></a>
 
@@ -2249,17 +1939,12 @@ Note that the internal heading reference is not relative to North, use
 ResetPositionSettings used during reset of the position estimate.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| heading_source_during_reset | [HeadingSource](#blueye-protocol-HeadingSource) |  | Option to use the drone compass or due North as heading during reset |
-| manual_heading | [float](#float) |  | Heading in degrees (0-359) |
-| reset_coordinate_source | [ResetCoordinateSource](#blueye-protocol-ResetCoordinateSource) |  | Option to use the device GPS or a manual coordinate. |
-| reset_coordinate | [LatLongPosition](#blueye-protocol-LatLongPosition) |  | Reset coordinate in decimal degrees |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| heading_source_during_reset | [ HeadingSource](#blueye-protocol-HeadingSource) | Option to use the drone compass or due North as heading during reset |
+| manual_heading | [ float](#float) | Heading in degrees (0-359) |
+| reset_coordinate_source | [ ResetCoordinateSource](#blueye-protocol-ResetCoordinateSource) | Option to use the device GPS or a manual coordinate. |
+| reset_coordinate | [ LatLongPosition](#blueye-protocol-LatLongPosition) | Reset coordinate in decimal degrees |
 
 <a name="blueye-protocol-StationKeepingState"></a>
 
@@ -2267,14 +1952,9 @@ ResetPositionSettings used during reset of the position estimate.
 Station keeping state.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| enabled | [bool](#bool) |  | If station keeping is enabled |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| enabled | [ bool](#bool) | If station keeping is enabled |
 
 <a name="blueye-protocol-StorageSpace"></a>
 
@@ -2282,15 +1962,10 @@ Station keeping state.
 Storage space.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| total_space | [int64](#int64) |  | Total bytes of storage space (B) |
-| free_space | [int64](#int64) |  | Available bytes of storage space (B) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| total_space | [ int64](#int64) | Total bytes of storage space (B) |
+| free_space | [ int64](#int64) | Available bytes of storage space (B) |
 
 <a name="blueye-protocol-SystemTime"></a>
 
@@ -2298,14 +1973,9 @@ Storage space.
 System time.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| unix_timestamp | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | Unix timestamp |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| unix_timestamp | [ google.protobuf.Timestamp](#google-protobuf-Timestamp) | Unix timestamp |
 
 <a name="blueye-protocol-ThicknessGauge"></a>
 
@@ -2313,17 +1983,12 @@ System time.
 Thickness measurement data from a Cygnus Thickness Gauge.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| thickness_measurement | [float](#float) |  | Thickness measurement of a steel plate |
-| echo_count | [uint32](#uint32) |  | Indicating the quality of the reading when invalid (0-3) |
-| sound_velocity | [uint32](#uint32) |  | Speed of sound in the steel member (m/s) |
-| is_measurement_valid | [bool](#bool) |  | Indicating if the measurement is valid |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| thickness_measurement | [ float](#float) | Thickness measurement of a steel plate |
+| echo_count | [ uint32](#uint32) | Indicating the quality of the reading when invalid (0-3) |
+| sound_velocity | [ uint32](#uint32) | Speed of sound in the steel member (m/s) |
+| is_measurement_valid | [ bool](#bool) | Indicating if the measurement is valid |
 
 <a name="blueye-protocol-TiltAngle"></a>
 
@@ -2331,14 +1996,9 @@ Thickness measurement data from a Cygnus Thickness Gauge.
 Angle of tilt camera in degrees.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| value | [float](#float) |  | Tilt angle (°) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| value | [ float](#float) | Tilt angle (°) |
 
 <a name="blueye-protocol-TiltStabilizationState"></a>
 
@@ -2349,14 +2009,9 @@ Blueye drones with mechanical tilt has the ability to enable
 camera stabilization.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| enabled | [bool](#bool) |  | If tilt stabilization is enabled |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| enabled | [ bool](#bool) | If tilt stabilization is enabled |
 
 <a name="blueye-protocol-TiltVelocity"></a>
 
@@ -2364,14 +2019,9 @@ camera stabilization.
 Relative velocity of tilt
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| value | [float](#float) |  | Relative angular velocity of tilt (-1..1), negative means down and positive means up |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| value | [ float](#float) | Relative angular velocity of tilt (-1..1), negative means down and positive means up |
 
 <a name="blueye-protocol-TimeLapseState"></a>
 
@@ -2379,16 +2029,11 @@ Relative velocity of tilt
 Time-lapse state published if time-lapse mission is running.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| interval | [float](#float) |  | Interval between photos |
-| photos_taken | [int32](#int32) |  | Number of photos taken |
-| interval_type | [IntervalType](#blueye-protocol-IntervalType) |  | Interval type for photos, distance or time |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| interval | [ float](#float) | Interval between photos |
+| photos_taken | [ int32](#int32) | Number of photos taken |
+| interval_type | [ IntervalType](#blueye-protocol-IntervalType) | Interval type for photos, distance or time |
 
 <a name="blueye-protocol-Vector3"></a>
 
@@ -2396,16 +2041,11 @@ Time-lapse state published if time-lapse mission is running.
 Vector with 3 elements
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| x | [double](#double) |  | x-component |
-| y | [double](#double) |  | y-component |
-| z | [double](#double) |  | z-component |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| x | [ double](#double) | x-component |
+| y | [ double](#double) | y-component |
+| z | [ double](#double) | z-component |
 
 <a name="blueye-protocol-WaterDensity"></a>
 
@@ -2416,29 +2056,19 @@ Used to specify the water density the drone is operating in,
 to achieve more accurate depth measurements, f. ex. influenced by salinity.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| value | [float](#float) |  | Water density (g/l) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| value | [ float](#float) | Water density (g/l) |
 
 <a name="blueye-protocol-WaterTemperature"></a>
 
 ### WaterTemperature
-Water temperature measured by the drone&#39;s combined depth and temperature sensor.
+Water temperature measured by the drone's combined depth and temperature sensor.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| value | [float](#float) |  | Water temperature (°C) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| value | [ float](#float) | Water temperature (°C) |
 
 <a name="blueye-protocol-WeatherVaningState"></a>
 
@@ -2446,21 +2076,16 @@ Water temperature measured by the drone&#39;s combined depth and temperature sen
 Weather vaning state.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| enabled | [bool](#bool) |  | If weather vaning is enabled |
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| enabled | [ bool](#bool) | If weather vaning is enabled |
 
-
-
-
-
- 
 
 
 <a name="blueye-protocol-BatteryBQ40Z50-BatteryStatus-BatteryError"></a>
 
 ### BatteryBQ40Z50.BatteryStatus.BatteryError
-Battery errror code from BQ40Z50 BMS data sheet.
+Battery error code from BQ40Z50 BMS data sheet.
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
@@ -2544,7 +2169,7 @@ Available font sizes for overlay text elements.
 <a name="blueye-protocol-Framerate"></a>
 
 ### Framerate
-Available camera framerates.
+Available camera frame rates.
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
@@ -2612,6 +2237,11 @@ GuestPort device ID.
 | GUEST_PORT_DEVICE_ID_BLUEYE_MULTIBEAM_HEAD_SERVO | 35 | Blueye Multibeam Head Servo |
 | GUEST_PORT_DEVICE_ID_CERULEAN_OMNISCAN_450FS | 36 | Cerulean Omniscan 450 FS |
 | GUEST_PORT_DEVICE_ID_CERULEAN_OMNISCAN_450SS | 37 | Cerulean Omniscan 450 SS |
+| GUEST_PORT_DEVICE_ID_BLUEYE_GNSS_DEVICE | 38 | Blueye GNSS device |
+| GUEST_PORT_DEVICE_ID_WATERLINKED_DVL_A50_600 | 39 | Waterlinked DVL A50 600m |
+| GUEST_PORT_DEVICE_ID_IMAGENEX_831L | 40 | Imagenex 831L Pipe Profiling Sonar |
+| GUEST_PORT_DEVICE_ID_BLUEPRINT_SUBSEA_OCULUS_C550D | 41 | Blueprint Subsea Oculus C550d |
+| GUEST_PORT_DEVICE_ID_BLUEPRINT_SUBSEA_OCULUS_M370S | 42 | Blueprint Subsea Oculus M370s |
 
 
 
@@ -2702,6 +2332,52 @@ Drone models produced by Blueye
 
 
 
+<a name="blueye-protocol-MultibeamConfig-MaximumNumberOfBeams"></a>
+
+### MultibeamConfig.MaximumNumberOfBeams
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| MAXIMUM_NUMBER_OF_BEAMS_UNSPECIFIED | 0 |  |
+| MAXIMUM_NUMBER_OF_BEAMS_MAX_128 | 1 | 128 beams |
+| MAXIMUM_NUMBER_OF_BEAMS_MAX_256 | 2 | 256 beams |
+| MAXIMUM_NUMBER_OF_BEAMS_MAX_512 | 3 | 512 beams |
+| MAXIMUM_NUMBER_OF_BEAMS_MAX_1024 | 4 | 1024 beams |
+
+
+
+<a name="blueye-protocol-MultibeamConfig-PingRate"></a>
+
+### MultibeamConfig.PingRate
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| PING_RATE_UNSPECIFIED | 0 |  |
+| PING_RATE_NORMAL | 1 | 10Hz max ping rate |
+| PING_RATE_HIGH | 2 | 15Hz max ping rate |
+| PING_RATE_HIGHEST | 3 | 40Hz max ping rate |
+| PING_RATE_LOW | 4 | 5Hz max ping rate |
+| PING_RATE_LOWEST | 5 | 2Hz max ping rate |
+| PING_RATE_STANDBY | 6 | Disable ping |
+
+
+
+<a name="blueye-protocol-MultibeamFrequencyMode"></a>
+
+### MultibeamFrequencyMode
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| MULTIBEAM_FREQUENCY_MODE_UNSPECIFIED | 0 |  |
+| MULTIBEAM_FREQUENCY_MODE_AUTO | 1 | Auto switching mode (if available) |
+| MULTIBEAM_FREQUENCY_MODE_LOW_FREQUENCY | 2 | Low frequency mode (wide aperture, navigation) |
+| MULTIBEAM_FREQUENCY_MODE_HIGH_FREQUENCY | 3 | High frequency mode (narrow aperture, target identification) |
+
+
+
 <a name="blueye-protocol-NavigationSensorID"></a>
 
 ### NavigationSensorID
@@ -2713,6 +2389,8 @@ List of navigation sensors that can be used by the position observer
 | NAVIGATION_SENSOR_ID_WATERLINKED_DVL_A50 | 1 | Water Linked DVL A50 |
 | NAVIGATION_SENSOR_ID_WATERLINKED_UGPS_G2 | 2 | Water Linked UGPS G2 |
 | NAVIGATION_SENSOR_ID_NMEA | 3 | NMEA stream from external positioning system |
+| NAVIGATION_SENSOR_ID_BLUEYE_GNSS | 4 | Blueye GNSS device on the ROV |
+| NAVIGATION_SENSOR_ID_NORTEK_DVL_NUCLEUS | 5 | Nortek DVL Nucleus 1000 |
 
 
 
@@ -2768,6 +2446,8 @@ Notification is used for displaying info, warnings, and errors to the user.
 | NOTIFICATION_TYPE_SET_TILT_MAIN_CAMERA | 28 | Set tilt for main camera |
 | NOTIFICATION_TYPE_SET_TILT_MULTIBEAM | 29 | Set tilt for multibeam |
 | NOTIFICATION_TYPE_INSTRUCTION_SKIPPED | 30 | When an instruction is not available in the ROV |
+| NOTIFICATION_TYPE_DVL_HIGH_TEMPERATURE_DETECTED | 31 | DVL high temperature detected |
+| NOTIFICATION_TYPE_DVL_THERMAL_PROTECTION_MODE_DETECTED | 32 | DVL thermal protection mode detected |
 
 
 
@@ -2832,8 +2512,8 @@ Available temperature units.
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
-| TEMPERATURE_UNIT_UNSPECIFIED | 0 | Temperature unit not specfied |
-| TEMPERATURE_UNIT_CELSIUS | 1 | Temperature should be displayed as Celcius |
+| TEMPERATURE_UNIT_UNSPECIFIED | 0 | Temperature unit not specified |
+| TEMPERATURE_UNIT_CELSIUS | 1 | Temperature should be displayed as Celsius |
 | TEMPERATURE_UNIT_FAHRENHEIT | 2 | Temperature should be displayed as Fahrenheit |
 
 
@@ -2850,16 +2530,9 @@ Available thickness units.
 | THICKNESS_UNIT_INCHES | 2 | Thickness should be displayed as inches |
 
 
- 
-
- 
-
- 
-
 
 
 <a name="mission_planning-proto"></a>
-<p align="right"><a href="#top">Top</a></p>
 
 ## mission_planning.proto
 Mission Planning Protocol
@@ -2873,15 +2546,10 @@ These messages are used to start a mission and to monitor the status of the miss
 CameraCommands are used to control the camera from a mission.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| camera_action | [CameraAction](#blueye-protocol-CameraAction) |  | Camera command |
-| action_param | [float](#float) |  | Used for taking photos based on a time or distance interval |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| camera_action | [ CameraAction](#blueye-protocol-CameraAction) | Camera command |
+| action_param | [ float](#float) | Used for taking photos based on a time or distance interval |
 
 <a name="blueye-protocol-ControlModeCommand"></a>
 
@@ -2889,32 +2557,22 @@ CameraCommands are used to control the camera from a mission.
 A ControlModeCommand is used to set vertical and horizontal control mode during a mission.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| control_mode_vertical | [ControlModeVertical](#blueye-protocol-ControlModeVertical) |  | Desired control mode in heave |
-| control_mode_horizontal | [ControlModeHorizontal](#blueye-protocol-ControlModeHorizontal) |  | Desired control mode in surge and yaw |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| control_mode_vertical | [ ControlModeVertical](#blueye-protocol-ControlModeVertical) | Desired control mode in heave |
+| control_mode_horizontal | [ ControlModeHorizontal](#blueye-protocol-ControlModeHorizontal) | Desired control mode in surge and yaw |
 
 <a name="blueye-protocol-DepthSetPoint"></a>
 
 ### DepthSetPoint
-Depth set point is used to describe a depth setpoint relative to the surface or the seabed.
+Depth set point is used to describe a depth set-point relative to the surface or the seabed.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| depth | [float](#float) |  | Desired depth at the wp (m) |
-| speed_to_depth | [float](#float) |  | Desired speed to desired depth set point (m/s) |
-| depth_zero_reference | [DepthZeroReference](#blueye-protocol-DepthZeroReference) |  | Used to destinguish desired altitude or depth |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| depth | [ float](#float) | Desired depth at the wp (m) |
+| speed_to_depth | [ float](#float) | Desired speed to desired depth set point (m/s) |
+| depth_zero_reference | [ DepthZeroReference](#blueye-protocol-DepthZeroReference) | Used to distinguish desired altitude or depth |
 
 <a name="blueye-protocol-DepthSetPointCommand"></a>
 
@@ -2922,14 +2580,9 @@ Depth set point is used to describe a depth setpoint relative to the surface or 
 A DepthSetPointCommand is used to go to a desired depth or altitude.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| depth_set_point | [DepthSetPoint](#blueye-protocol-DepthSetPoint) |  | Depth set point to go to |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| depth_set_point | [ DepthSetPoint](#blueye-protocol-DepthSetPoint) | Depth set point to go to |
 
 <a name="blueye-protocol-GoToHomeCommand"></a>
 
@@ -2937,14 +2590,9 @@ A DepthSetPointCommand is used to go to a desired depth or altitude.
 GoToHomeCommand is used to go to the home position.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| desired_speed | [float](#float) |  | Desired speed to home (m/s) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| desired_speed | [ float](#float) | Desired speed to home (m/s) |
 
 <a name="blueye-protocol-GoToSeabedCommand"></a>
 
@@ -2952,14 +2600,9 @@ GoToHomeCommand is used to go to the home position.
 GoToSeabedCommand is used to go to the seabed.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| desired_speed | [float](#float) |  | Desired speed to seabed (m/s) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| desired_speed | [ float](#float) | Desired speed to seabed (m/s) |
 
 <a name="blueye-protocol-GoToSurfaceCommand"></a>
 
@@ -2967,41 +2610,31 @@ GoToSeabedCommand is used to go to the seabed.
 GoToSurfaceCommand is used to go to the surface.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| desired_speed | [float](#float) |  | Desired speed to surface (m/s) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| desired_speed | [ float](#float) | Desired speed to surface (m/s) |
 
 <a name="blueye-protocol-Instruction"></a>
 
 ### Instruction
-A mission consitst of one or multiple instructions. One instruction can be of different types.
+A mission consists of one or multiple instructions. One instruction can be of different types.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [uint32](#uint32) |  |  |
-| group_id | [uint32](#uint32) |  | Group id used for polygoons |
-| auto_continue | [bool](#bool) |  | False will pause the mission after this instruction |
-| waypoint_command | [WaypointCommand](#blueye-protocol-WaypointCommand) |  | Go to waypoint |
-| depth_set_point_command | [DepthSetPointCommand](#blueye-protocol-DepthSetPointCommand) |  | Go to depth |
-| camera_command | [CameraCommand](#blueye-protocol-CameraCommand) |  | Camera commands |
-| control_mode_command | [ControlModeCommand](#blueye-protocol-ControlModeCommand) |  | Set control modes |
-| tilt_main_camera_command | [TiltMainCameraCommand](#blueye-protocol-TiltMainCameraCommand) |  | Set camera to angle x |
-| tilt_multibeam_command | [TiltMultibeamCommand](#blueye-protocol-TiltMultibeamCommand) |  | Set multibeam tilt angle |
-| wait_for_command | [WaitForCommand](#blueye-protocol-WaitForCommand) |  | Wait for x seconds |
-| go_to_surface_command | [GoToSurfaceCommand](#blueye-protocol-GoToSurfaceCommand) |  | Go to surface |
-| go_to_seabed_command | [GoToSeabedCommand](#blueye-protocol-GoToSeabedCommand) |  | Go to seabed |
-| go_to_home_command | [GoToHomeCommand](#blueye-protocol-GoToHomeCommand) |  | Go to home position |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| id | [ uint32](#uint32) |  |
+| group_id | [ uint32](#uint32) | Group id used for polygons |
+| auto_continue | [ bool](#bool) | False will pause the mission after this instruction |
+| <small><strong>oneof</strong> <code>command</code></small><br>waypoint_command | [ WaypointCommand](#blueye-protocol-WaypointCommand) | Go to waypoint |
+| <small><strong>oneof</strong> <code>command</code></small><br>depth_set_point_command | [ DepthSetPointCommand](#blueye-protocol-DepthSetPointCommand) | Go to depth |
+| <small><strong>oneof</strong> <code>command</code></small><br>camera_command | [ CameraCommand](#blueye-protocol-CameraCommand) | Camera commands |
+| <small><strong>oneof</strong> <code>command</code></small><br>control_mode_command | [ ControlModeCommand](#blueye-protocol-ControlModeCommand) | Set control modes |
+| <small><strong>oneof</strong> <code>command</code></small><br>tilt_main_camera_command | [ TiltMainCameraCommand](#blueye-protocol-TiltMainCameraCommand) | Set camera to angle x |
+| <small><strong>oneof</strong> <code>command</code></small><br>tilt_multibeam_command | [ TiltMultibeamCommand](#blueye-protocol-TiltMultibeamCommand) | Set multibeam tilt angle |
+| <small><strong>oneof</strong> <code>command</code></small><br>wait_for_command | [ WaitForCommand](#blueye-protocol-WaitForCommand) | Wait for x seconds |
+| <small><strong>oneof</strong> <code>command</code></small><br>go_to_surface_command | [ GoToSurfaceCommand](#blueye-protocol-GoToSurfaceCommand) | Go to surface |
+| <small><strong>oneof</strong> <code>command</code></small><br>go_to_seabed_command | [ GoToSeabedCommand](#blueye-protocol-GoToSeabedCommand) | Go to seabed |
+| <small><strong>oneof</strong> <code>command</code></small><br>go_to_home_command | [ GoToHomeCommand](#blueye-protocol-GoToHomeCommand) | Go to home position |
 
 <a name="blueye-protocol-Mission"></a>
 
@@ -3009,22 +2642,17 @@ A mission consitst of one or multiple instructions. One instruction can be of di
 A list of waypoints describes a mission that the auto pilot can execute.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [uint32](#uint32) |  | Mission id |
-| name | [string](#string) |  | Mission name provided from the app |
-| instructions | [Instruction](#blueye-protocol-Instruction) | repeated | List of instructions in the mission |
-| path_segments | [PathSegment](#blueye-protocol-PathSegment) | repeated | Calculated path segments from the reference generator (optinal) |
-| total_distance | [uint32](#uint32) |  | Total distance of the mission (m) (optinal) |
-| total_duration_time | [uint32](#uint32) |  | Total duration time of the mission (s) (optinal) |
-| default_surge_speed | [float](#float) |  | Default cruise speed of the mission (m/s) (optinal) |
-| default_heave_speed | [float](#float) |  | Default heave speed of the mission (m/s) (optinal) |
-| default_circle_of_acceptance | [float](#float) |  | Default circle of acceptance for waypoints (m) (optinal) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| id | [ uint32](#uint32) | Mission id |
+| name | [ string](#string) | Mission name provided from the app |
+| instructions | [repeated Instruction](#blueye-protocol-Instruction) | List of instructions in the mission |
+| path_segments | [repeated PathSegment](#blueye-protocol-PathSegment) | Calculated path segments from the reference generator (optional) |
+| total_distance | [ uint32](#uint32) | Total distance of the mission (m) (optional) |
+| total_duration_time | [ uint32](#uint32) | Total duration time of the mission (s) (optional) |
+| default_surge_speed | [ float](#float) | Default cruise speed of the mission (m/s) (optional) |
+| default_heave_speed | [ float](#float) | Default heave speed of the mission (m/s) (optional) |
+| default_circle_of_acceptance | [ float](#float) | Default circle of acceptance for waypoints (m) (optional) |
 
 <a name="blueye-protocol-MissionStatus"></a>
 
@@ -3032,22 +2660,17 @@ A list of waypoints describes a mission that the auto pilot can execute.
 Mission Status is used for showing the status of the mission.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| state | [MissionState](#blueye-protocol-MissionState) |  | State of the mission supervisor |
-| time_elapsed | [uint32](#uint32) |  | Time elapsed since mission started (s) |
-| estimated_time_to_complete | [uint32](#uint32) |  | Estimated time to complete the mission (s) |
-| distance_to_complete | [uint32](#uint32) |  | Distance left of the mission (m) |
-| completed_instruction_ids | [uint32](#uint32) | repeated | Ids of the completed instructions |
-| total_number_of_instructions | [uint32](#uint32) |  | Total number of instructions in the mission |
-| completed_path_segment_ids | [uint32](#uint32) | repeated | Ids of the completed path segments |
-| total_number_of_path_segments | [uint32](#uint32) |  | Total number of path segments in the mission |
-| id | [uint32](#uint32) |  | Mission id of the active mission |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| state | [ MissionState](#blueye-protocol-MissionState) | State of the mission supervisor |
+| time_elapsed | [ uint32](#uint32) | Time elapsed since mission started (s) |
+| estimated_time_to_complete | [ uint32](#uint32) | Estimated time to complete the mission (s) |
+| distance_to_complete | [ uint32](#uint32) | Distance left of the mission (m) |
+| completed_instruction_ids | [repeated uint32](#uint32) | Ids of the completed instructions |
+| total_number_of_instructions | [ uint32](#uint32) | Total number of instructions in the mission |
+| completed_path_segment_ids | [repeated uint32](#uint32) | Ids of the completed path segments |
+| total_number_of_path_segments | [ uint32](#uint32) | Total number of path segments in the mission |
+| id | [ uint32](#uint32) | Mission id of the active mission |
 
 <a name="blueye-protocol-PathSegment"></a>
 
@@ -3055,22 +2678,17 @@ Mission Status is used for showing the status of the mission.
 Path segment used to describe segments of a mission as a line between to waypoints.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [uint32](#uint32) |  | Path segment id starting at 0, -1 for inactive |
-| speed_to_target | [float](#float) |  | Desired speed over ground in (m/s) |
-| course_to_target | [float](#float) |  | Course to target relative to north (rad) [-pi, pi] |
-| depth_speed | [float](#float) |  | Desired speed in heave (m/s) |
-| horizontal_length | [float](#float) |  | Horizontal length of the path segment (m) |
-| vertical_length | [float](#float) |  | Vertical legth of the path segment (m) |
-| from_wp_id | [uint32](#uint32) |  | Id of the starting waypoint |
-| to_wp_id | [uint32](#uint32) |  | Id of the ending waypoint |
-| duration_time | [float](#float) |  | Estmated time it takes to complete given legth and desired speed (s) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| id | [ uint32](#uint32) | Path segment id starting at 0, -1 for inactive |
+| speed_to_target | [ float](#float) | Desired speed over ground in (m/s) |
+| course_to_target | [ float](#float) | Course to target relative to north (rad) [-pi, pi] |
+| depth_speed | [ float](#float) | Desired speed in heave (m/s) |
+| horizontal_length | [ float](#float) | Horizontal length of the path segment (m) |
+| vertical_length | [ float](#float) | Vertical length of the path segment (m) |
+| from_wp_id | [ uint32](#uint32) | Id of the starting waypoint |
+| to_wp_id | [ uint32](#uint32) | Id of the ending waypoint |
+| duration_time | [ float](#float) | Estimated time it takes to complete given length and desired speed (s) |
 
 <a name="blueye-protocol-ReferenceAutoPilot"></a>
 
@@ -3078,25 +2696,20 @@ Path segment used to describe segments of a mission as a line between to waypoin
 Reference for the auto pilot when a mission is active.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| instruction_type | [InstructionType](#blueye-protocol-InstructionType) |  | Instruction type |
-| active_instruction_id | [uint32](#uint32) |  | Id of the active instruction |
-| active_path_segment_id | [uint32](#uint32) |  | Id of the active path segment |
-| course_to_target | [float](#float) |  | Course to the next waypoint from north (rad) [-pi, pi] |
-| speed_over_ground | [float](#float) |  | Desired speed over ground (m/s) |
-| horizontal_distance_to_target | [float](#float) |  | Horizontal distance to the next waypoint (m) |
-| circle_of_acceptance | [float](#float) |  | Circle of acceptance to mark waypoint as visited (m) |
-| depth_set_point | [float](#float) |  | Desired depth set point (m) |
-| heave_velocity | [float](#float) |  | Desired heave velocity (m/s) |
-| vertical_distance_to_target | [float](#float) |  | Vertical distance to the next waypoint (m) |
-| depth_zero_reference | [DepthZeroReference](#blueye-protocol-DepthZeroReference) |  | Indicates if depth is measured from the surface or seabed |
-| time_to_complete | [float](#float) |  | Estimated time to complete the instruction (s) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| instruction_type | [ InstructionType](#blueye-protocol-InstructionType) | Instruction type |
+| active_instruction_id | [ uint32](#uint32) | Id of the active instruction |
+| active_path_segment_id | [ uint32](#uint32) | Id of the active path segment |
+| course_to_target | [ float](#float) | Course to the next waypoint from north (rad) [-pi, pi] |
+| speed_over_ground | [ float](#float) | Desired speed over ground (m/s) |
+| horizontal_distance_to_target | [ float](#float) | Horizontal distance to the next waypoint (m) |
+| circle_of_acceptance | [ float](#float) | Circle of acceptance to mark waypoint as visited (m) |
+| depth_set_point | [ float](#float) | Desired depth set point (m) |
+| heave_velocity | [ float](#float) | Desired heave velocity (m/s) |
+| vertical_distance_to_target | [ float](#float) | Vertical distance to the next waypoint (m) |
+| depth_zero_reference | [ DepthZeroReference](#blueye-protocol-DepthZeroReference) | Indicates if depth is measured from the surface or seabed |
+| time_to_complete | [ float](#float) | Estimated time to complete the instruction (s) |
 
 <a name="blueye-protocol-TiltMainCameraCommand"></a>
 
@@ -3104,14 +2717,9 @@ Reference for the auto pilot when a mission is active.
 The TiltMainCameraCommand can set the desired camera tilt angle.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| tilt_angle | [TiltAngle](#blueye-protocol-TiltAngle) |  | Tilt angle of the camera (-30..30) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| tilt_angle | [ TiltAngle](#blueye-protocol-TiltAngle) | Tilt angle of the camera (-30..30) |
 
 <a name="blueye-protocol-TiltMultibeamCommand"></a>
 
@@ -3119,29 +2727,19 @@ The TiltMainCameraCommand can set the desired camera tilt angle.
 The TiltMultibeamCommand is used to set the tilt angle of the servo.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| multibeam_servo | [MultibeamServo](#blueye-protocol-MultibeamServo) |  | Tilt angle for the multibeam servo |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| multibeam_servo | [ MultibeamServo](#blueye-protocol-MultibeamServo) | Tilt angle for the multibeam servo |
 
 <a name="blueye-protocol-WaitForCommand"></a>
 
 ### WaitForCommand
-WaitForCommand is used to wait duringing a mission.
+WaitForCommand is used to wait during a mission.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| wait_for_seconds | [float](#float) |  | Wait for x seconds |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| wait_for_seconds | [ float](#float) | Wait for x seconds |
 
 <a name="blueye-protocol-Waypoint"></a>
 
@@ -3149,19 +2747,14 @@ WaitForCommand is used to wait duringing a mission.
 Waypoints used to describe a path for the auto pilot.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [uint32](#uint32) |  | Waypoint id |
-| name | [string](#string) |  | Waypoint name provided from the app |
-| global_position | [LatLongPosition](#blueye-protocol-LatLongPosition) |  | Position if the waypoint (decimal degrees) |
-| circle_of_acceptance | [float](#float) |  | Radius of the accepance circle around the waypoint (m) |
-| speed_to_target | [float](#float) |  | Desired speed over ground to waypoint (m/s) |
-| depth_set_point | [DepthSetPoint](#blueye-protocol-DepthSetPoint) |  | Depth set point (optional) |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| id | [ uint32](#uint32) | Waypoint id |
+| name | [ string](#string) | Waypoint name provided from the app |
+| global_position | [ LatLongPosition](#blueye-protocol-LatLongPosition) | Position if the waypoint (decimal degrees) |
+| circle_of_acceptance | [ float](#float) | Radius of the acceptance circle around the waypoint (m) |
+| speed_to_target | [ float](#float) | Desired speed over ground to waypoint (m/s) |
+| depth_set_point | [ DepthSetPoint](#blueye-protocol-DepthSetPoint) | Depth set point (optional) |
 
 <a name="blueye-protocol-WaypointCommand"></a>
 
@@ -3169,15 +2762,10 @@ Waypoints used to describe a path for the auto pilot.
 A WaypointCommand will request the drone to drive to a point automatically.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| waypoint | [Waypoint](#blueye-protocol-Waypoint) |  | Waypoint to go to |
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| waypoint | [ Waypoint](#blueye-protocol-Waypoint) | Waypoint to go to |
 
-
-
-
-
- 
 
 
 <a name="blueye-protocol-CameraAction"></a>
@@ -3279,16 +2867,9 @@ List of mission supervisor states.
 | MISSION_STATE_FAILED_TO_START_MISSION | 8 | Mission has failed to start |
 
 
- 
-
- 
-
- 
-
 
 
 <a name="req_rep-proto"></a>
-<p align="right"><a href="#top">Top</a></p>
 
 ## req_rep.proto
 Request reply
@@ -3305,16 +2886,11 @@ Contains information about which client is in control, and a list of
 all connected clients.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| client_id | [uint32](#uint32) |  | The assigned ID of this client. |
-| client_id_in_control | [uint32](#uint32) |  | The ID of the client in control of the drone. |
-| connected_clients | [ConnectedClient](#blueye-protocol-ConnectedClient) | repeated | List of connected clients. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| client_id | [ uint32](#uint32) | The assigned ID of this client. |
+| client_id_in_control | [ uint32](#uint32) | The ID of the client in control of the drone. |
+| connected_clients | [repeated ConnectedClient](#blueye-protocol-ConnectedClient) | List of connected clients. |
 
 <a name="blueye-protocol-ConnectClientReq"></a>
 
@@ -3322,14 +2898,9 @@ all connected clients.
 Connect a new client to the drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| client_info | [ClientInfo](#blueye-protocol-ClientInfo) |  | Information about the client connecting to the drone. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| client_info | [ ClientInfo](#blueye-protocol-ClientInfo) | Information about the client connecting to the drone. |
 
 <a name="blueye-protocol-DisconnectClientRep"></a>
 
@@ -3339,15 +2910,10 @@ Response after disconnecting a client from the drone.
 Contains information about which clients are connected and in control.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| client_id_in_control | [uint32](#uint32) |  | The ID of the client in control of the drone. |
-| connected_clients | [ConnectedClient](#blueye-protocol-ConnectedClient) | repeated | List of connected clients. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| client_id_in_control | [ uint32](#uint32) | The ID of the client in control of the drone. |
+| connected_clients | [repeated ConnectedClient](#blueye-protocol-ConnectedClient) | List of connected clients. |
 
 <a name="blueye-protocol-DisconnectClientReq"></a>
 
@@ -3359,14 +2925,9 @@ It allows clients to disconnect instantly, without waiting for a watchdog to
 clear the client in control, or promote a new client to be in control.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| client_id | [uint32](#uint32) |  | The assigned ID of the client to disconnect. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| client_id | [ uint32](#uint32) | The assigned ID of the client to disconnect. |
 
 <a name="blueye-protocol-GetBatteryRep"></a>
 
@@ -3374,14 +2935,9 @@ clear the client in control, or promote a new client to be in control.
 Response with essential battery information.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| battery | [Battery](#blueye-protocol-Battery) |  | Essential battery information. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| battery | [ Battery](#blueye-protocol-Battery) | Essential battery information. |
 
 <a name="blueye-protocol-GetBatteryReq"></a>
 
@@ -3392,24 +2948,15 @@ Can be used to instantly get battery information,
 instead of having to wait for the BatteryTel message to be received.
 
 
-
-
-
-
 <a name="blueye-protocol-GetCameraParametersRep"></a>
 
 ### GetCameraParametersRep
 Response with the currently set camera parameters.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| camera_parameters | [CameraParameters](#blueye-protocol-CameraParameters) |  | The currently set camera parameters. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| camera_parameters | [ CameraParameters](#blueye-protocol-CameraParameters) | The currently set camera parameters. |
 
 <a name="blueye-protocol-GetCameraParametersReq"></a>
 
@@ -3417,14 +2964,9 @@ Response with the currently set camera parameters.
 Request to get the currently set camera parameters.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| camera | [Camera](#blueye-protocol-Camera) |  | Which camera to read camera parameters from. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| camera | [ Camera](#blueye-protocol-Camera) | Which camera to read camera parameters from. |
 
 <a name="blueye-protocol-GetMissionRep"></a>
 
@@ -3432,23 +2974,14 @@ Request to get the currently set camera parameters.
 Get active mission response.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| mission | [Mission](#blueye-protocol-Mission) |  | active mission with waypoints |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| mission | [ Mission](#blueye-protocol-Mission) | active mission with waypoints |
 
 <a name="blueye-protocol-GetMissionReq"></a>
 
 ### GetMissionReq
 Service request to the reference_generator to get the active mission.
-
-
-
-
 
 
 <a name="blueye-protocol-GetOverlayParametersRep"></a>
@@ -3457,14 +2990,9 @@ Service request to the reference_generator to get the active mission.
 Response with the currently set video overlay parameters.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| overlay_parameters | [OverlayParameters](#blueye-protocol-OverlayParameters) |  | The currently set overlay parameters. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| overlay_parameters | [ OverlayParameters](#blueye-protocol-OverlayParameters) | The currently set overlay parameters. |
 
 <a name="blueye-protocol-GetOverlayParametersReq"></a>
 
@@ -3472,8 +3000,20 @@ Response with the currently set video overlay parameters.
 Request to get currently set video overlay parameters.
 
 
+<a name="blueye-protocol-GetPersistentStorageSettingsRep"></a>
+
+### GetPersistentStorageSettingsRep
+Response with the currently set persistent storage settings.
 
 
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| persistent_storage_settings | [ PersistentStorageSettings](#blueye-protocol-PersistentStorageSettings) | The currently set persistent storage settings. |
+
+<a name="blueye-protocol-GetPersistentStorageSettingsReq"></a>
+
+### GetPersistentStorageSettingsReq
+Request to get currently set persistent storage settings.
 
 
 <a name="blueye-protocol-GetTelemetryRep"></a>
@@ -3482,14 +3022,9 @@ Request to get currently set video overlay parameters.
 Response with latest telemetry
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| payload | [google.protobuf.Any](#google-protobuf-Any) |  | The latest telemetry data, empty if no data available. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| payload | [ google.protobuf.Any](#google-protobuf-Any) | The latest telemetry data, empty if no data available. |
 
 <a name="blueye-protocol-GetTelemetryReq"></a>
 
@@ -3497,23 +3032,14 @@ Response with latest telemetry
 Request to get latest telemetry data
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| message_type | [string](#string) |  | Message name, f. ex. &#34;AttitudeTel&#34; |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| message_type | [ string](#string) | Message name, f. ex. "AttitudeTel" |
 
 <a name="blueye-protocol-PingRep"></a>
 
 ### PingRep
 Response message from a PingReq request.
-
-
-
-
 
 
 <a name="blueye-protocol-PingReq"></a>
@@ -3524,18 +3050,10 @@ The simplest message to use to test request/reply communication with the drone.
 The drone replies with a PingRep message immediately after receiving the PingReq.
 
 
-
-
-
-
 <a name="blueye-protocol-SetCameraParametersRep"></a>
 
 ### SetCameraParametersRep
 Response after setting the camera parameters.
-
-
-
-
 
 
 <a name="blueye-protocol-SetCameraParametersReq"></a>
@@ -3544,23 +3062,14 @@ Response after setting the camera parameters.
 Request to set camera parameters.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| camera_parameters | [CameraParameters](#blueye-protocol-CameraParameters) |  | The camera parameters to apply. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| camera_parameters | [ CameraParameters](#blueye-protocol-CameraParameters) | The camera parameters to apply. |
 
 <a name="blueye-protocol-SetInstructionUpdateRep"></a>
 
 ### SetInstructionUpdateRep
 Response after updating an instruction in the current mission.
-
-
-
-
 
 
 <a name="blueye-protocol-SetInstructionUpdateReq"></a>
@@ -3569,23 +3078,14 @@ Response after updating an instruction in the current mission.
 Updates an instruction in current mission with a new instruction payload.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| instruction | [Instruction](#blueye-protocol-Instruction) |  | instruction that will replace the desired instruction |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| instruction | [ Instruction](#blueye-protocol-Instruction) | instruction that will replace the desired instruction |
 
 <a name="blueye-protocol-SetMissionRep"></a>
 
 ### SetMissionRep
 Response after setting a new mission.
-
-
-
-
 
 
 <a name="blueye-protocol-SetMissionReq"></a>
@@ -3594,23 +3094,14 @@ Response after setting a new mission.
 Issue a desired mission to the reference_generator.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| mission | [Mission](#blueye-protocol-Mission) |  | requested mission isseued to the reference generator |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| mission | [ Mission](#blueye-protocol-Mission) | requested mission issued to the reference generator |
 
 <a name="blueye-protocol-SetOverlayParametersRep"></a>
 
 ### SetOverlayParametersRep
 Response after setting video overlay parameters.
-
-
-
-
 
 
 <a name="blueye-protocol-SetOverlayParametersReq"></a>
@@ -3619,14 +3110,29 @@ Response after setting video overlay parameters.
 Request to set video overlay parameters.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| overlay_parameters | [OverlayParameters](#blueye-protocol-OverlayParameters) |  | The video overlay parameters to apply. |
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| overlay_parameters | [ OverlayParameters](#blueye-protocol-OverlayParameters) | The video overlay parameters to apply. |
+
+<a name="blueye-protocol-SetPersistentStorageSettingsRep"></a>
+
+### SetPersistentStorageSettingsRep
+Response after setting persistent storage settings.
 
 
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| success | [ bool](#bool) | If the persistent storage settings were set successfully. |
+
+<a name="blueye-protocol-SetPersistentStorageSettingsReq"></a>
+
+### SetPersistentStorageSettingsReq
+Request to set persistent storage settings.
 
 
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| persistent_storage_settings | [ PersistentStorageSettings](#blueye-protocol-PersistentStorageSettings) | The persistent storage settings to apply. |
 
 <a name="blueye-protocol-SetPubFrequencyRep"></a>
 
@@ -3634,14 +3140,9 @@ Request to set video overlay parameters.
 Response after updating publish frequency
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| success | [bool](#bool) |  | True if message name valid and frequency successfully updated. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| success | [ bool](#bool) | True if message name valid and frequency successfully updated. |
 
 <a name="blueye-protocol-SetPubFrequencyReq"></a>
 
@@ -3649,24 +3150,15 @@ Response after updating publish frequency
 Request to update the publish frequency
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| message_type | [string](#string) |  | Message name, f. ex. &#34;AttitudeTel&#34; |
-| frequency | [float](#float) |  | Publish frequency (max 100 Hz). |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| message_type | [ string](#string) | Message name, f. ex. "AttitudeTel" |
+| frequency | [ float](#float) | Publish frequency (max 100 Hz). |
 
 <a name="blueye-protocol-SetThicknessGaugeParametersRep"></a>
 
 ### SetThicknessGaugeParametersRep
-Response after setting thicknes gauge parameters.
-
-
-
-
+Response after setting thickness gauge parameters.
 
 
 <a name="blueye-protocol-SetThicknessGaugeParametersReq"></a>
@@ -3677,14 +3169,9 @@ Request to set parameters for ultrasonic thickness gauge.
 The sound velocity is used to calculate the thickness of the material being measured.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| sound_velocity | [uint32](#uint32) |  | Sound velocity in m/s |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| sound_velocity | [ uint32](#uint32) | Sound velocity in m/s |
 
 <a name="blueye-protocol-SyncTimeRep"></a>
 
@@ -3692,14 +3179,9 @@ The sound velocity is used to calculate the thickness of the material being meas
 Response after setting the system time on the drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| success | [bool](#bool) |  | If the time was set successfully. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| success | [ bool](#bool) | If the time was set successfully. |
 
 <a name="blueye-protocol-SyncTimeReq"></a>
 
@@ -3707,26 +3189,14 @@ Response after setting the system time on the drone.
 Request to set the system time on the drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| time | [SystemTime](#blueye-protocol-SystemTime) |  | The time to set on the drone. |
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| time | [ SystemTime](#blueye-protocol-SystemTime) | The time to set on the drone. |
 
-
-
-
-
- 
-
- 
-
- 
-
- 
 
 
 
 <a name="telemetry-proto"></a>
-<p align="right"><a href="#top">Top</a></p>
 
 ## telemetry.proto
 Telemetry
@@ -3740,29 +3210,19 @@ These messages define telemetry messages from the Blueye drone.
 Receive the current altitude of the drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| altitude | [Altitude](#blueye-protocol-Altitude) |  | The altitude of the drone. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| altitude | [ Altitude](#blueye-protocol-Altitude) | The altitude of the drone. |
 
 <a name="blueye-protocol-AquaTrollProbeMetadataTel"></a>
 
 ### AquaTrollProbeMetadataTel
-Metadata from the In-Situ Aqua Troll probe&#39;s common registers
+Metadata from the In-Situ Aqua Troll probe's common registers
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| probe | [AquaTrollProbeMetadata](#blueye-protocol-AquaTrollProbeMetadata) |  | AquaTroll message containing sensor array. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| probe | [ AquaTrollProbeMetadata](#blueye-protocol-AquaTrollProbeMetadata) | AquaTroll message containing sensor array. |
 
 <a name="blueye-protocol-AquaTrollSensorMetadataTel"></a>
 
@@ -3770,14 +3230,9 @@ Metadata from the In-Situ Aqua Troll probe&#39;s common registers
 Metadata from a single sensor from In-Situ Aqua Troll probe
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| sensors | [AquaTrollSensorMetadataArray](#blueye-protocol-AquaTrollSensorMetadataArray) |  | AquaTroll message containing sensor array. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| sensors | [ AquaTrollSensorMetadataArray](#blueye-protocol-AquaTrollSensorMetadataArray) | AquaTroll message containing sensor array. |
 
 <a name="blueye-protocol-AquaTrollSensorParametersTel"></a>
 
@@ -3785,14 +3240,9 @@ Metadata from a single sensor from In-Situ Aqua Troll probe
 Single sensor from In-Situ Aqua Troll probe
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| sensors | [AquaTrollSensorParametersArray](#blueye-protocol-AquaTrollSensorParametersArray) |  | AquaTroll message containing parameter array. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| sensors | [ AquaTrollSensorParametersArray](#blueye-protocol-AquaTrollSensorParametersArray) | AquaTroll message containing parameter array. |
 
 <a name="blueye-protocol-AttitudeTel"></a>
 
@@ -3800,14 +3250,9 @@ Single sensor from In-Situ Aqua Troll probe
 Receive the current attitude of the drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| attitude | [Attitude](#blueye-protocol-Attitude) |  | The attitude of the drone. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| attitude | [ Attitude](#blueye-protocol-Attitude) | The attitude of the drone. |
 
 <a name="blueye-protocol-BatteryBQ40Z50Tel"></a>
 
@@ -3816,14 +3261,9 @@ Receive detailed information about a battery using the
 BQ40Z50 battery management system.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| battery | [BatteryBQ40Z50](#blueye-protocol-BatteryBQ40Z50) |  | Detailed battery information. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| battery | [ BatteryBQ40Z50](#blueye-protocol-BatteryBQ40Z50) | Detailed battery information. |
 
 <a name="blueye-protocol-BatteryTel"></a>
 
@@ -3831,14 +3271,19 @@ BQ40Z50 battery management system.
 Receive essential information about the battery status.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| battery | [Battery](#blueye-protocol-Battery) |  | Essential battery information. |
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| battery | [ Battery](#blueye-protocol-Battery) | Essential battery information. |
+
+<a name="blueye-protocol-CPUInfoTel"></a>
+
+### CPUInfoTel
+Information about cpu and memory usage
 
 
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| cpu_info | [ CPUInfo](#blueye-protocol-CPUInfo) |  |
 
 <a name="blueye-protocol-CPUTemperatureTel"></a>
 
@@ -3846,14 +3291,9 @@ Receive essential information about the battery status.
 Drone CPU temperature
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| temperature | [CPUTemperature](#blueye-protocol-CPUTemperature) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| temperature | [ CPUTemperature](#blueye-protocol-CPUTemperature) |  |
 
 <a name="blueye-protocol-CalibratedImuTel"></a>
 
@@ -3861,29 +3301,19 @@ Drone CPU temperature
 Calibrated IMU data
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| imu | [Imu](#blueye-protocol-Imu) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| imu | [ Imu](#blueye-protocol-Imu) |  |
 
 <a name="blueye-protocol-CalibrationStateTel"></a>
 
 ### CalibrationStateTel
-Calibration state used for calibration rotine.
+Calibration state used for calibration routine.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| calibration_state | [CalibrationState](#blueye-protocol-CalibrationState) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| calibration_state | [ CalibrationState](#blueye-protocol-CalibrationState) |  |
 
 <a name="blueye-protocol-CanisterBottomHumidityTel"></a>
 
@@ -3891,14 +3321,9 @@ Calibration state used for calibration rotine.
 Receive humidity information from the bottom canister.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| humidity | [CanisterHumidity](#blueye-protocol-CanisterHumidity) |  | Humidity information |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| humidity | [ CanisterHumidity](#blueye-protocol-CanisterHumidity) | Humidity information |
 
 <a name="blueye-protocol-CanisterBottomTemperatureTel"></a>
 
@@ -3906,14 +3331,9 @@ Receive humidity information from the bottom canister.
 Receive temperature information from the bottom canister.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| temperature | [CanisterTemperature](#blueye-protocol-CanisterTemperature) |  | Temperature information. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| temperature | [ CanisterTemperature](#blueye-protocol-CanisterTemperature) | Temperature information. |
 
 <a name="blueye-protocol-CanisterTopHumidityTel"></a>
 
@@ -3921,14 +3341,9 @@ Receive temperature information from the bottom canister.
 Receive humidity information from the top canister.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| humidity | [CanisterHumidity](#blueye-protocol-CanisterHumidity) |  | Humidity information |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| humidity | [ CanisterHumidity](#blueye-protocol-CanisterHumidity) | Humidity information |
 
 <a name="blueye-protocol-CanisterTopTemperatureTel"></a>
 
@@ -3936,14 +3351,9 @@ Receive humidity information from the top canister.
 Receive temperature information from the top canister.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| temperature | [CanisterTemperature](#blueye-protocol-CanisterTemperature) |  | Temperature information. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| temperature | [ CanisterTemperature](#blueye-protocol-CanisterTemperature) | Temperature information. |
 
 <a name="blueye-protocol-ConnectedClientsTel"></a>
 
@@ -3951,15 +3361,10 @@ Receive temperature information from the top canister.
 List of connected clients telemetry message.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| client_id_in_control | [uint32](#uint32) |  | The client id of the client in control. |
-| connected_clients | [ConnectedClient](#blueye-protocol-ConnectedClient) | repeated | List of connected clients. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| client_id_in_control | [ uint32](#uint32) | The client id of the client in control. |
+| connected_clients | [repeated ConnectedClient](#blueye-protocol-ConnectedClient) | List of connected clients. |
 
 <a name="blueye-protocol-ControlForceTel"></a>
 
@@ -3967,14 +3372,9 @@ List of connected clients telemetry message.
 Control force in all directions.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| control_force | [ControlForce](#blueye-protocol-ControlForce) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| control_force | [ ControlForce](#blueye-protocol-ControlForce) |  |
 
 <a name="blueye-protocol-ControlModeTel"></a>
 
@@ -3982,14 +3382,9 @@ Control force in all directions.
 Receive the current state of the control system.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| state | [ControlMode](#blueye-protocol-ControlMode) |  | State of the control system. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| state | [ ControlMode](#blueye-protocol-ControlMode) | State of the control system. |
 
 <a name="blueye-protocol-ControllerHealthTel"></a>
 
@@ -3997,14 +3392,9 @@ Receive the current state of the control system.
 Controller health indicating the load of the controller, used to set a color in the heading and depth bar.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| controller_health | [ControllerHealth](#blueye-protocol-ControllerHealth) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| controller_health | [ ControllerHealth](#blueye-protocol-ControllerHealth) |  |
 
 <a name="blueye-protocol-CpProbeTel"></a>
 
@@ -4012,14 +3402,9 @@ Controller health indicating the load of the controller, used to set a color in 
 Cathodic Protection Potential probe telemetry message
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| cp_probe | [CpProbe](#blueye-protocol-CpProbe) |  | Reading from cp probe. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| cp_probe | [ CpProbe](#blueye-protocol-CpProbe) | Reading from cp probe. |
 
 <a name="blueye-protocol-DataStorageSpaceTel"></a>
 
@@ -4027,14 +3412,9 @@ Cathodic Protection Potential probe telemetry message
 Data storage info.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| storage_space | [StorageSpace](#blueye-protocol-StorageSpace) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| storage_space | [ StorageSpace](#blueye-protocol-StorageSpace) |  |
 
 <a name="blueye-protocol-DepthTel"></a>
 
@@ -4042,14 +3422,9 @@ Data storage info.
 Measurement of the drones position relative to the sea surface.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| depth | [Depth](#blueye-protocol-Depth) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| depth | [ Depth](#blueye-protocol-Depth) |  |
 
 <a name="blueye-protocol-DiveTimeTel"></a>
 
@@ -4057,14 +3432,9 @@ Measurement of the drones position relative to the sea surface.
 Receive the dive time of the drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| dive_time | [DiveTime](#blueye-protocol-DiveTime) |  | The current dive time of the drone. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| dive_time | [ DiveTime](#blueye-protocol-DiveTime) | The current dive time of the drone. |
 
 <a name="blueye-protocol-DroneInfoTel"></a>
 
@@ -4072,14 +3442,9 @@ Receive the dive time of the drone.
 Receive metadata and information about the connected drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| drone_info | [DroneInfo](#blueye-protocol-DroneInfo) |  | Various metadata such as software versions and serial number. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| drone_info | [ DroneInfo](#blueye-protocol-DroneInfo) | Various metadata such as software versions and serial number. |
 
 <a name="blueye-protocol-DroneTimeTel"></a>
 
@@ -4087,15 +3452,20 @@ Receive metadata and information about the connected drone.
 Receive time information from the drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| real_time_clock | [SystemTime](#blueye-protocol-SystemTime) |  | The real-time clock of the drone. |
-| monotonic_clock | [SystemTime](#blueye-protocol-SystemTime) |  | The monotonic clock of the drone (time since power on). |
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| real_time_clock | [ SystemTime](#blueye-protocol-SystemTime) | The real-time clock of the drone. |
+| monotonic_clock | [ SystemTime](#blueye-protocol-SystemTime) | The monotonic clock of the drone (time since power on). |
+
+<a name="blueye-protocol-DvlVelocityTel"></a>
+
+### DvlVelocityTel
+Dvl raw sensor data.
 
 
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| dvl_velocity | [ DvlVelocity](#blueye-protocol-DvlVelocity) | Dvl velocity data. |
 
 <a name="blueye-protocol-ErrorFlagsTel"></a>
 
@@ -4103,14 +3473,9 @@ Receive time information from the drone.
 Receive currently set error flags.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| error_flags | [ErrorFlags](#blueye-protocol-ErrorFlags) |  | Currently set error flags on the drone. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| error_flags | [ ErrorFlags](#blueye-protocol-ErrorFlags) | Currently set error flags on the drone. |
 
 <a name="blueye-protocol-ForwardDistanceTel"></a>
 
@@ -4118,14 +3483,9 @@ Receive currently set error flags.
 Distance to an object in front of the drone when a 1D pinger is mounted forwards.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| forward_distance | [ForwardDistance](#blueye-protocol-ForwardDistance) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| forward_distance | [ ForwardDistance](#blueye-protocol-ForwardDistance) |  |
 
 <a name="blueye-protocol-GenericServoTel"></a>
 
@@ -4133,14 +3493,9 @@ Distance to an object in front of the drone when a 1D pinger is mounted forwards
 State of a generic servo
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| servo | [GenericServo](#blueye-protocol-GenericServo) |  | Servo state |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| servo | [ GenericServo](#blueye-protocol-GenericServo) | Servo state |
 
 <a name="blueye-protocol-GuestPortCurrentTel"></a>
 
@@ -4148,14 +3503,9 @@ State of a generic servo
 GuestPort current readings
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| current | [GuestPortCurrent](#blueye-protocol-GuestPortCurrent) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| current | [ GuestPortCurrent](#blueye-protocol-GuestPortCurrent) |  |
 
 <a name="blueye-protocol-GuestPortLightsTel"></a>
 
@@ -4163,14 +3513,9 @@ GuestPort current readings
 Receive the status of any guest port lights connected to the drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| lights | [Lights](#blueye-protocol-Lights) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| lights | [ Lights](#blueye-protocol-Lights) |  |
 
 <a name="blueye-protocol-Imu1Tel"></a>
 
@@ -4178,14 +3523,9 @@ Receive the status of any guest port lights connected to the drone.
 Raw IMU data from IMU 1
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| imu | [Imu](#blueye-protocol-Imu) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| imu | [ Imu](#blueye-protocol-Imu) |  |
 
 <a name="blueye-protocol-Imu2Tel"></a>
 
@@ -4193,14 +3533,9 @@ Raw IMU data from IMU 1
 Raw IMU data from IMU 2
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| imu | [Imu](#blueye-protocol-Imu) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| imu | [ Imu](#blueye-protocol-Imu) |  |
 
 <a name="blueye-protocol-IperfTel"></a>
 
@@ -4208,14 +3543,9 @@ Raw IMU data from IMU 2
 Iperf indicates the available bandwidth on the tether from drone to surface unit.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| status | [IperfStatus](#blueye-protocol-IperfStatus) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| status | [ IperfStatus](#blueye-protocol-IperfStatus) |  |
 
 <a name="blueye-protocol-LaserTel"></a>
 
@@ -4223,14 +3553,9 @@ Iperf indicates the available bandwidth on the tether from drone to surface unit
 Receive the status of any lasers connected to the drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| laser | [Laser](#blueye-protocol-Laser) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| laser | [ Laser](#blueye-protocol-Laser) |  |
 
 <a name="blueye-protocol-LightsTel"></a>
 
@@ -4238,14 +3563,9 @@ Receive the status of any lasers connected to the drone.
 Receive the status of the main lights of the drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| lights | [Lights](#blueye-protocol-Lights) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| lights | [ Lights](#blueye-protocol-Lights) |  |
 
 <a name="blueye-protocol-MedusaSpectrometerDataTel"></a>
 
@@ -4253,14 +3573,9 @@ Receive the status of the main lights of the drone.
 Medusa gamma ray sensor spectrometer data
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| data | [MedusaSpectrometerData](#blueye-protocol-MedusaSpectrometerData) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| data | [ MedusaSpectrometerData](#blueye-protocol-MedusaSpectrometerData) |  |
 
 <a name="blueye-protocol-MissionStatusTel"></a>
 
@@ -4268,14 +3583,39 @@ Medusa gamma ray sensor spectrometer data
 Mission status from the mission supervisor.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| mission_status | [MissionStatus](#blueye-protocol-MissionStatus) |  |  |
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| mission_status | [ MissionStatus](#blueye-protocol-MissionStatus) |  |
+
+<a name="blueye-protocol-MultibeamConfigTel"></a>
+
+### MultibeamConfigTel
+Multibeam sonar config
 
 
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| config | [ MultibeamConfig](#blueye-protocol-MultibeamConfig) | Config data from a multibeam sonar |
+
+<a name="blueye-protocol-MultibeamDiscoveryTel"></a>
+
+### MultibeamDiscoveryTel
+Multibeam sonar status message
 
 
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| discovery | [ MultibeamDiscovery](#blueye-protocol-MultibeamDiscovery) | Discovery data from a multibeam sonar |
 
+<a name="blueye-protocol-MultibeamPingTel"></a>
+
+### MultibeamPingTel
+Multibeam sonar ping data
+
+
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| ping | [ MultibeamPing](#blueye-protocol-MultibeamPing) | Ping data from a multibeam sonar |
 
 <a name="blueye-protocol-MultibeamServoTel"></a>
 
@@ -4283,14 +3623,9 @@ Mission status from the mission supervisor.
 State of the servo installed in the multibeam
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| servo | [MultibeamServo](#blueye-protocol-MultibeamServo) |  | Multibeam servo state |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| servo | [ MultibeamServo](#blueye-protocol-MultibeamServo) | Multibeam servo state |
 
 <a name="blueye-protocol-NStreamersTel"></a>
 
@@ -4298,14 +3633,9 @@ State of the servo installed in the multibeam
 Number of connected clients streaming video.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| n_streamers | [NStreamers](#blueye-protocol-NStreamers) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| n_streamers | [ NStreamers](#blueye-protocol-NStreamers) |  |
 
 <a name="blueye-protocol-NotificationTel"></a>
 
@@ -4313,14 +3643,9 @@ Number of connected clients streaming video.
 Notification from the control system.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| notification | [Notification](#blueye-protocol-Notification) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| notification | [ Notification](#blueye-protocol-Notification) |  |
 
 <a name="blueye-protocol-PilotGPSPositionTel"></a>
 
@@ -4328,14 +3653,9 @@ Notification from the control system.
 Pilot position (originating from device GPS) for logging.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| position | [LatLongPosition](#blueye-protocol-LatLongPosition) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| position | [ LatLongPosition](#blueye-protocol-LatLongPosition) |  |
 
 <a name="blueye-protocol-PositionEstimateTel"></a>
 
@@ -4343,14 +3663,9 @@ Pilot position (originating from device GPS) for logging.
 Position estimate of the drone if a DVL or a positioning system is available.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| position_estimate | [PositionEstimate](#blueye-protocol-PositionEstimate) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| position_estimate | [ PositionEstimate](#blueye-protocol-PositionEstimate) |  |
 
 <a name="blueye-protocol-RecordStateTel"></a>
 
@@ -4358,14 +3673,9 @@ Position estimate of the drone if a DVL or a positioning system is available.
 Record state from the drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| record_state | [RecordState](#blueye-protocol-RecordState) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| record_state | [ RecordState](#blueye-protocol-RecordState) |  |
 
 <a name="blueye-protocol-ReferenceAutoPilotTel"></a>
 
@@ -4373,14 +3683,9 @@ Record state from the drone.
 Reference for the auto pilot when a mission is active.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| reference_auto_pilot | [ReferenceAutoPilot](#blueye-protocol-ReferenceAutoPilot) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| reference_auto_pilot | [ ReferenceAutoPilot](#blueye-protocol-ReferenceAutoPilot) |  |
 
 <a name="blueye-protocol-ReferenceTel"></a>
 
@@ -4388,14 +3693,9 @@ Reference for the auto pilot when a mission is active.
 Reference signals indicating desired states.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| reference | [Reference](#blueye-protocol-Reference) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| reference | [ Reference](#blueye-protocol-Reference) |  |
 
 <a name="blueye-protocol-ThicknessGaugeTel"></a>
 
@@ -4403,14 +3703,9 @@ Reference signals indicating desired states.
 Thickness gauge measurement telemetry message.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| thickness_gauge | [ThicknessGauge](#blueye-protocol-ThicknessGauge) |  | Tickness measurement with a cygnus gauge. |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| thickness_gauge | [ ThicknessGauge](#blueye-protocol-ThicknessGauge) | Thickness measurement with a cygnus gauge. |
 
 <a name="blueye-protocol-TiltAngleTel"></a>
 
@@ -4418,14 +3713,9 @@ Thickness gauge measurement telemetry message.
 Tilt angle state on main camera.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| angle | [TiltAngle](#blueye-protocol-TiltAngle) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| angle | [ TiltAngle](#blueye-protocol-TiltAngle) |  |
 
 <a name="blueye-protocol-TiltStabilizationTel"></a>
 
@@ -4433,14 +3723,9 @@ Tilt angle state on main camera.
 Tilt stabilization state.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| state | [TiltStabilizationState](#blueye-protocol-TiltStabilizationState) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| state | [ TiltStabilizationState](#blueye-protocol-TiltStabilizationState) |  |
 
 <a name="blueye-protocol-TimeLapseStateTel"></a>
 
@@ -4448,14 +3733,9 @@ Tilt stabilization state.
 Time-lapse state from the drone.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| time_lapse_state | [TimeLapseState](#blueye-protocol-TimeLapseState) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| time_lapse_state | [ TimeLapseState](#blueye-protocol-TimeLapseState) |  |
 
 <a name="blueye-protocol-VideoStorageSpaceTel"></a>
 
@@ -4463,36 +3743,20 @@ Time-lapse state from the drone.
 Video storage info.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| storage_space | [StorageSpace](#blueye-protocol-StorageSpace) |  |  |
-
-
-
-
-
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| storage_space | [ StorageSpace](#blueye-protocol-StorageSpace) |  |
 
 <a name="blueye-protocol-WaterTemperatureTel"></a>
 
 ### WaterTemperatureTel
-Water temerature from the depth sensor.
+Water temperature from the depth sensor.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| temperature | [WaterTemperature](#blueye-protocol-WaterTemperature) |  |  |
+| Field | Type | Description |
+| ------| ---- | ----------- |
+| temperature | [ WaterTemperature](#blueye-protocol-WaterTemperature) |  |
 
-
-
-
-
- 
-
- 
-
- 
-
- 
 
 
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -1,5 +1,5 @@
 ## Installation
-The SDK requires Python 3.9 or higher. Since many operating systems do not package the newest
+The SDK requires Python 3.10 or higher. Since many operating systems do not package the newest
 version of Python we recommend using [`pyenv`](https://github.com/pyenv/pyenv) or something similar
 for configuring multiple python versions on the same system. Pyenv also has the added benefit of
 managing your virtual environments for you, though you are of course free to use other tools for
@@ -10,7 +10,7 @@ The instructions below show the necessary steps to get started with the SDK on a
 ??? abstract "Windows"
     **Install Python**
 
-    Install Python 3.9 or higher, you can find the latest python versions [here](https://www.python.org/downloads/).
+    Install Python 3.10 or higher, you can find the latest python versions [here](https://www.python.org/downloads/).
     Remember to check the option "Add Python to path" when installing.
 
     **Install virtualenv for managing Python versions (optional)**

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,7 +7,7 @@ description = "A cross-platform package to replace curses (mouse/keyboard input 
 optional = true
 python-versions = ">= 3.8"
 groups = ["main"]
-markers = "extra == \"examples\""
+markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and extra == \"examples\""
 files = [
     {file = "asciimatics-1.15.0-py3-none-any.whl", hash = "sha256:0fe068a6bed522929bd04bb5b8a2fb6ebf0aef1b7a9b3843cf71030a34bc38d5"},
     {file = "asciimatics-1.15.0.tar.gz", hash = "sha256:cfdd398042727519d8b73e62b8ef82c0becfed4eb420899c3b96c98d0b96821a"},
@@ -26,6 +26,7 @@ description = "Internationalization utilities"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "babel-2.16.0-py3-none-any.whl", hash = "sha256:368b5b98b37c06b7daf6696391c3240c938b37767d4584413e8438c5c435fa8b"},
     {file = "babel-2.16.0.tar.gz", hash = "sha256:d1f3554ca26605fe173f3de0c65f750f5a42f924499bf134de6423582298e316"},
@@ -41,6 +42,7 @@ description = "The uncompromising code formatter."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "black-24.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6668650ea4b685440857138e5fe40cde4d652633b1bdffc62933d0db4ed9812"},
     {file = "black-24.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1c536fcf674217e87b8cc3657b81809d3c085d7bf3ef262ead700da345bfa6ea"},
@@ -83,20 +85,21 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "blueye-protocol"
-version = "2.6.0"
+version = "2.7.0"
 description = "Python protocol definition for the Blueye drones"
 optional = false
-python-versions = "<4.0,>=3.9"
+python-versions = "<4.0,>=3.10"
 groups = ["main"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "blueye_protocol-2.6.0-py3-none-any.whl", hash = "sha256:baa1b7f7584142bc92b95f58c38bd8e159c8b3c4ea0e143256ad5ebbc1a81eec"},
-    {file = "blueye_protocol-2.6.0.tar.gz", hash = "sha256:a53f4f635973c3eae3bea507d01998e345d4b7b6e0906ec4042eed8787a1fa93"},
+    {file = "blueye_protocol-2.7.0-py3-none-any.whl", hash = "sha256:f09ed7134b2616fed2a32e95e0441744f00be1513387bb7b48b217fb552fe938"},
+    {file = "blueye_protocol-2.7.0.tar.gz", hash = "sha256:29c05f9c9b7c0d92dd43076690bc9019f58377c50951162a8848bd9050501358"},
 ]
 
 [package.dependencies]
-numpy = {version = ">=1.26,<2.0", markers = "python_version >= \"3.9\" and python_version < \"3.13\""}
-proto-plus = ">=1.22.1,<2.0.0"
-setuptools = ">=40"
+numpy = ">=2.2,<3.0"
+proto-plus = ">=1.25,<2.0"
+setuptools = ">=75.8"
 
 [[package]]
 name = "certifi"
@@ -105,6 +108,7 @@ description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 groups = ["main", "dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "certifi-2024.12.14-py3-none-any.whl", hash = "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56"},
     {file = "certifi-2024.12.14.tar.gz", hash = "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"},
@@ -117,7 +121,7 @@ description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "implementation_name == \"pypy\""
+markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and implementation_name == \"pypy\""
 files = [
     {file = "cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14"},
     {file = "cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67"},
@@ -198,6 +202,7 @@ description = "Validate configuration and produce human readable error messages.
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9"},
     {file = "cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560"},
@@ -210,6 +215,7 @@ description = "The Real First Universal Charset Detector. Open, modern and activ
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "charset_normalizer-3.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:91b36a978b5ae0ee86c394f5a54d6ef44db1de0815eb43de826d41d21e4af3de"},
     {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7461baadb4dc00fd9e0acbe254e3d7d2112e7f92ced2adc96e54ef6501c5f176"},
@@ -312,6 +318,7 @@ description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
     {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
@@ -327,6 +334,7 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -334,78 +342,67 @@ files = [
 
 [[package]]
 name = "contourpy"
-version = "1.3.0"
+version = "1.3.1"
 description = "Python library for calculating contours of 2D quadrilateral grids"
 optional = true
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"examples\""
+markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and extra == \"examples\""
 files = [
-    {file = "contourpy-1.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:880ea32e5c774634f9fcd46504bf9f080a41ad855f4fef54f5380f5133d343c7"},
-    {file = "contourpy-1.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:76c905ef940a4474a6289c71d53122a4f77766eef23c03cd57016ce19d0f7b42"},
-    {file = "contourpy-1.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:92f8557cbb07415a4d6fa191f20fd9d2d9eb9c0b61d1b2f52a8926e43c6e9af7"},
-    {file = "contourpy-1.3.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:36f965570cff02b874773c49bfe85562b47030805d7d8360748f3eca570f4cab"},
-    {file = "contourpy-1.3.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cacd81e2d4b6f89c9f8a5b69b86490152ff39afc58a95af002a398273e5ce589"},
-    {file = "contourpy-1.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:69375194457ad0fad3a839b9e29aa0b0ed53bb54db1bfb6c3ae43d111c31ce41"},
-    {file = "contourpy-1.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7a52040312b1a858b5e31ef28c2e865376a386c60c0e248370bbea2d3f3b760d"},
-    {file = "contourpy-1.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3faeb2998e4fcb256542e8a926d08da08977f7f5e62cf733f3c211c2a5586223"},
-    {file = "contourpy-1.3.0-cp310-cp310-win32.whl", hash = "sha256:36e0cff201bcb17a0a8ecc7f454fe078437fa6bda730e695a92f2d9932bd507f"},
-    {file = "contourpy-1.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:87ddffef1dbe5e669b5c2440b643d3fdd8622a348fe1983fad7a0f0ccb1cd67b"},
-    {file = "contourpy-1.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0fa4c02abe6c446ba70d96ece336e621efa4aecae43eaa9b030ae5fb92b309ad"},
-    {file = "contourpy-1.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:834e0cfe17ba12f79963861e0f908556b2cedd52e1f75e6578801febcc6a9f49"},
-    {file = "contourpy-1.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dbc4c3217eee163fa3984fd1567632b48d6dfd29216da3ded3d7b844a8014a66"},
-    {file = "contourpy-1.3.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4865cd1d419e0c7a7bf6de1777b185eebdc51470800a9f42b9e9decf17762081"},
-    {file = "contourpy-1.3.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:303c252947ab4b14c08afeb52375b26781ccd6a5ccd81abcdfc1fafd14cf93c1"},
-    {file = "contourpy-1.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:637f674226be46f6ba372fd29d9523dd977a291f66ab2a74fbeb5530bb3f445d"},
-    {file = "contourpy-1.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:76a896b2f195b57db25d6b44e7e03f221d32fe318d03ede41f8b4d9ba1bff53c"},
-    {file = "contourpy-1.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e1fd23e9d01591bab45546c089ae89d926917a66dceb3abcf01f6105d927e2cb"},
-    {file = "contourpy-1.3.0-cp311-cp311-win32.whl", hash = "sha256:d402880b84df3bec6eab53cd0cf802cae6a2ef9537e70cf75e91618a3801c20c"},
-    {file = "contourpy-1.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:6cb6cc968059db9c62cb35fbf70248f40994dfcd7aa10444bbf8b3faeb7c2d67"},
-    {file = "contourpy-1.3.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:570ef7cf892f0afbe5b2ee410c507ce12e15a5fa91017a0009f79f7d93a1268f"},
-    {file = "contourpy-1.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:da84c537cb8b97d153e9fb208c221c45605f73147bd4cadd23bdae915042aad6"},
-    {file = "contourpy-1.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0be4d8425bfa755e0fd76ee1e019636ccc7c29f77a7c86b4328a9eb6a26d0639"},
-    {file = "contourpy-1.3.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9c0da700bf58f6e0b65312d0a5e695179a71d0163957fa381bb3c1f72972537c"},
-    {file = "contourpy-1.3.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eb8b141bb00fa977d9122636b16aa67d37fd40a3d8b52dd837e536d64b9a4d06"},
-    {file = "contourpy-1.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3634b5385c6716c258d0419c46d05c8aa7dc8cb70326c9a4fb66b69ad2b52e09"},
-    {file = "contourpy-1.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0dce35502151b6bd35027ac39ba6e5a44be13a68f55735c3612c568cac3805fd"},
-    {file = "contourpy-1.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aea348f053c645100612b333adc5983d87be69acdc6d77d3169c090d3b01dc35"},
-    {file = "contourpy-1.3.0-cp312-cp312-win32.whl", hash = "sha256:90f73a5116ad1ba7174341ef3ea5c3150ddf20b024b98fb0c3b29034752c8aeb"},
-    {file = "contourpy-1.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b11b39aea6be6764f84360fce6c82211a9db32a7c7de8fa6dd5397cf1d079c3b"},
-    {file = "contourpy-1.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3e1c7fa44aaae40a2247e2e8e0627f4bea3dd257014764aa644f319a5f8600e3"},
-    {file = "contourpy-1.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:364174c2a76057feef647c802652f00953b575723062560498dc7930fc9b1cb7"},
-    {file = "contourpy-1.3.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32b238b3b3b649e09ce9aaf51f0c261d38644bdfa35cbaf7b263457850957a84"},
-    {file = "contourpy-1.3.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d51fca85f9f7ad0b65b4b9fe800406d0d77017d7270d31ec3fb1cc07358fdea0"},
-    {file = "contourpy-1.3.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:732896af21716b29ab3e988d4ce14bc5133733b85956316fb0c56355f398099b"},
-    {file = "contourpy-1.3.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d73f659398a0904e125280836ae6f88ba9b178b2fed6884f3b1f95b989d2c8da"},
-    {file = "contourpy-1.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c6c7c2408b7048082932cf4e641fa3b8ca848259212f51c8c59c45aa7ac18f14"},
-    {file = "contourpy-1.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f317576606de89da6b7e0861cf6061f6146ead3528acabff9236458a6ba467f8"},
-    {file = "contourpy-1.3.0-cp313-cp313-win32.whl", hash = "sha256:31cd3a85dbdf1fc002280c65caa7e2b5f65e4a973fcdf70dd2fdcb9868069294"},
-    {file = "contourpy-1.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:4553c421929ec95fb07b3aaca0fae668b2eb5a5203d1217ca7c34c063c53d087"},
-    {file = "contourpy-1.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:345af746d7766821d05d72cb8f3845dfd08dd137101a2cb9b24de277d716def8"},
-    {file = "contourpy-1.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3bb3808858a9dc68f6f03d319acd5f1b8a337e6cdda197f02f4b8ff67ad2057b"},
-    {file = "contourpy-1.3.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:420d39daa61aab1221567b42eecb01112908b2cab7f1b4106a52caaec8d36973"},
-    {file = "contourpy-1.3.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4d63ee447261e963af02642ffcb864e5a2ee4cbfd78080657a9880b8b1868e18"},
-    {file = "contourpy-1.3.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:167d6c890815e1dac9536dca00828b445d5d0df4d6a8c6adb4a7ec3166812fa8"},
-    {file = "contourpy-1.3.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:710a26b3dc80c0e4febf04555de66f5fd17e9cf7170a7b08000601a10570bda6"},
-    {file = "contourpy-1.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:75ee7cb1a14c617f34a51d11fa7524173e56551646828353c4af859c56b766e2"},
-    {file = "contourpy-1.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:33c92cdae89ec5135d036e7218e69b0bb2851206077251f04a6c4e0e21f03927"},
-    {file = "contourpy-1.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a11077e395f67ffc2c44ec2418cfebed032cd6da3022a94fc227b6faf8e2acb8"},
-    {file = "contourpy-1.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e8134301d7e204c88ed7ab50028ba06c683000040ede1d617298611f9dc6240c"},
-    {file = "contourpy-1.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e12968fdfd5bb45ffdf6192a590bd8ddd3ba9e58360b29683c6bb71a7b41edca"},
-    {file = "contourpy-1.3.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fd2a0fc506eccaaa7595b7e1418951f213cf8255be2600f1ea1b61e46a60c55f"},
-    {file = "contourpy-1.3.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4cfb5c62ce023dfc410d6059c936dcf96442ba40814aefbfa575425a3a7f19dc"},
-    {file = "contourpy-1.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:68a32389b06b82c2fdd68276148d7b9275b5f5cf13e5417e4252f6d1a34f72a2"},
-    {file = "contourpy-1.3.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:94e848a6b83da10898cbf1311a815f770acc9b6a3f2d646f330d57eb4e87592e"},
-    {file = "contourpy-1.3.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:d78ab28a03c854a873787a0a42254a0ccb3cb133c672f645c9f9c8f3ae9d0800"},
-    {file = "contourpy-1.3.0-cp39-cp39-win32.whl", hash = "sha256:81cb5ed4952aae6014bc9d0421dec7c5835c9c8c31cdf51910b708f548cf58e5"},
-    {file = "contourpy-1.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:14e262f67bd7e6eb6880bc564dcda30b15e351a594657e55b7eec94b6ef72843"},
-    {file = "contourpy-1.3.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:fe41b41505a5a33aeaed2a613dccaeaa74e0e3ead6dd6fd3a118fb471644fd6c"},
-    {file = "contourpy-1.3.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eca7e17a65f72a5133bdbec9ecf22401c62bcf4821361ef7811faee695799779"},
-    {file = "contourpy-1.3.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:1ec4dc6bf570f5b22ed0d7efba0dfa9c5b9e0431aeea7581aa217542d9e809a4"},
-    {file = "contourpy-1.3.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:00ccd0dbaad6d804ab259820fa7cb0b8036bda0686ef844d24125d8287178ce0"},
-    {file = "contourpy-1.3.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ca947601224119117f7c19c9cdf6b3ab54c5726ef1d906aa4a69dfb6dd58102"},
-    {file = "contourpy-1.3.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:c6ec93afeb848a0845a18989da3beca3eec2c0f852322efe21af1931147d12cb"},
-    {file = "contourpy-1.3.0.tar.gz", hash = "sha256:7ffa0db17717a8ffb127efd0c95a4362d996b892c2904db72428d5b52e1938a4"},
+    {file = "contourpy-1.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a045f341a77b77e1c5de31e74e966537bba9f3c4099b35bf4c2e3939dd54cdab"},
+    {file = "contourpy-1.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:500360b77259914f7805af7462e41f9cb7ca92ad38e9f94d6c8641b089338124"},
+    {file = "contourpy-1.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2f926efda994cdf3c8d3fdb40b9962f86edbc4457e739277b961eced3d0b4c1"},
+    {file = "contourpy-1.3.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:adce39d67c0edf383647a3a007de0a45fd1b08dedaa5318404f1a73059c2512b"},
+    {file = "contourpy-1.3.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:abbb49fb7dac584e5abc6636b7b2a7227111c4f771005853e7d25176daaf8453"},
+    {file = "contourpy-1.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0cffcbede75c059f535725c1680dfb17b6ba8753f0c74b14e6a9c68c29d7ea3"},
+    {file = "contourpy-1.3.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ab29962927945d89d9b293eabd0d59aea28d887d4f3be6c22deaefbb938a7277"},
+    {file = "contourpy-1.3.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:974d8145f8ca354498005b5b981165b74a195abfae9a8129df3e56771961d595"},
+    {file = "contourpy-1.3.1-cp310-cp310-win32.whl", hash = "sha256:ac4578ac281983f63b400f7fe6c101bedc10651650eef012be1ccffcbacf3697"},
+    {file = "contourpy-1.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:174e758c66bbc1c8576992cec9599ce8b6672b741b5d336b5c74e35ac382b18e"},
+    {file = "contourpy-1.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3e8b974d8db2c5610fb4e76307e265de0edb655ae8169e8b21f41807ccbeec4b"},
+    {file = "contourpy-1.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:20914c8c973f41456337652a6eeca26d2148aa96dd7ac323b74516988bea89fc"},
+    {file = "contourpy-1.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19d40d37c1c3a4961b4619dd9d77b12124a453cc3d02bb31a07d58ef684d3d86"},
+    {file = "contourpy-1.3.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:113231fe3825ebf6f15eaa8bc1f5b0ddc19d42b733345eae0934cb291beb88b6"},
+    {file = "contourpy-1.3.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4dbbc03a40f916a8420e420d63e96a1258d3d1b58cbdfd8d1f07b49fcbd38e85"},
+    {file = "contourpy-1.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a04ecd68acbd77fa2d39723ceca4c3197cb2969633836ced1bea14e219d077c"},
+    {file = "contourpy-1.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c414fc1ed8ee1dbd5da626cf3710c6013d3d27456651d156711fa24f24bd1291"},
+    {file = "contourpy-1.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:31c1b55c1f34f80557d3830d3dd93ba722ce7e33a0b472cba0ec3b6535684d8f"},
+    {file = "contourpy-1.3.1-cp311-cp311-win32.whl", hash = "sha256:f611e628ef06670df83fce17805c344710ca5cde01edfdc72751311da8585375"},
+    {file = "contourpy-1.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:b2bdca22a27e35f16794cf585832e542123296b4687f9fd96822db6bae17bfc9"},
+    {file = "contourpy-1.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0ffa84be8e0bd33410b17189f7164c3589c229ce5db85798076a3fa136d0e509"},
+    {file = "contourpy-1.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:805617228ba7e2cbbfb6c503858e626ab528ac2a32a04a2fe88ffaf6b02c32bc"},
+    {file = "contourpy-1.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ade08d343436a94e633db932e7e8407fe7de8083967962b46bdfc1b0ced39454"},
+    {file = "contourpy-1.3.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:47734d7073fb4590b4a40122b35917cd77be5722d80683b249dac1de266aac80"},
+    {file = "contourpy-1.3.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2ba94a401342fc0f8b948e57d977557fbf4d515f03c67682dd5c6191cb2d16ec"},
+    {file = "contourpy-1.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:efa874e87e4a647fd2e4f514d5e91c7d493697127beb95e77d2f7561f6905bd9"},
+    {file = "contourpy-1.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1bf98051f1045b15c87868dbaea84f92408337d4f81d0e449ee41920ea121d3b"},
+    {file = "contourpy-1.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:61332c87493b00091423e747ea78200659dc09bdf7fd69edd5e98cef5d3e9a8d"},
+    {file = "contourpy-1.3.1-cp312-cp312-win32.whl", hash = "sha256:e914a8cb05ce5c809dd0fe350cfbb4e881bde5e2a38dc04e3afe1b3e58bd158e"},
+    {file = "contourpy-1.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:08d9d449a61cf53033612cb368f3a1b26cd7835d9b8cd326647efe43bca7568d"},
+    {file = "contourpy-1.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a761d9ccfc5e2ecd1bf05534eda382aa14c3e4f9205ba5b1684ecfe400716ef2"},
+    {file = "contourpy-1.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:523a8ee12edfa36f6d2a49407f705a6ef4c5098de4f498619787e272de93f2d5"},
+    {file = "contourpy-1.3.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece6df05e2c41bd46776fbc712e0996f7c94e0d0543af1656956d150c4ca7c81"},
+    {file = "contourpy-1.3.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:573abb30e0e05bf31ed067d2f82500ecfdaec15627a59d63ea2d95714790f5c2"},
+    {file = "contourpy-1.3.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a9fa36448e6a3a1a9a2ba23c02012c43ed88905ec80163f2ffe2421c7192a5d7"},
+    {file = "contourpy-1.3.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ea9924d28fc5586bf0b42d15f590b10c224117e74409dd7a0be3b62b74a501c"},
+    {file = "contourpy-1.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5b75aa69cb4d6f137b36f7eb2ace9280cfb60c55dc5f61c731fdf6f037f958a3"},
+    {file = "contourpy-1.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:041b640d4ec01922083645a94bb3b2e777e6b626788f4095cf21abbe266413c1"},
+    {file = "contourpy-1.3.1-cp313-cp313-win32.whl", hash = "sha256:36987a15e8ace5f58d4d5da9dca82d498c2bbb28dff6e5d04fbfcc35a9cb3a82"},
+    {file = "contourpy-1.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:a7895f46d47671fa7ceec40f31fae721da51ad34bdca0bee83e38870b1f47ffd"},
+    {file = "contourpy-1.3.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9ddeb796389dadcd884c7eb07bd14ef12408aaae358f0e2ae24114d797eede30"},
+    {file = "contourpy-1.3.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:19c1555a6801c2f084c7ddc1c6e11f02eb6a6016ca1318dd5452ba3f613a1751"},
+    {file = "contourpy-1.3.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:841ad858cff65c2c04bf93875e384ccb82b654574a6d7f30453a04f04af71342"},
+    {file = "contourpy-1.3.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4318af1c925fb9a4fb190559ef3eec206845f63e80fb603d47f2d6d67683901c"},
+    {file = "contourpy-1.3.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:14c102b0eab282427b662cb590f2e9340a9d91a1c297f48729431f2dcd16e14f"},
+    {file = "contourpy-1.3.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:05e806338bfeaa006acbdeba0ad681a10be63b26e1b17317bfac3c5d98f36cda"},
+    {file = "contourpy-1.3.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4d76d5993a34ef3df5181ba3c92fabb93f1eaa5729504fb03423fcd9f3177242"},
+    {file = "contourpy-1.3.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:89785bb2a1980c1bd87f0cb1517a71cde374776a5f150936b82580ae6ead44a1"},
+    {file = "contourpy-1.3.1-cp313-cp313t-win32.whl", hash = "sha256:8eb96e79b9f3dcadbad2a3891672f81cdcab7f95b27f28f1c67d75f045b6b4f1"},
+    {file = "contourpy-1.3.1-cp313-cp313t-win_amd64.whl", hash = "sha256:287ccc248c9e0d0566934e7d606201abd74761b5703d804ff3df8935f523d546"},
+    {file = "contourpy-1.3.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:b457d6430833cee8e4b8e9b6f07aa1c161e5e0d52e118dc102c8f9bd7dd060d6"},
+    {file = "contourpy-1.3.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb76c1a154b83991a3cbbf0dfeb26ec2833ad56f95540b442c73950af2013750"},
+    {file = "contourpy-1.3.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:44a29502ca9c7b5ba389e620d44f2fbe792b1fb5734e8b931ad307071ec58c53"},
+    {file = "contourpy-1.3.1.tar.gz", hash = "sha256:dfd97abd83335045a913e3bcc4a09c0ceadbe66580cf573fe961f4a825efa699"},
 ]
 
 [package.dependencies]
@@ -425,6 +422,7 @@ description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "coverage-7.6.10-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5c912978f7fbf47ef99cec50c4401340436d200d41d714c7a4766f377c5b7b78"},
     {file = "coverage-7.6.10-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a01ec4af7dfeb96ff0078ad9a48810bb0cc8abcb0115180c6013a6b26237626c"},
@@ -503,7 +501,7 @@ description = "Composable style cycles"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"examples\""
+markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and extra == \"examples\""
 files = [
     {file = "cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30"},
     {file = "cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c"},
@@ -520,6 +518,7 @@ description = "Distribution utilities"
 optional = false
 python-versions = "*"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87"},
     {file = "distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403"},
@@ -548,6 +547,7 @@ description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0"},
     {file = "filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435"},
@@ -565,7 +565,7 @@ description = "Tools to manipulate font files"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"examples\""
+markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and extra == \"examples\""
 files = [
     {file = "fonttools-4.55.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1dcc07934a2165ccdc3a5a608db56fb3c24b609658a5b340aee4ecf3ba679dc0"},
     {file = "fonttools-4.55.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f7d66c15ba875432a2d2fb419523f5d3d347f91f48f57b8b08a2dfc3c39b8a3f"},
@@ -640,7 +640,7 @@ description = "Foxglove WebSocket server"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"examples\""
+markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and extra == \"examples\""
 files = [
     {file = "foxglove-websocket-0.1.2.tar.gz", hash = "sha256:26bc61e026d9f2b6f0fe34df6a798ce95e453cdce5565b730e0591ac1f52fdcb"},
     {file = "foxglove_websocket-0.1.2-py3-none-any.whl", hash = "sha256:7a231f90ee1ec08c2f6b302270bf45998cc125fb0b16e170a3ea6d1b8b559d1e"},
@@ -659,6 +659,7 @@ description = "Let your Python tests travel through time"
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "freezegun-1.5.1-py3-none-any.whl", hash = "sha256:bf111d7138a8abe55ab48a71755673dbaa4ab87f4cff5634a4442dfec34c15f1"},
     {file = "freezegun-1.5.1.tar.gz", hash = "sha256:b29dedfcda6d5e8e083ce71b2b542753ad48cfec44037b3fc79702e2980a89e9"},
@@ -674,6 +675,7 @@ description = "Copy your docs directly to the gh-pages branch."
 optional = false
 python-versions = "*"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343"},
     {file = "ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619"},
@@ -687,14 +689,15 @@ dev = ["flake8", "markdown", "twine", "wheel"]
 
 [[package]]
 name = "griffe"
-version = "1.5.4"
+version = "1.5.5"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "griffe-1.5.4-py3-none-any.whl", hash = "sha256:ed33af890586a5bebc842fcb919fc694b3dc1bc55b7d9e0228de41ce566b4a1d"},
-    {file = "griffe-1.5.4.tar.gz", hash = "sha256:073e78ad3e10c8378c2f798bd4ef87b92d8411e9916e157fd366a17cc4fd4e52"},
+    {file = "griffe-1.5.5-py3-none-any.whl", hash = "sha256:2761b1e8876c6f1f9ab1af274df93ea6bbadd65090de5f38f4cb5cc84897c7dd"},
+    {file = "griffe-1.5.5.tar.gz", hash = "sha256:35ee5b38b93d6a839098aad0f92207e6ad6b70c3e8866c08ca669275b8cba585"},
 ]
 
 [package.dependencies]
@@ -707,6 +710,7 @@ description = "Hjson, a user interface for JSON."
 optional = false
 python-versions = "*"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "hjson-3.1.0-py3-none-any.whl", hash = "sha256:65713cdcf13214fb554eb8b4ef803419733f4f5e551047c9b711098ab7186b89"},
     {file = "hjson-3.1.0.tar.gz", hash = "sha256:55af475a27cf83a7969c808399d7bccdec8fb836a07ddbd574587593b9cdcf75"},
@@ -719,6 +723,7 @@ description = "File identification library for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "identify-2.6.5-py2.py3-none-any.whl", hash = "sha256:14181a47091eb75b337af4c23078c9d09225cd4c48929f521f3bf16b09d02566"},
     {file = "identify-2.6.5.tar.gz", hash = "sha256:c10b33f250e5bba374fae86fb57f3adcebf1161bce7cdf92031915fd480c13bc"},
@@ -734,6 +739,7 @@ description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
 groups = ["main", "dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
@@ -749,7 +755,7 @@ description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
-markers = "python_version < \"3.10\""
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b"},
     {file = "importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"},
@@ -771,17 +777,14 @@ type = ["pytest-mypy"]
 name = "importlib-resources"
 version = "6.5.2"
 description = "Read resources from Python packages"
-optional = true
+optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"examples\" and python_version < \"3.10\""
+groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec"},
     {file = "importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c"},
 ]
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
@@ -798,6 +801,7 @@ description = "brain-dead simple config-ini parsing"
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
@@ -810,7 +814,7 @@ description = "Cross-platform Python support for keyboards, mice and gamepads."
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"examples\""
+markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and extra == \"examples\""
 files = [
     {file = "inputs-0.5-py2.py3-none-any.whl", hash = "sha256:13f894564e52134cf1e3862b1811da034875eb1f2b62e6021e3776e9669a96ec"},
     {file = "inputs-0.5.tar.gz", hash = "sha256:a31d5b96a3525f1232f326be9e7ce8ccaf873c6b1fb84d9f3c9bc3d79b23eae4"},
@@ -823,6 +827,7 @@ description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"},
     {file = "jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb"},
@@ -836,127 +841,93 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "kiwisolver"
-version = "1.4.7"
+version = "1.4.8"
 description = "A fast implementation of the Cassowary constraint solver"
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"examples\""
+markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and extra == \"examples\""
 files = [
-    {file = "kiwisolver-1.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8a9c83f75223d5e48b0bc9cb1bf2776cf01563e00ade8775ffe13b0b6e1af3a6"},
-    {file = "kiwisolver-1.4.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:58370b1ffbd35407444d57057b57da5d6549d2d854fa30249771775c63b5fe17"},
-    {file = "kiwisolver-1.4.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:aa0abdf853e09aff551db11fce173e2177d00786c688203f52c87ad7fcd91ef9"},
-    {file = "kiwisolver-1.4.7-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8d53103597a252fb3ab8b5845af04c7a26d5e7ea8122303dd7a021176a87e8b9"},
-    {file = "kiwisolver-1.4.7-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:88f17c5ffa8e9462fb79f62746428dd57b46eb931698e42e990ad63103f35e6c"},
-    {file = "kiwisolver-1.4.7-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:88a9ca9c710d598fd75ee5de59d5bda2684d9db36a9f50b6125eaea3969c2599"},
-    {file = "kiwisolver-1.4.7-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f4d742cb7af1c28303a51b7a27aaee540e71bb8e24f68c736f6f2ffc82f2bf05"},
-    {file = "kiwisolver-1.4.7-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e28c7fea2196bf4c2f8d46a0415c77a1c480cc0724722f23d7410ffe9842c407"},
-    {file = "kiwisolver-1.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e968b84db54f9d42046cf154e02911e39c0435c9801681e3fc9ce8a3c4130278"},
-    {file = "kiwisolver-1.4.7-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0c18ec74c0472de033e1bebb2911c3c310eef5649133dd0bedf2a169a1b269e5"},
-    {file = "kiwisolver-1.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:8f0ea6da6d393d8b2e187e6a5e3fb81f5862010a40c3945e2c6d12ae45cfb2ad"},
-    {file = "kiwisolver-1.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:f106407dda69ae456dd1227966bf445b157ccc80ba0dff3802bb63f30b74e895"},
-    {file = "kiwisolver-1.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:84ec80df401cfee1457063732d90022f93951944b5b58975d34ab56bb150dfb3"},
-    {file = "kiwisolver-1.4.7-cp310-cp310-win32.whl", hash = "sha256:71bb308552200fb2c195e35ef05de12f0c878c07fc91c270eb3d6e41698c3bcc"},
-    {file = "kiwisolver-1.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:44756f9fd339de0fb6ee4f8c1696cfd19b2422e0d70b4cefc1cc7f1f64045a8c"},
-    {file = "kiwisolver-1.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:78a42513018c41c2ffd262eb676442315cbfe3c44eed82385c2ed043bc63210a"},
-    {file = "kiwisolver-1.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d2b0e12a42fb4e72d509fc994713d099cbb15ebf1103545e8a45f14da2dfca54"},
-    {file = "kiwisolver-1.4.7-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2a8781ac3edc42ea4b90bc23e7d37b665d89423818e26eb6df90698aa2287c95"},
-    {file = "kiwisolver-1.4.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:46707a10836894b559e04b0fd143e343945c97fd170d69a2d26d640b4e297935"},
-    {file = "kiwisolver-1.4.7-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ef97b8df011141c9b0f6caf23b29379f87dd13183c978a30a3c546d2c47314cb"},
-    {file = "kiwisolver-1.4.7-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ab58c12a2cd0fc769089e6d38466c46d7f76aced0a1f54c77652446733d2d02"},
-    {file = "kiwisolver-1.4.7-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:803b8e1459341c1bb56d1c5c010406d5edec8a0713a0945851290a7930679b51"},
-    {file = "kiwisolver-1.4.7-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f9a9e8a507420fe35992ee9ecb302dab68550dedc0da9e2880dd88071c5fb052"},
-    {file = "kiwisolver-1.4.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18077b53dc3bb490e330669a99920c5e6a496889ae8c63b58fbc57c3d7f33a18"},
-    {file = "kiwisolver-1.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6af936f79086a89b3680a280c47ea90b4df7047b5bdf3aa5c524bbedddb9e545"},
-    {file = "kiwisolver-1.4.7-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:3abc5b19d24af4b77d1598a585b8a719beb8569a71568b66f4ebe1fb0449460b"},
-    {file = "kiwisolver-1.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:933d4de052939d90afbe6e9d5273ae05fb836cc86c15b686edd4b3560cc0ee36"},
-    {file = "kiwisolver-1.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:65e720d2ab2b53f1f72fb5da5fb477455905ce2c88aaa671ff0a447c2c80e8e3"},
-    {file = "kiwisolver-1.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3bf1ed55088f214ba6427484c59553123fdd9b218a42bbc8c6496d6754b1e523"},
-    {file = "kiwisolver-1.4.7-cp311-cp311-win32.whl", hash = "sha256:4c00336b9dd5ad96d0a558fd18a8b6f711b7449acce4c157e7343ba92dd0cf3d"},
-    {file = "kiwisolver-1.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:929e294c1ac1e9f615c62a4e4313ca1823ba37326c164ec720a803287c4c499b"},
-    {file = "kiwisolver-1.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:e33e8fbd440c917106b237ef1a2f1449dfbb9b6f6e1ce17c94cd6a1e0d438376"},
-    {file = "kiwisolver-1.4.7-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:5360cc32706dab3931f738d3079652d20982511f7c0ac5711483e6eab08efff2"},
-    {file = "kiwisolver-1.4.7-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:942216596dc64ddb25adb215c3c783215b23626f8d84e8eff8d6d45c3f29f75a"},
-    {file = "kiwisolver-1.4.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:48b571ecd8bae15702e4f22d3ff6a0f13e54d3d00cd25216d5e7f658242065ee"},
-    {file = "kiwisolver-1.4.7-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ad42ba922c67c5f219097b28fae965e10045ddf145d2928bfac2eb2e17673640"},
-    {file = "kiwisolver-1.4.7-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:612a10bdae23404a72941a0fc8fa2660c6ea1217c4ce0dbcab8a8f6543ea9e7f"},
-    {file = "kiwisolver-1.4.7-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9e838bba3a3bac0fe06d849d29772eb1afb9745a59710762e4ba3f4cb8424483"},
-    {file = "kiwisolver-1.4.7-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:22f499f6157236c19f4bbbd472fa55b063db77a16cd74d49afe28992dff8c258"},
-    {file = "kiwisolver-1.4.7-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:693902d433cf585133699972b6d7c42a8b9f8f826ebcaf0132ff55200afc599e"},
-    {file = "kiwisolver-1.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4e77f2126c3e0b0d055f44513ed349038ac180371ed9b52fe96a32aa071a5107"},
-    {file = "kiwisolver-1.4.7-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:657a05857bda581c3656bfc3b20e353c232e9193eb167766ad2dc58b56504948"},
-    {file = "kiwisolver-1.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4bfa75a048c056a411f9705856abfc872558e33c055d80af6a380e3658766038"},
-    {file = "kiwisolver-1.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:34ea1de54beef1c104422d210c47c7d2a4999bdecf42c7b5718fbe59a4cac383"},
-    {file = "kiwisolver-1.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:90da3b5f694b85231cf93586dad5e90e2d71b9428f9aad96952c99055582f520"},
-    {file = "kiwisolver-1.4.7-cp312-cp312-win32.whl", hash = "sha256:18e0cca3e008e17fe9b164b55735a325140a5a35faad8de92dd80265cd5eb80b"},
-    {file = "kiwisolver-1.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:58cb20602b18f86f83a5c87d3ee1c766a79c0d452f8def86d925e6c60fbf7bfb"},
-    {file = "kiwisolver-1.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:f5a8b53bdc0b3961f8b6125e198617c40aeed638b387913bf1ce78afb1b0be2a"},
-    {file = "kiwisolver-1.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2e6039dcbe79a8e0f044f1c39db1986a1b8071051efba3ee4d74f5b365f5226e"},
-    {file = "kiwisolver-1.4.7-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a1ecf0ac1c518487d9d23b1cd7139a6a65bc460cd101ab01f1be82ecf09794b6"},
-    {file = "kiwisolver-1.4.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ab9ccab2b5bd5702ab0803676a580fffa2aa178c2badc5557a84cc943fcf750"},
-    {file = "kiwisolver-1.4.7-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f816dd2277f8d63d79f9c8473a79fe54047bc0467754962840782c575522224d"},
-    {file = "kiwisolver-1.4.7-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf8bcc23ceb5a1b624572a1623b9f79d2c3b337c8c455405ef231933a10da379"},
-    {file = "kiwisolver-1.4.7-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dea0bf229319828467d7fca8c7c189780aa9ff679c94539eed7532ebe33ed37c"},
-    {file = "kiwisolver-1.4.7-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c06a4c7cf15ec739ce0e5971b26c93638730090add60e183530d70848ebdd34"},
-    {file = "kiwisolver-1.4.7-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:913983ad2deb14e66d83c28b632fd35ba2b825031f2fa4ca29675e665dfecbe1"},
-    {file = "kiwisolver-1.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5337ec7809bcd0f424c6b705ecf97941c46279cf5ed92311782c7c9c2026f07f"},
-    {file = "kiwisolver-1.4.7-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4c26ed10c4f6fa6ddb329a5120ba3b6db349ca192ae211e882970bfc9d91420b"},
-    {file = "kiwisolver-1.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c619b101e6de2222c1fcb0531e1b17bbffbe54294bfba43ea0d411d428618c27"},
-    {file = "kiwisolver-1.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:073a36c8273647592ea332e816e75ef8da5c303236ec0167196793eb1e34657a"},
-    {file = "kiwisolver-1.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3ce6b2b0231bda412463e152fc18335ba32faf4e8c23a754ad50ffa70e4091ee"},
-    {file = "kiwisolver-1.4.7-cp313-cp313-win32.whl", hash = "sha256:f4c9aee212bc89d4e13f58be11a56cc8036cabad119259d12ace14b34476fd07"},
-    {file = "kiwisolver-1.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:8a3ec5aa8e38fc4c8af308917ce12c536f1c88452ce554027e55b22cbbfbff76"},
-    {file = "kiwisolver-1.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:76c8094ac20ec259471ac53e774623eb62e6e1f56cd8690c67ce6ce4fcb05650"},
-    {file = "kiwisolver-1.4.7-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5d5abf8f8ec1f4e22882273c423e16cae834c36856cac348cfbfa68e01c40f3a"},
-    {file = "kiwisolver-1.4.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:aeb3531b196ef6f11776c21674dba836aeea9d5bd1cf630f869e3d90b16cfade"},
-    {file = "kiwisolver-1.4.7-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b7d755065e4e866a8086c9bdada157133ff466476a2ad7861828e17b6026e22c"},
-    {file = "kiwisolver-1.4.7-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08471d4d86cbaec61f86b217dd938a83d85e03785f51121e791a6e6689a3be95"},
-    {file = "kiwisolver-1.4.7-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bbfcb7165ce3d54a3dfbe731e470f65739c4c1f85bb1018ee912bae139e263b"},
-    {file = "kiwisolver-1.4.7-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5d34eb8494bea691a1a450141ebb5385e4b69d38bb8403b5146ad279f4b30fa3"},
-    {file = "kiwisolver-1.4.7-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9242795d174daa40105c1d86aba618e8eab7bf96ba8c3ee614da8302a9f95503"},
-    {file = "kiwisolver-1.4.7-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a0f64a48bb81af7450e641e3fe0b0394d7381e342805479178b3d335d60ca7cf"},
-    {file = "kiwisolver-1.4.7-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:8e045731a5416357638d1700927529e2b8ab304811671f665b225f8bf8d8f933"},
-    {file = "kiwisolver-1.4.7-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:4322872d5772cae7369f8351da1edf255a604ea7087fe295411397d0cfd9655e"},
-    {file = "kiwisolver-1.4.7-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:e1631290ee9271dffe3062d2634c3ecac02c83890ada077d225e081aca8aab89"},
-    {file = "kiwisolver-1.4.7-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:edcfc407e4eb17e037bca59be0e85a2031a2ac87e4fed26d3e9df88b4165f92d"},
-    {file = "kiwisolver-1.4.7-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:4d05d81ecb47d11e7f8932bd8b61b720bf0b41199358f3f5e36d38e28f0532c5"},
-    {file = "kiwisolver-1.4.7-cp38-cp38-win32.whl", hash = "sha256:b38ac83d5f04b15e515fd86f312479d950d05ce2368d5413d46c088dda7de90a"},
-    {file = "kiwisolver-1.4.7-cp38-cp38-win_amd64.whl", hash = "sha256:d83db7cde68459fc803052a55ace60bea2bae361fc3b7a6d5da07e11954e4b09"},
-    {file = "kiwisolver-1.4.7-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3f9362ecfca44c863569d3d3c033dbe8ba452ff8eed6f6b5806382741a1334bd"},
-    {file = "kiwisolver-1.4.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e8df2eb9b2bac43ef8b082e06f750350fbbaf2887534a5be97f6cf07b19d9583"},
-    {file = "kiwisolver-1.4.7-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f32d6edbc638cde7652bd690c3e728b25332acbadd7cad670cc4a02558d9c417"},
-    {file = "kiwisolver-1.4.7-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e2e6c39bd7b9372b0be21456caab138e8e69cc0fc1190a9dfa92bd45a1e6e904"},
-    {file = "kiwisolver-1.4.7-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:dda56c24d869b1193fcc763f1284b9126550eaf84b88bbc7256e15028f19188a"},
-    {file = "kiwisolver-1.4.7-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79849239c39b5e1fd906556c474d9b0439ea6792b637511f3fe3a41158d89ca8"},
-    {file = "kiwisolver-1.4.7-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5e3bc157fed2a4c02ec468de4ecd12a6e22818d4f09cde2c31ee3226ffbefab2"},
-    {file = "kiwisolver-1.4.7-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3da53da805b71e41053dc670f9a820d1157aae77b6b944e08024d17bcd51ef88"},
-    {file = "kiwisolver-1.4.7-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:8705f17dfeb43139a692298cb6637ee2e59c0194538153e83e9ee0c75c2eddde"},
-    {file = "kiwisolver-1.4.7-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:82a5c2f4b87c26bb1a0ef3d16b5c4753434633b83d365cc0ddf2770c93829e3c"},
-    {file = "kiwisolver-1.4.7-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:ce8be0466f4c0d585cdb6c1e2ed07232221df101a4c6f28821d2aa754ca2d9e2"},
-    {file = "kiwisolver-1.4.7-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:409afdfe1e2e90e6ee7fc896f3df9a7fec8e793e58bfa0d052c8a82f99c37abb"},
-    {file = "kiwisolver-1.4.7-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:5b9c3f4ee0b9a439d2415012bd1b1cc2df59e4d6a9939f4d669241d30b414327"},
-    {file = "kiwisolver-1.4.7-cp39-cp39-win32.whl", hash = "sha256:a79ae34384df2b615eefca647a2873842ac3b596418032bef9a7283675962644"},
-    {file = "kiwisolver-1.4.7-cp39-cp39-win_amd64.whl", hash = "sha256:cf0438b42121a66a3a667de17e779330fc0f20b0d97d59d2f2121e182b0505e4"},
-    {file = "kiwisolver-1.4.7-cp39-cp39-win_arm64.whl", hash = "sha256:764202cc7e70f767dab49e8df52c7455e8de0df5d858fa801a11aa0d882ccf3f"},
-    {file = "kiwisolver-1.4.7-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:94252291e3fe68001b1dd747b4c0b3be12582839b95ad4d1b641924d68fd4643"},
-    {file = "kiwisolver-1.4.7-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5b7dfa3b546da08a9f622bb6becdb14b3e24aaa30adba66749d38f3cc7ea9706"},
-    {file = "kiwisolver-1.4.7-pp310-pypy310_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bd3de6481f4ed8b734da5df134cd5a6a64fe32124fe83dde1e5b5f29fe30b1e6"},
-    {file = "kiwisolver-1.4.7-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a91b5f9f1205845d488c928e8570dcb62b893372f63b8b6e98b863ebd2368ff2"},
-    {file = "kiwisolver-1.4.7-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40fa14dbd66b8b8f470d5fc79c089a66185619d31645f9b0773b88b19f7223c4"},
-    {file = "kiwisolver-1.4.7-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:eb542fe7933aa09d8d8f9d9097ef37532a7df6497819d16efe4359890a2f417a"},
-    {file = "kiwisolver-1.4.7-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:bfa1acfa0c54932d5607e19a2c24646fb4c1ae2694437789129cf099789a3b00"},
-    {file = "kiwisolver-1.4.7-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:eee3ea935c3d227d49b4eb85660ff631556841f6e567f0f7bda972df6c2c9935"},
-    {file = "kiwisolver-1.4.7-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f3160309af4396e0ed04db259c3ccbfdc3621b5559b5453075e5de555e1f3a1b"},
-    {file = "kiwisolver-1.4.7-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a17f6a29cf8935e587cc8a4dbfc8368c55edc645283db0ce9801016f83526c2d"},
-    {file = "kiwisolver-1.4.7-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:10849fb2c1ecbfae45a693c070e0320a91b35dd4bcf58172c023b994283a124d"},
-    {file = "kiwisolver-1.4.7-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:ac542bf38a8a4be2dc6b15248d36315ccc65f0743f7b1a76688ffb6b5129a5c2"},
-    {file = "kiwisolver-1.4.7-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:8b01aac285f91ca889c800042c35ad3b239e704b150cfd3382adfc9dcc780e39"},
-    {file = "kiwisolver-1.4.7-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:48be928f59a1f5c8207154f935334d374e79f2b5d212826307d072595ad76a2e"},
-    {file = "kiwisolver-1.4.7-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f37cfe618a117e50d8c240555331160d73d0411422b59b5ee217843d7b693608"},
-    {file = "kiwisolver-1.4.7-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:599b5c873c63a1f6ed7eead644a8a380cfbdf5db91dcb6f85707aaab213b1674"},
-    {file = "kiwisolver-1.4.7-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:801fa7802e5cfabe3ab0c81a34c323a319b097dfb5004be950482d882f3d7225"},
-    {file = "kiwisolver-1.4.7-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:0c6c43471bc764fad4bc99c5c2d6d16a676b1abf844ca7c8702bdae92df01ee0"},
-    {file = "kiwisolver-1.4.7.tar.gz", hash = "sha256:9893ff81bd7107f7b685d3017cc6583daadb4fc26e4a888350df530e41980a60"},
+    {file = "kiwisolver-1.4.8-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:88c6f252f6816a73b1f8c904f7bbe02fd67c09a69f7cb8a0eecdbf5ce78e63db"},
+    {file = "kiwisolver-1.4.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c72941acb7b67138f35b879bbe85be0f6c6a70cab78fe3ef6db9c024d9223e5b"},
+    {file = "kiwisolver-1.4.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ce2cf1e5688edcb727fdf7cd1bbd0b6416758996826a8be1d958f91880d0809d"},
+    {file = "kiwisolver-1.4.8-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c8bf637892dc6e6aad2bc6d4d69d08764166e5e3f69d469e55427b6ac001b19d"},
+    {file = "kiwisolver-1.4.8-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:034d2c891f76bd3edbdb3ea11140d8510dca675443da7304205a2eaa45d8334c"},
+    {file = "kiwisolver-1.4.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d47b28d1dfe0793d5e96bce90835e17edf9a499b53969b03c6c47ea5985844c3"},
+    {file = "kiwisolver-1.4.8-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:eb158fe28ca0c29f2260cca8c43005329ad58452c36f0edf298204de32a9a3ed"},
+    {file = "kiwisolver-1.4.8-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5536185fce131780ebd809f8e623bf4030ce1b161353166c49a3c74c287897f"},
+    {file = "kiwisolver-1.4.8-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:369b75d40abedc1da2c1f4de13f3482cb99e3237b38726710f4a793432b1c5ff"},
+    {file = "kiwisolver-1.4.8-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:641f2ddf9358c80faa22e22eb4c9f54bd3f0e442e038728f500e3b978d00aa7d"},
+    {file = "kiwisolver-1.4.8-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:d561d2d8883e0819445cfe58d7ddd673e4015c3c57261d7bdcd3710d0d14005c"},
+    {file = "kiwisolver-1.4.8-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:1732e065704b47c9afca7ffa272f845300a4eb959276bf6970dc07265e73b605"},
+    {file = "kiwisolver-1.4.8-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:bcb1ebc3547619c3b58a39e2448af089ea2ef44b37988caf432447374941574e"},
+    {file = "kiwisolver-1.4.8-cp310-cp310-win_amd64.whl", hash = "sha256:89c107041f7b27844179ea9c85d6da275aa55ecf28413e87624d033cf1f6b751"},
+    {file = "kiwisolver-1.4.8-cp310-cp310-win_arm64.whl", hash = "sha256:b5773efa2be9eb9fcf5415ea3ab70fc785d598729fd6057bea38d539ead28271"},
+    {file = "kiwisolver-1.4.8-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a4d3601908c560bdf880f07d94f31d734afd1bb71e96585cace0e38ef44c6d84"},
+    {file = "kiwisolver-1.4.8-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:856b269c4d28a5c0d5e6c1955ec36ebfd1651ac00e1ce0afa3e28da95293b561"},
+    {file = "kiwisolver-1.4.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c2b9a96e0f326205af81a15718a9073328df1173a2619a68553decb7097fd5d7"},
+    {file = "kiwisolver-1.4.8-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5020c83e8553f770cb3b5fc13faac40f17e0b205bd237aebd21d53d733adb03"},
+    {file = "kiwisolver-1.4.8-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dace81d28c787956bfbfbbfd72fdcef014f37d9b48830829e488fdb32b49d954"},
+    {file = "kiwisolver-1.4.8-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:11e1022b524bd48ae56c9b4f9296bce77e15a2e42a502cceba602f804b32bb79"},
+    {file = "kiwisolver-1.4.8-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b9b4d2892fefc886f30301cdd80debd8bb01ecdf165a449eb6e78f79f0fabd6"},
+    {file = "kiwisolver-1.4.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a96c0e790ee875d65e340ab383700e2b4891677b7fcd30a699146f9384a2bb0"},
+    {file = "kiwisolver-1.4.8-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:23454ff084b07ac54ca8be535f4174170c1094a4cff78fbae4f73a4bcc0d4dab"},
+    {file = "kiwisolver-1.4.8-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:87b287251ad6488e95b4f0b4a79a6d04d3ea35fde6340eb38fbd1ca9cd35bbbc"},
+    {file = "kiwisolver-1.4.8-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b21dbe165081142b1232a240fc6383fd32cdd877ca6cc89eab93e5f5883e1c25"},
+    {file = "kiwisolver-1.4.8-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:768cade2c2df13db52475bd28d3a3fac8c9eff04b0e9e2fda0f3760f20b3f7fc"},
+    {file = "kiwisolver-1.4.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d47cfb2650f0e103d4bf68b0b5804c68da97272c84bb12850d877a95c056bd67"},
+    {file = "kiwisolver-1.4.8-cp311-cp311-win_amd64.whl", hash = "sha256:ed33ca2002a779a2e20eeb06aea7721b6e47f2d4b8a8ece979d8ba9e2a167e34"},
+    {file = "kiwisolver-1.4.8-cp311-cp311-win_arm64.whl", hash = "sha256:16523b40aab60426ffdebe33ac374457cf62863e330a90a0383639ce14bf44b2"},
+    {file = "kiwisolver-1.4.8-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d6af5e8815fd02997cb6ad9bbed0ee1e60014438ee1a5c2444c96f87b8843502"},
+    {file = "kiwisolver-1.4.8-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bade438f86e21d91e0cf5dd7c0ed00cda0f77c8c1616bd83f9fc157fa6760d31"},
+    {file = "kiwisolver-1.4.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b83dc6769ddbc57613280118fb4ce3cd08899cc3369f7d0e0fab518a7cf37fdb"},
+    {file = "kiwisolver-1.4.8-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:111793b232842991be367ed828076b03d96202c19221b5ebab421ce8bcad016f"},
+    {file = "kiwisolver-1.4.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:257af1622860e51b1a9d0ce387bf5c2c4f36a90594cb9514f55b074bcc787cfc"},
+    {file = "kiwisolver-1.4.8-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:69b5637c3f316cab1ec1c9a12b8c5f4750a4c4b71af9157645bf32830e39c03a"},
+    {file = "kiwisolver-1.4.8-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:782bb86f245ec18009890e7cb8d13a5ef54dcf2ebe18ed65f795e635a96a1c6a"},
+    {file = "kiwisolver-1.4.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc978a80a0db3a66d25767b03688f1147a69e6237175c0f4ffffaaedf744055a"},
+    {file = "kiwisolver-1.4.8-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:36dbbfd34838500a31f52c9786990d00150860e46cd5041386f217101350f0d3"},
+    {file = "kiwisolver-1.4.8-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:eaa973f1e05131de5ff3569bbba7f5fd07ea0595d3870ed4a526d486fe57fa1b"},
+    {file = "kiwisolver-1.4.8-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a66f60f8d0c87ab7f59b6fb80e642ebb29fec354a4dfad687ca4092ae69d04f4"},
+    {file = "kiwisolver-1.4.8-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:858416b7fb777a53f0c59ca08190ce24e9abbd3cffa18886a5781b8e3e26f65d"},
+    {file = "kiwisolver-1.4.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:085940635c62697391baafaaeabdf3dd7a6c3643577dde337f4d66eba021b2b8"},
+    {file = "kiwisolver-1.4.8-cp312-cp312-win_amd64.whl", hash = "sha256:01c3d31902c7db5fb6182832713d3b4122ad9317c2c5877d0539227d96bb2e50"},
+    {file = "kiwisolver-1.4.8-cp312-cp312-win_arm64.whl", hash = "sha256:a3c44cb68861de93f0c4a8175fbaa691f0aa22550c331fefef02b618a9dcb476"},
+    {file = "kiwisolver-1.4.8-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1c8ceb754339793c24aee1c9fb2485b5b1f5bb1c2c214ff13368431e51fc9a09"},
+    {file = "kiwisolver-1.4.8-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a62808ac74b5e55a04a408cda6156f986cefbcf0ada13572696b507cc92fa1"},
+    {file = "kiwisolver-1.4.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:68269e60ee4929893aad82666821aaacbd455284124817af45c11e50a4b42e3c"},
+    {file = "kiwisolver-1.4.8-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:34d142fba9c464bc3bbfeff15c96eab0e7310343d6aefb62a79d51421fcc5f1b"},
+    {file = "kiwisolver-1.4.8-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ddc373e0eef45b59197de815b1b28ef89ae3955e7722cc9710fb91cd77b7f47"},
+    {file = "kiwisolver-1.4.8-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:77e6f57a20b9bd4e1e2cedda4d0b986ebd0216236f0106e55c28aea3d3d69b16"},
+    {file = "kiwisolver-1.4.8-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:08e77738ed7538f036cd1170cbed942ef749137b1311fa2bbe2a7fda2f6bf3cc"},
+    {file = "kiwisolver-1.4.8-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5ce1e481a74b44dd5e92ff03ea0cb371ae7a0268318e202be06c8f04f4f1246"},
+    {file = "kiwisolver-1.4.8-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fc2ace710ba7c1dfd1a3b42530b62b9ceed115f19a1656adefce7b1782a37794"},
+    {file = "kiwisolver-1.4.8-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:3452046c37c7692bd52b0e752b87954ef86ee2224e624ef7ce6cb21e8c41cc1b"},
+    {file = "kiwisolver-1.4.8-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7e9a60b50fe8b2ec6f448fe8d81b07e40141bfced7f896309df271a0b92f80f3"},
+    {file = "kiwisolver-1.4.8-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:918139571133f366e8362fa4a297aeba86c7816b7ecf0bc79168080e2bd79957"},
+    {file = "kiwisolver-1.4.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e063ef9f89885a1d68dd8b2e18f5ead48653176d10a0e324e3b0030e3a69adeb"},
+    {file = "kiwisolver-1.4.8-cp313-cp313-win_amd64.whl", hash = "sha256:a17b7c4f5b2c51bb68ed379defd608a03954a1845dfed7cc0117f1cc8a9b7fd2"},
+    {file = "kiwisolver-1.4.8-cp313-cp313-win_arm64.whl", hash = "sha256:3cd3bc628b25f74aedc6d374d5babf0166a92ff1317f46267f12d2ed54bc1d30"},
+    {file = "kiwisolver-1.4.8-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:370fd2df41660ed4e26b8c9d6bbcad668fbe2560462cba151a721d49e5b6628c"},
+    {file = "kiwisolver-1.4.8-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:84a2f830d42707de1d191b9490ac186bf7997a9495d4e9072210a1296345f7dc"},
+    {file = "kiwisolver-1.4.8-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7a3ad337add5148cf51ce0b55642dc551c0b9d6248458a757f98796ca7348712"},
+    {file = "kiwisolver-1.4.8-cp313-cp313t-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7506488470f41169b86d8c9aeff587293f530a23a23a49d6bc64dab66bedc71e"},
+    {file = "kiwisolver-1.4.8-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f0121b07b356a22fb0414cec4666bbe36fd6d0d759db3d37228f496ed67c880"},
+    {file = "kiwisolver-1.4.8-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d6d6bd87df62c27d4185de7c511c6248040afae67028a8a22012b010bc7ad062"},
+    {file = "kiwisolver-1.4.8-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:291331973c64bb9cce50bbe871fb2e675c4331dab4f31abe89f175ad7679a4d7"},
+    {file = "kiwisolver-1.4.8-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:893f5525bb92d3d735878ec00f781b2de998333659507d29ea4466208df37bed"},
+    {file = "kiwisolver-1.4.8-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b47a465040146981dc9db8647981b8cb96366fbc8d452b031e4f8fdffec3f26d"},
+    {file = "kiwisolver-1.4.8-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:99cea8b9dd34ff80c521aef46a1dddb0dcc0283cf18bde6d756f1e6f31772165"},
+    {file = "kiwisolver-1.4.8-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:151dffc4865e5fe6dafce5480fab84f950d14566c480c08a53c663a0020504b6"},
+    {file = "kiwisolver-1.4.8-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:577facaa411c10421314598b50413aa1ebcf5126f704f1e5d72d7e4e9f020d90"},
+    {file = "kiwisolver-1.4.8-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:be4816dc51c8a471749d664161b434912eee82f2ea66bd7628bd14583a833e85"},
+    {file = "kiwisolver-1.4.8-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:e7a019419b7b510f0f7c9dceff8c5eae2392037eae483a7f9162625233802b0a"},
+    {file = "kiwisolver-1.4.8-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:286b18e86682fd2217a48fc6be6b0f20c1d0ed10958d8dc53453ad58d7be0bf8"},
+    {file = "kiwisolver-1.4.8-pp310-pypy310_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4191ee8dfd0be1c3666ccbac178c5a05d5f8d689bbe3fc92f3c4abec817f8fe0"},
+    {file = "kiwisolver-1.4.8-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7cd2785b9391f2873ad46088ed7599a6a71e762e1ea33e87514b1a441ed1da1c"},
+    {file = "kiwisolver-1.4.8-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c07b29089b7ba090b6f1a669f1411f27221c3662b3a1b7010e67b59bb5a6f10b"},
+    {file = "kiwisolver-1.4.8-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:65ea09a5a3faadd59c2ce96dc7bf0f364986a315949dc6374f04396b0d60e09b"},
+    {file = "kiwisolver-1.4.8.tar.gz", hash = "sha256:23d5f023bdc8c7e54eb65f03ca5d5bb25b601eac4d7f1a042888a1f45237987e"},
 ]
 
 [[package]]
@@ -966,7 +937,7 @@ description = "Powerful and Pythonic XML processing library combining libxml2/li
 optional = true
 python-versions = ">=3.6"
 groups = ["main"]
-markers = "extra == \"examples\""
+markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and extra == \"examples\""
 files = [
     {file = "lxml-5.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:dd36439be765e2dde7660212b5275641edbc813e7b24668831a5c8ac91180656"},
     {file = "lxml-5.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ae5fe5c4b525aa82b8076c1a59d642c17b6e8739ecf852522c6321852178119d"},
@@ -1122,13 +1093,11 @@ description = "Python implementation of John Gruber's Markdown."
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "Markdown-3.7-py3-none-any.whl", hash = "sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803"},
     {file = "markdown-3.7.tar.gz", hash = "sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2"},
 ]
-
-[package.dependencies]
-importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
 
 [package.extras]
 docs = ["mdx-gh-links (>=0.2)", "mkdocs (>=1.5)", "mkdocs-gen-files", "mkdocs-literate-nav", "mkdocs-nature (>=0.6)", "mkdocs-section-index", "mkdocstrings[python]"]
@@ -1141,6 +1110,7 @@ description = "Safely add untrusted strings to HTML/XML markup."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "MarkupSafe-3.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8"},
     {file = "MarkupSafe-3.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9e2d922824181480953426608b81967de705c3cef4d1af983af849d7bd619158"},
@@ -1207,61 +1177,53 @@ files = [
 
 [[package]]
 name = "matplotlib"
-version = "3.9.4"
+version = "3.10.0"
 description = "Python plotting package"
 optional = true
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"examples\""
+markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and extra == \"examples\""
 files = [
-    {file = "matplotlib-3.9.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:c5fdd7abfb706dfa8d307af64a87f1a862879ec3cd8d0ec8637458f0885b9c50"},
-    {file = "matplotlib-3.9.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d89bc4e85e40a71d1477780366c27fb7c6494d293e1617788986f74e2a03d7ff"},
-    {file = "matplotlib-3.9.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ddf9f3c26aae695c5daafbf6b94e4c1a30d6cd617ba594bbbded3b33a1fcfa26"},
-    {file = "matplotlib-3.9.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18ebcf248030173b59a868fda1fe42397253f6698995b55e81e1f57431d85e50"},
-    {file = "matplotlib-3.9.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:974896ec43c672ec23f3f8c648981e8bc880ee163146e0312a9b8def2fac66f5"},
-    {file = "matplotlib-3.9.4-cp310-cp310-win_amd64.whl", hash = "sha256:4598c394ae9711cec135639374e70871fa36b56afae17bdf032a345be552a88d"},
-    {file = "matplotlib-3.9.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:d4dd29641d9fb8bc4492420c5480398dd40a09afd73aebe4eb9d0071a05fbe0c"},
-    {file = "matplotlib-3.9.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:30e5b22e8bcfb95442bf7d48b0d7f3bdf4a450cbf68986ea45fca3d11ae9d099"},
-    {file = "matplotlib-3.9.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2bb0030d1d447fd56dcc23b4c64a26e44e898f0416276cac1ebc25522e0ac249"},
-    {file = "matplotlib-3.9.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aca90ed222ac3565d2752b83dbb27627480d27662671e4d39da72e97f657a423"},
-    {file = "matplotlib-3.9.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a181b2aa2906c608fcae72f977a4a2d76e385578939891b91c2550c39ecf361e"},
-    {file = "matplotlib-3.9.4-cp311-cp311-win_amd64.whl", hash = "sha256:1f6882828231eca17f501c4dcd98a05abb3f03d157fbc0769c6911fe08b6cfd3"},
-    {file = "matplotlib-3.9.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:dfc48d67e6661378a21c2983200a654b72b5c5cdbd5d2cf6e5e1ece860f0cc70"},
-    {file = "matplotlib-3.9.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47aef0fab8332d02d68e786eba8113ffd6f862182ea2999379dec9e237b7e483"},
-    {file = "matplotlib-3.9.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fba1f52c6b7dc764097f52fd9ab627b90db452c9feb653a59945de16752e965f"},
-    {file = "matplotlib-3.9.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:173ac3748acaac21afcc3fa1633924609ba1b87749006bc25051c52c422a5d00"},
-    {file = "matplotlib-3.9.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:320edea0cadc07007765e33f878b13b3738ffa9745c5f707705692df70ffe0e0"},
-    {file = "matplotlib-3.9.4-cp312-cp312-win_amd64.whl", hash = "sha256:a4a4cfc82330b27042a7169533da7991e8789d180dd5b3daeaee57d75cd5a03b"},
-    {file = "matplotlib-3.9.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:37eeffeeca3c940985b80f5b9a7b95ea35671e0e7405001f249848d2b62351b6"},
-    {file = "matplotlib-3.9.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3e7465ac859ee4abcb0d836137cd8414e7bb7ad330d905abced457217d4f0f45"},
-    {file = "matplotlib-3.9.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4c12302c34afa0cf061bea23b331e747e5e554b0fa595c96e01c7b75bc3b858"},
-    {file = "matplotlib-3.9.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b8c97917f21b75e72108b97707ba3d48f171541a74aa2a56df7a40626bafc64"},
-    {file = "matplotlib-3.9.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0229803bd7e19271b03cb09f27db76c918c467aa4ce2ae168171bc67c3f508df"},
-    {file = "matplotlib-3.9.4-cp313-cp313-win_amd64.whl", hash = "sha256:7c0d8ef442ebf56ff5e206f8083d08252ee738e04f3dc88ea882853a05488799"},
-    {file = "matplotlib-3.9.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a04c3b00066a688834356d196136349cb32f5e1003c55ac419e91585168b88fb"},
-    {file = "matplotlib-3.9.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:04c519587f6c210626741a1e9a68eefc05966ede24205db8982841826af5871a"},
-    {file = "matplotlib-3.9.4-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:308afbf1a228b8b525fcd5cec17f246bbbb63b175a3ef6eb7b4d33287ca0cf0c"},
-    {file = "matplotlib-3.9.4-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ddb3b02246ddcffd3ce98e88fed5b238bc5faff10dbbaa42090ea13241d15764"},
-    {file = "matplotlib-3.9.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8a75287e9cb9eee48cb79ec1d806f75b29c0fde978cb7223a1f4c5848d696041"},
-    {file = "matplotlib-3.9.4-cp313-cp313t-win_amd64.whl", hash = "sha256:488deb7af140f0ba86da003e66e10d55ff915e152c78b4b66d231638400b1965"},
-    {file = "matplotlib-3.9.4-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:3c3724d89a387ddf78ff88d2a30ca78ac2b4c89cf37f2db4bd453c34799e933c"},
-    {file = "matplotlib-3.9.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d5f0a8430ffe23d7e32cfd86445864ccad141797f7d25b7c41759a5b5d17cfd7"},
-    {file = "matplotlib-3.9.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6bb0141a21aef3b64b633dc4d16cbd5fc538b727e4958be82a0e1c92a234160e"},
-    {file = "matplotlib-3.9.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57aa235109e9eed52e2c2949db17da185383fa71083c00c6c143a60e07e0888c"},
-    {file = "matplotlib-3.9.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:b18c600061477ccfdd1e6fd050c33d8be82431700f3452b297a56d9ed7037abb"},
-    {file = "matplotlib-3.9.4-cp39-cp39-win_amd64.whl", hash = "sha256:ef5f2d1b67d2d2145ff75e10f8c008bfbf71d45137c4b648c87193e7dd053eac"},
-    {file = "matplotlib-3.9.4-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:44e0ed786d769d85bc787b0606a53f2d8d2d1d3c8a2608237365e9121c1a338c"},
-    {file = "matplotlib-3.9.4-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:09debb9ce941eb23ecdbe7eab972b1c3e0276dcf01688073faff7b0f61d6c6ca"},
-    {file = "matplotlib-3.9.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcc53cf157a657bfd03afab14774d54ba73aa84d42cfe2480c91bd94873952db"},
-    {file = "matplotlib-3.9.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:ad45da51be7ad02387801fd154ef74d942f49fe3fcd26a64c94842ba7ec0d865"},
-    {file = "matplotlib-3.9.4.tar.gz", hash = "sha256:1e00e8be7393cbdc6fedfa8a6fba02cf3e83814b285db1c60b906a023ba41bc3"},
+    {file = "matplotlib-3.10.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2c5829a5a1dd5a71f0e31e6e8bb449bc0ee9dbfb05ad28fc0c6b55101b3a4be6"},
+    {file = "matplotlib-3.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a2a43cbefe22d653ab34bb55d42384ed30f611bcbdea1f8d7f431011a2e1c62e"},
+    {file = "matplotlib-3.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:607b16c8a73943df110f99ee2e940b8a1cbf9714b65307c040d422558397dac5"},
+    {file = "matplotlib-3.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:01d2b19f13aeec2e759414d3bfe19ddfb16b13a1250add08d46d5ff6f9be83c6"},
+    {file = "matplotlib-3.10.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e6c6461e1fc63df30bf6f80f0b93f5b6784299f721bc28530477acd51bfc3d1"},
+    {file = "matplotlib-3.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:994c07b9d9fe8d25951e3202a68c17900679274dadfc1248738dcfa1bd40d7f3"},
+    {file = "matplotlib-3.10.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:fd44fc75522f58612ec4a33958a7e5552562b7705b42ef1b4f8c0818e304a363"},
+    {file = "matplotlib-3.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c58a9622d5dbeb668f407f35f4e6bfac34bb9ecdcc81680c04d0258169747997"},
+    {file = "matplotlib-3.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:845d96568ec873be63f25fa80e9e7fae4be854a66a7e2f0c8ccc99e94a8bd4ef"},
+    {file = "matplotlib-3.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5439f4c5a3e2e8eab18e2f8c3ef929772fd5641876db71f08127eed95ab64683"},
+    {file = "matplotlib-3.10.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4673ff67a36152c48ddeaf1135e74ce0d4bce1bbf836ae40ed39c29edf7e2765"},
+    {file = "matplotlib-3.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:7e8632baebb058555ac0cde75db885c61f1212e47723d63921879806b40bec6a"},
+    {file = "matplotlib-3.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4659665bc7c9b58f8c00317c3c2a299f7f258eeae5a5d56b4c64226fca2f7c59"},
+    {file = "matplotlib-3.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d44cb942af1693cced2604c33a9abcef6205601c445f6d0dc531d813af8a2f5a"},
+    {file = "matplotlib-3.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a994f29e968ca002b50982b27168addfd65f0105610b6be7fa515ca4b5307c95"},
+    {file = "matplotlib-3.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b0558bae37f154fffda54d779a592bc97ca8b4701f1c710055b609a3bac44c8"},
+    {file = "matplotlib-3.10.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:503feb23bd8c8acc75541548a1d709c059b7184cde26314896e10a9f14df5f12"},
+    {file = "matplotlib-3.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:c40ba2eb08b3f5de88152c2333c58cee7edcead0a2a0d60fcafa116b17117adc"},
+    {file = "matplotlib-3.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:96f2886f5c1e466f21cc41b70c5a0cd47bfa0015eb2d5793c88ebce658600e25"},
+    {file = "matplotlib-3.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:12eaf48463b472c3c0f8dbacdbf906e573013df81a0ab82f0616ea4b11281908"},
+    {file = "matplotlib-3.10.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2fbbabc82fde51391c4da5006f965e36d86d95f6ee83fb594b279564a4c5d0d2"},
+    {file = "matplotlib-3.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad2e15300530c1a94c63cfa546e3b7864bd18ea2901317bae8bbf06a5ade6dcf"},
+    {file = "matplotlib-3.10.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3547d153d70233a8496859097ef0312212e2689cdf8d7ed764441c77604095ae"},
+    {file = "matplotlib-3.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:c55b20591ced744aa04e8c3e4b7543ea4d650b6c3c4b208c08a05b4010e8b442"},
+    {file = "matplotlib-3.10.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9ade1003376731a971e398cc4ef38bb83ee8caf0aee46ac6daa4b0506db1fd06"},
+    {file = "matplotlib-3.10.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:95b710fea129c76d30be72c3b38f330269363fbc6e570a5dd43580487380b5ff"},
+    {file = "matplotlib-3.10.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cdbaf909887373c3e094b0318d7ff230b2ad9dcb64da7ade654182872ab2593"},
+    {file = "matplotlib-3.10.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d907fddb39f923d011875452ff1eca29a9e7f21722b873e90db32e5d8ddff12e"},
+    {file = "matplotlib-3.10.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3b427392354d10975c1d0f4ee18aa5844640b512d5311ef32efd4dd7db106ede"},
+    {file = "matplotlib-3.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5fd41b0ec7ee45cd960a8e71aea7c946a28a0b8a4dcee47d2856b2af051f334c"},
+    {file = "matplotlib-3.10.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:81713dd0d103b379de4516b861d964b1d789a144103277769238c732229d7f03"},
+    {file = "matplotlib-3.10.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:359f87baedb1f836ce307f0e850d12bb5f1936f70d035561f90d41d305fdacea"},
+    {file = "matplotlib-3.10.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae80dc3a4add4665cf2faa90138384a7ffe2a4e37c58d83e115b54287c4f06ef"},
+    {file = "matplotlib-3.10.0.tar.gz", hash = "sha256:b886d02a581b96704c9d1ffe55709e49b4d2d52709ccebc4be42db856e511278"},
 ]
 
 [package.dependencies]
 contourpy = ">=1.0.1"
 cycler = ">=0.10"
 fonttools = ">=4.22.0"
-importlib-resources = {version = ">=3.2.0", markers = "python_version < \"3.10\""}
 kiwisolver = ">=1.3.1"
 numpy = ">=1.23"
 packaging = ">=20.0"
@@ -1270,7 +1232,7 @@ pyparsing = ">=2.3.1"
 python-dateutil = ">=2.7"
 
 [package.extras]
-dev = ["meson-python (>=0.13.1,<0.17.0)", "numpy (>=1.25)", "pybind11 (>=2.6,!=2.13.3)", "setuptools (>=64)", "setuptools_scm (>=7)"]
+dev = ["meson-python (>=0.13.1,<0.17.0)", "pybind11 (>=2.13.2,!=2.13.3)", "setuptools (>=64)", "setuptools_scm (>=7)"]
 
 [[package]]
 name = "mergedeep"
@@ -1279,6 +1241,7 @@ description = "A deep merge function for 🐍."
 optional = false
 python-versions = ">=3.6"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307"},
     {file = "mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8"},
@@ -1286,25 +1249,30 @@ files = [
 
 [[package]]
 name = "mike"
-version = "1.1.2"
+version = "2.1.3"
 description = "Manage multiple versions of your MkDocs-powered documentation"
 optional = false
 python-versions = "*"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "mike-1.1.2-py3-none-any.whl", hash = "sha256:4c307c28769834d78df10f834f57f810f04ca27d248f80a75f49c6fa2d1527ca"},
-    {file = "mike-1.1.2.tar.gz", hash = "sha256:56c3f1794c2d0b5fdccfa9b9487beb013ca813de2e3ad0744724e9d34d40b77b"},
+    {file = "mike-2.1.3-py3-none-any.whl", hash = "sha256:d90c64077e84f06272437b464735130d380703a76a5738b152932884c60c062a"},
+    {file = "mike-2.1.3.tar.gz", hash = "sha256:abd79b8ea483fb0275b7972825d3082e5ae67a41820f8d8a0dc7a3f49944e810"},
 ]
 
 [package.dependencies]
-jinja2 = "*"
+importlib-metadata = "*"
+importlib-resources = "*"
+jinja2 = ">=2.7"
 mkdocs = ">=1.0"
+pyparsing = ">=3.0"
 pyyaml = ">=5.1"
+pyyaml-env-tag = "*"
 verspec = "*"
 
 [package.extras]
-dev = ["coverage", "flake8 (>=3.0)", "shtab"]
-test = ["coverage", "flake8 (>=3.0)", "shtab"]
+dev = ["coverage", "flake8 (>=3.0)", "flake8-quotes", "shtab"]
+test = ["coverage", "flake8 (>=3.0)", "flake8-quotes", "shtab"]
 
 [[package]]
 name = "mkdocs"
@@ -1313,6 +1281,7 @@ description = "Project documentation with Markdown."
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e"},
     {file = "mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2"},
@@ -1322,7 +1291,6 @@ files = [
 click = ">=7.0"
 colorama = {version = ">=0.4", markers = "platform_system == \"Windows\""}
 ghp-import = ">=1.0"
-importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
 jinja2 = ">=2.11.1"
 markdown = ">=3.3.6"
 markupsafe = ">=2.0.1"
@@ -1345,6 +1313,7 @@ description = "Automatically link across pages in MkDocs."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "mkdocs_autorefs-1.3.0-py3-none-any.whl", hash = "sha256:d180f9778a04e78b7134e31418f238bba56f56d6a8af97873946ff661befffb3"},
     {file = "mkdocs_autorefs-1.3.0.tar.gz", hash = "sha256:6867764c099ace9025d6ac24fd07b85a98335fbd30107ef01053697c8f46db61"},
@@ -1362,6 +1331,7 @@ description = "MkDocs plugin to programmatically generate documentation pages du
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "mkdocs_gen_files-0.5.0-py3-none-any.whl", hash = "sha256:7ac060096f3f40bd19039e7277dd3050be9a453c8ac578645844d4d91d7978ea"},
     {file = "mkdocs_gen_files-0.5.0.tar.gz", hash = "sha256:4c7cf256b5d67062a788f6b1d035e157fc1a9498c2399be9af5257d4ff4d19bc"},
@@ -1377,13 +1347,13 @@ description = "MkDocs extension that lists all dependencies according to a mkdoc
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134"},
     {file = "mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c"},
 ]
 
 [package.dependencies]
-importlib-metadata = {version = ">=4.3", markers = "python_version < \"3.10\""}
 mergedeep = ">=1.3.4"
 platformdirs = ">=2.2.0"
 pyyaml = ">=5.1"
@@ -1395,6 +1365,7 @@ description = "Unleash the power of MkDocs with macros and variables"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "mkdocs_macros_plugin-1.3.7-py3-none-any.whl", hash = "sha256:02432033a5b77fb247d6ec7924e72fc4ceec264165b1644ab8d0dc159c22ce59"},
     {file = "mkdocs_macros_plugin-1.3.7.tar.gz", hash = "sha256:17c7fd1a49b94defcdb502fd453d17a1e730f8836523379d21292eb2be4cb523"},
@@ -1421,6 +1392,7 @@ description = "Documentation that simply works"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "mkdocs_material-9.5.49-py3-none-any.whl", hash = "sha256:c3c2d8176b18198435d3a3e119011922f3e11424074645c24019c2dcf08a360e"},
     {file = "mkdocs_material-9.5.49.tar.gz", hash = "sha256:3671bb282b4f53a1c72e08adbe04d2481a98f85fed392530051f80ff94a9621d"},
@@ -1451,6 +1423,7 @@ description = "Extension pack for Python Markdown and MkDocs Material."
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31"},
     {file = "mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443"},
@@ -1463,6 +1436,7 @@ description = "Automatic documentation from sources, for MkDocs."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "mkdocstrings-0.27.0-py3-none-any.whl", hash = "sha256:6ceaa7ea830770959b55a16203ac63da24badd71325b96af950e59fd37366332"},
     {file = "mkdocstrings-0.27.0.tar.gz", hash = "sha256:16adca6d6b0a1f9e0c07ff0b02ced8e16f228a9d65a37c063ec4c14d7b76a657"},
@@ -1470,7 +1444,6 @@ files = [
 
 [package.dependencies]
 click = ">=7.0"
-importlib-metadata = {version = ">=4.6", markers = "python_version < \"3.10\""}
 Jinja2 = ">=2.11.1"
 Markdown = ">=3.6"
 MarkupSafe = ">=1.1"
@@ -1479,7 +1452,6 @@ mkdocs-autorefs = ">=1.2"
 mkdocstrings-python = {version = ">=0.5.2", optional = true, markers = "extra == \"python\""}
 platformdirs = ">=2.2"
 pymdown-extensions = ">=6.3"
-typing-extensions = {version = ">=4.1", markers = "python_version < \"3.10\""}
 
 [package.extras]
 crystal = ["mkdocstrings-crystal (>=0.3.4)"]
@@ -1493,6 +1465,7 @@ description = "A Python handler for mkdocstrings."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "mkdocstrings_python-1.13.0-py3-none-any.whl", hash = "sha256:b88bbb207bab4086434743849f8e796788b373bd32e7bfefbf8560ac45d88f97"},
     {file = "mkdocstrings_python-1.13.0.tar.gz", hash = "sha256:2dbd5757e8375b9720e81db16f52f1856bf59905428fd7ef88005d1370e2f64c"},
@@ -1510,6 +1483,7 @@ description = "Type system extensions for programs checked with the mypy type ch
 optional = false
 python-versions = ">=3.5"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
     {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
@@ -1522,6 +1496,7 @@ description = "Node.js virtual environment builder"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9"},
     {file = "nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f"},
@@ -1529,49 +1504,68 @@ files = [
 
 [[package]]
 name = "numpy"
-version = "1.26.4"
+version = "2.2.1"
 description = "Fundamental package for array computing in Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version < \"3.13\" or extra == \"examples\""
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0"},
-    {file = "numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a"},
-    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4"},
-    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f"},
-    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a"},
-    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2"},
-    {file = "numpy-1.26.4-cp310-cp310-win32.whl", hash = "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07"},
-    {file = "numpy-1.26.4-cp310-cp310-win_amd64.whl", hash = "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5"},
-    {file = "numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71"},
-    {file = "numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef"},
-    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e"},
-    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5"},
-    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a"},
-    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a"},
-    {file = "numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20"},
-    {file = "numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2"},
-    {file = "numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218"},
-    {file = "numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b"},
-    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b"},
-    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed"},
-    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a"},
-    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0"},
-    {file = "numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110"},
-    {file = "numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818"},
-    {file = "numpy-1.26.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c"},
-    {file = "numpy-1.26.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be"},
-    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764"},
-    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3"},
-    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd"},
-    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c"},
-    {file = "numpy-1.26.4-cp39-cp39-win32.whl", hash = "sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6"},
-    {file = "numpy-1.26.4-cp39-cp39-win_amd64.whl", hash = "sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea"},
-    {file = "numpy-1.26.4-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30"},
-    {file = "numpy-1.26.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c"},
-    {file = "numpy-1.26.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0"},
-    {file = "numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"},
+    {file = "numpy-2.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5edb4e4caf751c1518e6a26a83501fda79bff41cc59dac48d70e6d65d4ec4440"},
+    {file = "numpy-2.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:aa3017c40d513ccac9621a2364f939d39e550c542eb2a894b4c8da92b38896ab"},
+    {file = "numpy-2.2.1-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:61048b4a49b1c93fe13426e04e04fdf5a03f456616f6e98c7576144677598675"},
+    {file = "numpy-2.2.1-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:7671dc19c7019103ca44e8d94917eba8534c76133523ca8406822efdd19c9308"},
+    {file = "numpy-2.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4250888bcb96617e00bfa28ac24850a83c9f3a16db471eca2ee1f1714df0f957"},
+    {file = "numpy-2.2.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7746f235c47abc72b102d3bce9977714c2444bdfaea7888d241b4c4bb6a78bf"},
+    {file = "numpy-2.2.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:059e6a747ae84fce488c3ee397cee7e5f905fd1bda5fb18c66bc41807ff119b2"},
+    {file = "numpy-2.2.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f62aa6ee4eb43b024b0e5a01cf65a0bb078ef8c395e8713c6e8a12a697144528"},
+    {file = "numpy-2.2.1-cp310-cp310-win32.whl", hash = "sha256:48fd472630715e1c1c89bf1feab55c29098cb403cc184b4859f9c86d4fcb6a95"},
+    {file = "numpy-2.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:b541032178a718c165a49638d28272b771053f628382d5e9d1c93df23ff58dbf"},
+    {file = "numpy-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:40f9e544c1c56ba8f1cf7686a8c9b5bb249e665d40d626a23899ba6d5d9e1484"},
+    {file = "numpy-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f9b57eaa3b0cd8db52049ed0330747b0364e899e8a606a624813452b8203d5f7"},
+    {file = "numpy-2.2.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:bc8a37ad5b22c08e2dbd27df2b3ef7e5c0864235805b1e718a235bcb200cf1cb"},
+    {file = "numpy-2.2.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:9036d6365d13b6cbe8f27a0eaf73ddcc070cae584e5ff94bb45e3e9d729feab5"},
+    {file = "numpy-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:51faf345324db860b515d3f364eaa93d0e0551a88d6218a7d61286554d190d73"},
+    {file = "numpy-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38efc1e56b73cc9b182fe55e56e63b044dd26a72128fd2fbd502f75555d92591"},
+    {file = "numpy-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:31b89fa67a8042e96715c68e071a1200c4e172f93b0fbe01a14c0ff3ff820fc8"},
+    {file = "numpy-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4c86e2a209199ead7ee0af65e1d9992d1dce7e1f63c4b9a616500f93820658d0"},
+    {file = "numpy-2.2.1-cp311-cp311-win32.whl", hash = "sha256:b34d87e8a3090ea626003f87f9392b3929a7bbf4104a05b6667348b6bd4bf1cd"},
+    {file = "numpy-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:360137f8fb1b753c5cde3ac388597ad680eccbbbb3865ab65efea062c4a1fd16"},
+    {file = "numpy-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:694f9e921a0c8f252980e85bce61ebbd07ed2b7d4fa72d0e4246f2f8aa6642ab"},
+    {file = "numpy-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3683a8d166f2692664262fd4900f207791d005fb088d7fdb973cc8d663626faa"},
+    {file = "numpy-2.2.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:780077d95eafc2ccc3ced969db22377b3864e5b9a0ea5eb347cc93b3ea900315"},
+    {file = "numpy-2.2.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:55ba24ebe208344aa7a00e4482f65742969a039c2acfcb910bc6fcd776eb4355"},
+    {file = "numpy-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b1d07b53b78bf84a96898c1bc139ad7f10fda7423f5fd158fd0f47ec5e01ac7"},
+    {file = "numpy-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5062dc1a4e32a10dc2b8b13cedd58988261416e811c1dc4dbdea4f57eea61b0d"},
+    {file = "numpy-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:fce4f615f8ca31b2e61aa0eb5865a21e14f5629515c9151850aa936c02a1ee51"},
+    {file = "numpy-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:67d4cda6fa6ffa073b08c8372aa5fa767ceb10c9a0587c707505a6d426f4e046"},
+    {file = "numpy-2.2.1-cp312-cp312-win32.whl", hash = "sha256:32cb94448be47c500d2c7a95f93e2f21a01f1fd05dd2beea1ccd049bb6001cd2"},
+    {file = "numpy-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:ba5511d8f31c033a5fcbda22dd5c813630af98c70b2661f2d2c654ae3cdfcfc8"},
+    {file = "numpy-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f1d09e520217618e76396377c81fba6f290d5f926f50c35f3a5f72b01a0da780"},
+    {file = "numpy-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3ecc47cd7f6ea0336042be87d9e7da378e5c7e9b3c8ad0f7c966f714fc10d821"},
+    {file = "numpy-2.2.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:f419290bc8968a46c4933158c91a0012b7a99bb2e465d5ef5293879742f8797e"},
+    {file = "numpy-2.2.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:5b6c390bfaef8c45a260554888966618328d30e72173697e5cabe6b285fb2348"},
+    {file = "numpy-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:526fc406ab991a340744aad7e25251dd47a6720a685fa3331e5c59fef5282a59"},
+    {file = "numpy-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f74e6fdeb9a265624ec3a3918430205dff1df7e95a230779746a6af78bc615af"},
+    {file = "numpy-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:53c09385ff0b72ba79d8715683c1168c12e0b6e84fb0372e97553d1ea91efe51"},
+    {file = "numpy-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f3eac17d9ec51be534685ba877b6ab5edc3ab7ec95c8f163e5d7b39859524716"},
+    {file = "numpy-2.2.1-cp313-cp313-win32.whl", hash = "sha256:9ad014faa93dbb52c80d8f4d3dcf855865c876c9660cb9bd7553843dd03a4b1e"},
+    {file = "numpy-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:164a829b6aacf79ca47ba4814b130c4020b202522a93d7bff2202bfb33b61c60"},
+    {file = "numpy-2.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4dfda918a13cc4f81e9118dea249e192ab167a0bb1966272d5503e39234d694e"},
+    {file = "numpy-2.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:733585f9f4b62e9b3528dd1070ec4f52b8acf64215b60a845fa13ebd73cd0712"},
+    {file = "numpy-2.2.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:89b16a18e7bba224ce5114db863e7029803c179979e1af6ad6a6b11f70545008"},
+    {file = "numpy-2.2.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:676f4eebf6b2d430300f1f4f4c2461685f8269f94c89698d832cdf9277f30b84"},
+    {file = "numpy-2.2.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27f5cdf9f493b35f7e41e8368e7d7b4bbafaf9660cba53fb21d2cd174ec09631"},
+    {file = "numpy-2.2.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1ad395cf254c4fbb5b2132fee391f361a6e8c1adbd28f2cd8e79308a615fe9d"},
+    {file = "numpy-2.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:08ef779aed40dbc52729d6ffe7dd51df85796a702afbf68a4f4e41fafdc8bda5"},
+    {file = "numpy-2.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:26c9c4382b19fcfbbed3238a14abf7ff223890ea1936b8890f058e7ba35e8d71"},
+    {file = "numpy-2.2.1-cp313-cp313t-win32.whl", hash = "sha256:93cf4e045bae74c90ca833cba583c14b62cb4ba2cba0abd2b141ab52548247e2"},
+    {file = "numpy-2.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:bff7d8ec20f5f42607599f9994770fa65d76edca264a87b5e4ea5629bce12268"},
+    {file = "numpy-2.2.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7ba9cc93a91d86365a5d270dee221fdc04fb68d7478e6bf6af650de78a8339e3"},
+    {file = "numpy-2.2.1-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:3d03883435a19794e41f147612a77a8f56d4e52822337844fff3d4040a142964"},
+    {file = "numpy-2.2.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4511d9e6071452b944207c8ce46ad2f897307910b402ea5fa975da32e0102800"},
+    {file = "numpy-2.2.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:5c5cc0cbabe9452038ed984d05ac87910f89370b9242371bd9079cb4af61811e"},
+    {file = "numpy-2.2.1.tar.gz", hash = "sha256:45681fd7128c8ad1c379f0ca0776a8b0c6583d2f69889ddac01559dfe4390918"},
 ]
 
 [[package]]
@@ -1581,6 +1575,7 @@ description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
     {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
@@ -1593,6 +1588,7 @@ description = "Divides large result sets into pages for easier browsing"
 optional = false
 python-versions = "*"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591"},
     {file = "paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945"},
@@ -1604,53 +1600,91 @@ lint = ["black"]
 
 [[package]]
 name = "pandas"
-version = "1.5.3"
+version = "2.2.3"
 description = "Powerful data structures for data analysis, time series, and statistics"
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"examples\""
+markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and extra == \"examples\""
 files = [
-    {file = "pandas-1.5.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3749077d86e3a2f0ed51367f30bf5b82e131cc0f14260c4d3e499186fccc4406"},
-    {file = "pandas-1.5.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:972d8a45395f2a2d26733eb8d0f629b2f90bebe8e8eddbb8829b180c09639572"},
-    {file = "pandas-1.5.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:50869a35cbb0f2e0cd5ec04b191e7b12ed688874bd05dd777c19b28cbea90996"},
-    {file = "pandas-1.5.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3ac844a0fe00bfaeb2c9b51ab1424e5c8744f89860b138434a363b1f620f354"},
-    {file = "pandas-1.5.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a0a56cef15fd1586726dace5616db75ebcfec9179a3a55e78f72c5639fa2a23"},
-    {file = "pandas-1.5.3-cp310-cp310-win_amd64.whl", hash = "sha256:478ff646ca42b20376e4ed3fa2e8d7341e8a63105586efe54fa2508ee087f328"},
-    {file = "pandas-1.5.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6973549c01ca91ec96199e940495219c887ea815b2083722821f1d7abfa2b4dc"},
-    {file = "pandas-1.5.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c39a8da13cede5adcd3be1182883aea1c925476f4e84b2807a46e2775306305d"},
-    {file = "pandas-1.5.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f76d097d12c82a535fda9dfe5e8dd4127952b45fea9b0276cb30cca5ea313fbc"},
-    {file = "pandas-1.5.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e474390e60ed609cec869b0da796ad94f420bb057d86784191eefc62b65819ae"},
-    {file = "pandas-1.5.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f2b952406a1588ad4cad5b3f55f520e82e902388a6d5a4a91baa8d38d23c7f6"},
-    {file = "pandas-1.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:bc4c368f42b551bf72fac35c5128963a171b40dce866fb066540eeaf46faa003"},
-    {file = "pandas-1.5.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:14e45300521902689a81f3f41386dc86f19b8ba8dd5ac5a3c7010ef8d2932813"},
-    {file = "pandas-1.5.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9842b6f4b8479e41968eced654487258ed81df7d1c9b7b870ceea24ed9459b31"},
-    {file = "pandas-1.5.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:26d9c71772c7afb9d5046e6e9cf42d83dd147b5cf5bcb9d97252077118543792"},
-    {file = "pandas-1.5.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5fbcb19d6fceb9e946b3e23258757c7b225ba450990d9ed63ccceeb8cae609f7"},
-    {file = "pandas-1.5.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:565fa34a5434d38e9d250af3c12ff931abaf88050551d9fbcdfafca50d62babf"},
-    {file = "pandas-1.5.3-cp38-cp38-win32.whl", hash = "sha256:87bd9c03da1ac870a6d2c8902a0e1fd4267ca00f13bc494c9e5a9020920e1d51"},
-    {file = "pandas-1.5.3-cp38-cp38-win_amd64.whl", hash = "sha256:41179ce559943d83a9b4bbacb736b04c928b095b5f25dd2b7389eda08f46f373"},
-    {file = "pandas-1.5.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c74a62747864ed568f5a82a49a23a8d7fe171d0c69038b38cedf0976831296fa"},
-    {file = "pandas-1.5.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c4c00e0b0597c8e4f59e8d461f797e5d70b4d025880516a8261b2817c47759ee"},
-    {file = "pandas-1.5.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a50d9a4336a9621cab7b8eb3fb11adb82de58f9b91d84c2cd526576b881a0c5a"},
-    {file = "pandas-1.5.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd05f7783b3274aa206a1af06f0ceed3f9b412cf665b7247eacd83be41cf7bf0"},
-    {file = "pandas-1.5.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f69c4029613de47816b1bb30ff5ac778686688751a5e9c99ad8c7031f6508e5"},
-    {file = "pandas-1.5.3-cp39-cp39-win32.whl", hash = "sha256:7cec0bee9f294e5de5bbfc14d0573f65526071029d036b753ee6507d2a21480a"},
-    {file = "pandas-1.5.3-cp39-cp39-win_amd64.whl", hash = "sha256:dfd681c5dc216037e0b0a2c821f5ed99ba9f03ebcf119c7dac0e9a7b960b9ec9"},
-    {file = "pandas-1.5.3.tar.gz", hash = "sha256:74a3fd7e5a7ec052f183273dc7b0acd3a863edf7520f5d3a1765c04ffdb3b0b1"},
+    {file = "pandas-2.2.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1948ddde24197a0f7add2bdc4ca83bf2b1ef84a1bc8ccffd95eda17fd836ecb5"},
+    {file = "pandas-2.2.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:381175499d3802cde0eabbaf6324cce0c4f5d52ca6f8c377c29ad442f50f6348"},
+    {file = "pandas-2.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d9c45366def9a3dd85a6454c0e7908f2b3b8e9c138f5dc38fed7ce720d8453ed"},
+    {file = "pandas-2.2.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86976a1c5b25ae3f8ccae3a5306e443569ee3c3faf444dfd0f41cda24667ad57"},
+    {file = "pandas-2.2.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b8661b0238a69d7aafe156b7fa86c44b881387509653fdf857bebc5e4008ad42"},
+    {file = "pandas-2.2.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37e0aced3e8f539eccf2e099f65cdb9c8aa85109b0be6e93e2baff94264bdc6f"},
+    {file = "pandas-2.2.3-cp310-cp310-win_amd64.whl", hash = "sha256:56534ce0746a58afaf7942ba4863e0ef81c9c50d3f0ae93e9497d6a41a057645"},
+    {file = "pandas-2.2.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:66108071e1b935240e74525006034333f98bcdb87ea116de573a6a0dccb6c039"},
+    {file = "pandas-2.2.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7c2875855b0ff77b2a64a0365e24455d9990730d6431b9e0ee18ad8acee13dbd"},
+    {file = "pandas-2.2.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd8d0c3be0515c12fed0bdbae072551c8b54b7192c7b1fda0ba56059a0179698"},
+    {file = "pandas-2.2.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c124333816c3a9b03fbeef3a9f230ba9a737e9e5bb4060aa2107a86cc0a497fc"},
+    {file = "pandas-2.2.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:63cc132e40a2e084cf01adf0775b15ac515ba905d7dcca47e9a251819c575ef3"},
+    {file = "pandas-2.2.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29401dbfa9ad77319367d36940cd8a0b3a11aba16063e39632d98b0e931ddf32"},
+    {file = "pandas-2.2.3-cp311-cp311-win_amd64.whl", hash = "sha256:3fc6873a41186404dad67245896a6e440baacc92f5b716ccd1bc9ed2995ab2c5"},
+    {file = "pandas-2.2.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b1d432e8d08679a40e2a6d8b2f9770a5c21793a6f9f47fdd52c5ce1948a5a8a9"},
+    {file = "pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a5a1595fe639f5988ba6a8e5bc9649af3baf26df3998a0abe56c02609392e0a4"},
+    {file = "pandas-2.2.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5de54125a92bb4d1c051c0659e6fcb75256bf799a732a87184e5ea503965bce3"},
+    {file = "pandas-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fffb8ae78d8af97f849404f21411c95062db1496aeb3e56f146f0355c9989319"},
+    {file = "pandas-2.2.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6dfcb5ee8d4d50c06a51c2fffa6cff6272098ad6540aed1a76d15fb9318194d8"},
+    {file = "pandas-2.2.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:062309c1b9ea12a50e8ce661145c6aab431b1e99530d3cd60640e255778bd43a"},
+    {file = "pandas-2.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:59ef3764d0fe818125a5097d2ae867ca3fa64df032331b7e0917cf5d7bf66b13"},
+    {file = "pandas-2.2.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f00d1345d84d8c86a63e476bb4955e46458b304b9575dcf71102b5c705320015"},
+    {file = "pandas-2.2.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3508d914817e153ad359d7e069d752cdd736a247c322d932eb89e6bc84217f28"},
+    {file = "pandas-2.2.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22a9d949bfc9a502d320aa04e5d02feab689d61da4e7764b62c30b991c42c5f0"},
+    {file = "pandas-2.2.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3a255b2c19987fbbe62a9dfd6cff7ff2aa9ccab3fc75218fd4b7530f01efa24"},
+    {file = "pandas-2.2.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:800250ecdadb6d9c78eae4990da62743b857b470883fa27f652db8bdde7f6659"},
+    {file = "pandas-2.2.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6374c452ff3ec675a8f46fd9ab25c4ad0ba590b71cf0656f8b6daa5202bca3fb"},
+    {file = "pandas-2.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:61c5ad4043f791b61dd4752191d9f07f0ae412515d59ba8f005832a532f8736d"},
+    {file = "pandas-2.2.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3b71f27954685ee685317063bf13c7709a7ba74fc996b84fc6821c59b0f06468"},
+    {file = "pandas-2.2.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:38cf8125c40dae9d5acc10fa66af8ea6fdf760b2714ee482ca691fc66e6fcb18"},
+    {file = "pandas-2.2.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba96630bc17c875161df3818780af30e43be9b166ce51c9a18c1feae342906c2"},
+    {file = "pandas-2.2.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db71525a1538b30142094edb9adc10be3f3e176748cd7acc2240c2f2e5aa3a4"},
+    {file = "pandas-2.2.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:15c0e1e02e93116177d29ff83e8b1619c93ddc9c49083f237d4312337a61165d"},
+    {file = "pandas-2.2.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ad5b65698ab28ed8d7f18790a0dc58005c7629f227be9ecc1072aa74c0c1d43a"},
+    {file = "pandas-2.2.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bc6b93f9b966093cb0fd62ff1a7e4c09e6d546ad7c1de191767baffc57628f39"},
+    {file = "pandas-2.2.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5dbca4c1acd72e8eeef4753eeca07de9b1db4f398669d5994086f788a5d7cc30"},
+    {file = "pandas-2.2.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8cd6d7cc958a3910f934ea8dbdf17b2364827bb4dafc38ce6eef6bb3d65ff09c"},
+    {file = "pandas-2.2.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99df71520d25fade9db7c1076ac94eb994f4d2673ef2aa2e86ee039b6746d20c"},
+    {file = "pandas-2.2.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:31d0ced62d4ea3e231a9f228366919a5ea0b07440d9d4dac345376fd8e1477ea"},
+    {file = "pandas-2.2.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:7eee9e7cea6adf3e3d24e304ac6b8300646e2a5d1cd3a3c2abed9101b0846761"},
+    {file = "pandas-2.2.3-cp39-cp39-win_amd64.whl", hash = "sha256:4850ba03528b6dd51d6c5d273c46f183f39a9baf3f0143e566b89450965b105e"},
+    {file = "pandas-2.2.3.tar.gz", hash = "sha256:4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667"},
 ]
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.20.3", markers = "python_version < \"3.10\""},
-    {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
-    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
+    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
+    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
 ]
-python-dateutil = ">=2.8.1"
+python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
+tzdata = ">=2022.7"
 
 [package.extras]
-test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
+all = ["PyQt5 (>=5.15.9)", "SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)", "beautifulsoup4 (>=4.11.2)", "bottleneck (>=1.3.6)", "dataframe-api-compat (>=0.1.7)", "fastparquet (>=2022.12.0)", "fsspec (>=2022.11.0)", "gcsfs (>=2022.11.0)", "html5lib (>=1.1)", "hypothesis (>=6.46.1)", "jinja2 (>=3.1.2)", "lxml (>=4.9.2)", "matplotlib (>=3.6.3)", "numba (>=0.56.4)", "numexpr (>=2.8.4)", "odfpy (>=1.4.1)", "openpyxl (>=3.1.0)", "pandas-gbq (>=0.19.0)", "psycopg2 (>=2.9.6)", "pyarrow (>=10.0.1)", "pymysql (>=1.0.2)", "pyreadstat (>=1.2.0)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)", "python-calamine (>=0.1.7)", "pyxlsb (>=1.0.10)", "qtpy (>=2.3.0)", "s3fs (>=2022.11.0)", "scipy (>=1.10.0)", "tables (>=3.8.0)", "tabulate (>=0.9.0)", "xarray (>=2022.12.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.5)", "zstandard (>=0.19.0)"]
+aws = ["s3fs (>=2022.11.0)"]
+clipboard = ["PyQt5 (>=5.15.9)", "qtpy (>=2.3.0)"]
+compression = ["zstandard (>=0.19.0)"]
+computation = ["scipy (>=1.10.0)", "xarray (>=2022.12.0)"]
+consortium-standard = ["dataframe-api-compat (>=0.1.7)"]
+excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.1.0)", "python-calamine (>=0.1.7)", "pyxlsb (>=1.0.10)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.5)"]
+feather = ["pyarrow (>=10.0.1)"]
+fss = ["fsspec (>=2022.11.0)"]
+gcp = ["gcsfs (>=2022.11.0)", "pandas-gbq (>=0.19.0)"]
+hdf5 = ["tables (>=3.8.0)"]
+html = ["beautifulsoup4 (>=4.11.2)", "html5lib (>=1.1)", "lxml (>=4.9.2)"]
+mysql = ["SQLAlchemy (>=2.0.0)", "pymysql (>=1.0.2)"]
+output-formatting = ["jinja2 (>=3.1.2)", "tabulate (>=0.9.0)"]
+parquet = ["pyarrow (>=10.0.1)"]
+performance = ["bottleneck (>=1.3.6)", "numba (>=0.56.4)", "numexpr (>=2.8.4)"]
+plot = ["matplotlib (>=3.6.3)"]
+postgresql = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "psycopg2 (>=2.9.6)"]
+pyarrow = ["pyarrow (>=10.0.1)"]
+spss = ["pyreadstat (>=1.2.0)"]
+sql-other = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)"]
+test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
+xml = ["lxml (>=4.9.2)"]
 
 [[package]]
 name = "pathspec"
@@ -1659,6 +1693,7 @@ description = "Utility library for gitignore style pattern matching of file path
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
     {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
@@ -1671,7 +1706,7 @@ description = "Python Imaging Library (Fork)"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"examples\""
+markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and extra == \"examples\""
 files = [
     {file = "pillow-11.1.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:e1abe69aca89514737465752b4bcaf8016de61b3be1397a8fc260ba33321b3a8"},
     {file = "pillow-11.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c640e5a06869c75994624551f45e5506e4256562ead981cce820d5ab39ae2192"},
@@ -1761,6 +1796,7 @@ description = "A small Python package for determining appropriate platform-speci
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
     {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
@@ -1778,6 +1814,7 @@ description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
     {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
@@ -1789,14 +1826,15 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
-version = "3.8.0"
+version = "4.0.1"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "pre_commit-3.8.0-py2.py3-none-any.whl", hash = "sha256:9a90a53bf82fdd8778d58085faf8d83df56e40dfe18f45b19446e26bf1b3a63f"},
-    {file = "pre_commit-3.8.0.tar.gz", hash = "sha256:8bb6494d4a20423842e198980c9ecf9f96607a07ea29549e180eef9ae80fe7af"},
+    {file = "pre_commit-4.0.1-py2.py3-none-any.whl", hash = "sha256:efde913840816312445dc98787724647c65473daefe420785f885e8ed9a06878"},
+    {file = "pre_commit-4.0.1.tar.gz", hash = "sha256:80905ac375958c0444c65e9cebebd948b3cdb518f335a091a670a89d652139d2"},
 ]
 
 [package.dependencies]
@@ -1813,6 +1851,7 @@ description = "Beautiful, Pythonic protocol buffers."
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "proto_plus-1.25.0-py3-none-any.whl", hash = "sha256:c91fc4a65074ade8e458e95ef8bac34d4008daa7cce4a12d6707066fca648961"},
     {file = "proto_plus-1.25.0.tar.gz", hash = "sha256:fbb17f57f7bd05a68b7707e745e26528b0b3c34e378db91eef93912c54982d91"},
@@ -1831,6 +1870,7 @@ description = ""
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "protobuf-5.29.3-cp310-abi3-win32.whl", hash = "sha256:3ea51771449e1035f26069c4c7fd51fba990d07bc55ba80701c78f886bf9c888"},
     {file = "protobuf-5.29.3-cp310-abi3-win_amd64.whl", hash = "sha256:a4fa6f80816a9a0678429e84973f2f98cbc218cca434abe8db2ad0bffc98503a"},
@@ -1852,7 +1892,7 @@ description = "C parser in Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "implementation_name == \"pypy\""
+markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and implementation_name == \"pypy\""
 files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
@@ -1865,7 +1905,7 @@ description = "Pure-python FIGlet implementation"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"examples\""
+markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and extra == \"examples\""
 files = [
     {file = "pyfiglet-1.0.2-py3-none-any.whl", hash = "sha256:889b351d79c99e50a3f619c8f8e6ffdb27fd8c939fc43ecbd7559bd57d5f93ea"},
     {file = "pyfiglet-1.0.2.tar.gz", hash = "sha256:758788018ab8faaddc0984e1ea05ff330d3c64be663c513cc1f105f6a3066dab"},
@@ -1878,6 +1918,7 @@ description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"},
     {file = "pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f"},
@@ -1893,6 +1934,7 @@ description = "Extension pack for Python Markdown."
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "pymdown_extensions-10.14-py3-none-any.whl", hash = "sha256:202481f716cc8250e4be8fce997781ebf7917701b59652458ee47f2401f818b5"},
     {file = "pymdown_extensions-10.14.tar.gz", hash = "sha256:741bd7c4ff961ba40b7528d32284c53bc436b8b1645e8e37c3e57770b8700a34"},
@@ -1909,28 +1951,29 @@ extra = ["pygments (>=2.19.1)"]
 name = "pyparsing"
 version = "3.2.1"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
-optional = true
+optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"examples\""
+groups = ["main", "dev"]
 files = [
     {file = "pyparsing-3.2.1-py3-none-any.whl", hash = "sha256:506ff4f4386c4cec0590ec19e6302d3aedb992fdc02c761e90416f158dacf8e1"},
     {file = "pyparsing-3.2.1.tar.gz", hash = "sha256:61980854fd66de3a90028d679a954d5f2623e83144b5afe5ee86f43d762e5f0a"},
 ]
+markers = {main = "(python_version <= \"3.11\" or python_version >= \"3.12\") and extra == \"examples\"", dev = "python_version <= \"3.11\" or python_version >= \"3.12\""}
 
 [package.extras]
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "7.4.4"
+version = "8.3.4"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"},
-    {file = "pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"},
+    {file = "pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6"},
+    {file = "pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"},
 ]
 
 [package.dependencies]
@@ -1938,30 +1981,31 @@ colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
-pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+pluggy = ">=1.5,<2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-cov"
-version = "4.1.0"
+version = "6.0.0"
 description = "Pytest plugin for measuring coverage."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
-    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
+    {file = "pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0"},
+    {file = "pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35"},
 ]
 
 [package.dependencies]
-coverage = {version = ">=5.2.1", extras = ["toml"]}
+coverage = {version = ">=7.5", extras = ["toml"]}
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "pytest-mock"
@@ -1970,6 +2014,7 @@ description = "Thin-wrapper around the mock package for easier use with pytest"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
     {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
@@ -1988,6 +2033,7 @@ description = "Extensions to the standard Python datetime module"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 groups = ["main", "dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
     {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
@@ -2003,7 +2049,7 @@ description = "World timezone definitions, modern and historical"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"examples\""
+markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and extra == \"examples\""
 files = [
     {file = "pytz-2024.2-py2.py3-none-any.whl", hash = "sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725"},
     {file = "pytz-2024.2.tar.gz", hash = "sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a"},
@@ -2016,7 +2062,7 @@ description = "Python for Window Extensions"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"examples\" and sys_platform == \"win32\""
+markers = "extra == \"examples\" and sys_platform == \"win32\" and (python_version <= \"3.11\" or python_version >= \"3.12\")"
 files = [
     {file = "pywin32-308-cp310-cp310-win32.whl", hash = "sha256:796ff4426437896550d2981b9c2ac0ffd75238ad9ea2d3bfa67a1abd546d262e"},
     {file = "pywin32-308-cp310-cp310-win_amd64.whl", hash = "sha256:4fc888c59b3c0bef905ce7eb7e2106a07712015ea1c8234b703a088d46110e8e"},
@@ -2045,6 +2091,7 @@ description = "YAML parser and emitter for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
     {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
@@ -2108,6 +2155,7 @@ description = "A custom YAML tag for referencing environment variables in YAML f
 optional = false
 python-versions = ">=3.6"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "pyyaml_env_tag-0.1-py3-none-any.whl", hash = "sha256:af31106dec8a4d68c60207c1886031cbf839b68aa7abccdb19868200532c2069"},
     {file = "pyyaml_env_tag-0.1.tar.gz", hash = "sha256:70092675bda14fdec33b31ba77e7543de9ddc88f2e5b99160396572d11525bdb"},
@@ -2118,105 +2166,122 @@ pyyaml = "*"
 
 [[package]]
 name = "pyzmq"
-version = "25.1.2"
+version = "26.2.0"
 description = "Python bindings for 0MQ"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 groups = ["main"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "pyzmq-25.1.2-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:e624c789359f1a16f83f35e2c705d07663ff2b4d4479bad35621178d8f0f6ea4"},
-    {file = "pyzmq-25.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:49151b0efece79f6a79d41a461d78535356136ee70084a1c22532fc6383f4ad0"},
-    {file = "pyzmq-25.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d9a5f194cf730f2b24d6af1f833c14c10f41023da46a7f736f48b6d35061e76e"},
-    {file = "pyzmq-25.1.2-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:faf79a302f834d9e8304fafdc11d0d042266667ac45209afa57e5efc998e3872"},
-    {file = "pyzmq-25.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f51a7b4ead28d3fca8dda53216314a553b0f7a91ee8fc46a72b402a78c3e43d"},
-    {file = "pyzmq-25.1.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:0ddd6d71d4ef17ba5a87becf7ddf01b371eaba553c603477679ae817a8d84d75"},
-    {file = "pyzmq-25.1.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:246747b88917e4867e2367b005fc8eefbb4a54b7db363d6c92f89d69abfff4b6"},
-    {file = "pyzmq-25.1.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:00c48ae2fd81e2a50c3485de1b9d5c7c57cd85dc8ec55683eac16846e57ac979"},
-    {file = "pyzmq-25.1.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5a68d491fc20762b630e5db2191dd07ff89834086740f70e978bb2ef2668be08"},
-    {file = "pyzmq-25.1.2-cp310-cp310-win32.whl", hash = "sha256:09dfe949e83087da88c4a76767df04b22304a682d6154de2c572625c62ad6886"},
-    {file = "pyzmq-25.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:fa99973d2ed20417744fca0073390ad65ce225b546febb0580358e36aa90dba6"},
-    {file = "pyzmq-25.1.2-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:82544e0e2d0c1811482d37eef297020a040c32e0687c1f6fc23a75b75db8062c"},
-    {file = "pyzmq-25.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:01171fc48542348cd1a360a4b6c3e7d8f46cdcf53a8d40f84db6707a6768acc1"},
-    {file = "pyzmq-25.1.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc69c96735ab501419c432110016329bf0dea8898ce16fab97c6d9106dc0b348"},
-    {file = "pyzmq-25.1.2-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3e124e6b1dd3dfbeb695435dff0e383256655bb18082e094a8dd1f6293114642"},
-    {file = "pyzmq-25.1.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7598d2ba821caa37a0f9d54c25164a4fa351ce019d64d0b44b45540950458840"},
-    {file = "pyzmq-25.1.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:d1299d7e964c13607efd148ca1f07dcbf27c3ab9e125d1d0ae1d580a1682399d"},
-    {file = "pyzmq-25.1.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4e6f689880d5ad87918430957297c975203a082d9a036cc426648fcbedae769b"},
-    {file = "pyzmq-25.1.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:cc69949484171cc961e6ecd4a8911b9ce7a0d1f738fcae717177c231bf77437b"},
-    {file = "pyzmq-25.1.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9880078f683466b7f567b8624bfc16cad65077be046b6e8abb53bed4eeb82dd3"},
-    {file = "pyzmq-25.1.2-cp311-cp311-win32.whl", hash = "sha256:4e5837af3e5aaa99a091302df5ee001149baff06ad22b722d34e30df5f0d9097"},
-    {file = "pyzmq-25.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:25c2dbb97d38b5ac9fd15586e048ec5eb1e38f3d47fe7d92167b0c77bb3584e9"},
-    {file = "pyzmq-25.1.2-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:11e70516688190e9c2db14fcf93c04192b02d457b582a1f6190b154691b4c93a"},
-    {file = "pyzmq-25.1.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:313c3794d650d1fccaaab2df942af9f2c01d6217c846177cfcbc693c7410839e"},
-    {file = "pyzmq-25.1.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b3cbba2f47062b85fe0ef9de5b987612140a9ba3a9c6d2543c6dec9f7c2ab27"},
-    {file = "pyzmq-25.1.2-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fc31baa0c32a2ca660784d5af3b9487e13b61b3032cb01a115fce6588e1bed30"},
-    {file = "pyzmq-25.1.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:02c9087b109070c5ab0b383079fa1b5f797f8d43e9a66c07a4b8b8bdecfd88ee"},
-    {file = "pyzmq-25.1.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:f8429b17cbb746c3e043cb986328da023657e79d5ed258b711c06a70c2ea7537"},
-    {file = "pyzmq-25.1.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:5074adeacede5f810b7ef39607ee59d94e948b4fd954495bdb072f8c54558181"},
-    {file = "pyzmq-25.1.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:7ae8f354b895cbd85212da245f1a5ad8159e7840e37d78b476bb4f4c3f32a9fe"},
-    {file = "pyzmq-25.1.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:b264bf2cc96b5bc43ce0e852be995e400376bd87ceb363822e2cb1964fcdc737"},
-    {file = "pyzmq-25.1.2-cp312-cp312-win32.whl", hash = "sha256:02bbc1a87b76e04fd780b45e7f695471ae6de747769e540da909173d50ff8e2d"},
-    {file = "pyzmq-25.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:ced111c2e81506abd1dc142e6cd7b68dd53747b3b7ae5edbea4578c5eeff96b7"},
-    {file = "pyzmq-25.1.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:7b6d09a8962a91151f0976008eb7b29b433a560fde056ec7a3db9ec8f1075438"},
-    {file = "pyzmq-25.1.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:967668420f36878a3c9ecb5ab33c9d0ff8d054f9c0233d995a6d25b0e95e1b6b"},
-    {file = "pyzmq-25.1.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5edac3f57c7ddaacdb4d40f6ef2f9e299471fc38d112f4bc6d60ab9365445fb0"},
-    {file = "pyzmq-25.1.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:0dabfb10ef897f3b7e101cacba1437bd3a5032ee667b7ead32bbcdd1a8422fe7"},
-    {file = "pyzmq-25.1.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:2c6441e0398c2baacfe5ba30c937d274cfc2dc5b55e82e3749e333aabffde561"},
-    {file = "pyzmq-25.1.2-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:16b726c1f6c2e7625706549f9dbe9b06004dfbec30dbed4bf50cbdfc73e5b32a"},
-    {file = "pyzmq-25.1.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:a86c2dd76ef71a773e70551a07318b8e52379f58dafa7ae1e0a4be78efd1ff16"},
-    {file = "pyzmq-25.1.2-cp36-cp36m-win32.whl", hash = "sha256:359f7f74b5d3c65dae137f33eb2bcfa7ad9ebefd1cab85c935f063f1dbb245cc"},
-    {file = "pyzmq-25.1.2-cp36-cp36m-win_amd64.whl", hash = "sha256:55875492f820d0eb3417b51d96fea549cde77893ae3790fd25491c5754ea2f68"},
-    {file = "pyzmq-25.1.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b8c8a419dfb02e91b453615c69568442e897aaf77561ee0064d789705ff37a92"},
-    {file = "pyzmq-25.1.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8807c87fa893527ae8a524c15fc505d9950d5e856f03dae5921b5e9aa3b8783b"},
-    {file = "pyzmq-25.1.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5e319ed7d6b8f5fad9b76daa0a68497bc6f129858ad956331a5835785761e003"},
-    {file = "pyzmq-25.1.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:3c53687dde4d9d473c587ae80cc328e5b102b517447456184b485587ebd18b62"},
-    {file = "pyzmq-25.1.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:9add2e5b33d2cd765ad96d5eb734a5e795a0755f7fc49aa04f76d7ddda73fd70"},
-    {file = "pyzmq-25.1.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:e690145a8c0c273c28d3b89d6fb32c45e0d9605b2293c10e650265bf5c11cfec"},
-    {file = "pyzmq-25.1.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:00a06faa7165634f0cac1abb27e54d7a0b3b44eb9994530b8ec73cf52e15353b"},
-    {file = "pyzmq-25.1.2-cp37-cp37m-win32.whl", hash = "sha256:0f97bc2f1f13cb16905a5f3e1fbdf100e712d841482b2237484360f8bc4cb3d7"},
-    {file = "pyzmq-25.1.2-cp37-cp37m-win_amd64.whl", hash = "sha256:6cc0020b74b2e410287e5942e1e10886ff81ac77789eb20bec13f7ae681f0fdd"},
-    {file = "pyzmq-25.1.2-cp38-cp38-macosx_10_15_universal2.whl", hash = "sha256:bef02cfcbded83473bdd86dd8d3729cd82b2e569b75844fb4ea08fee3c26ae41"},
-    {file = "pyzmq-25.1.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e10a4b5a4b1192d74853cc71a5e9fd022594573926c2a3a4802020360aa719d8"},
-    {file = "pyzmq-25.1.2-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8c5f80e578427d4695adac6fdf4370c14a2feafdc8cb35549c219b90652536ae"},
-    {file = "pyzmq-25.1.2-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5dde6751e857910c1339890f3524de74007958557593b9e7e8c5f01cd919f8a7"},
-    {file = "pyzmq-25.1.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea1608dd169da230a0ad602d5b1ebd39807ac96cae1845c3ceed39af08a5c6df"},
-    {file = "pyzmq-25.1.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:0f513130c4c361201da9bc69df25a086487250e16b5571ead521b31ff6b02220"},
-    {file = "pyzmq-25.1.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:019744b99da30330798bb37df33549d59d380c78e516e3bab9c9b84f87a9592f"},
-    {file = "pyzmq-25.1.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2e2713ef44be5d52dd8b8e2023d706bf66cb22072e97fc71b168e01d25192755"},
-    {file = "pyzmq-25.1.2-cp38-cp38-win32.whl", hash = "sha256:07cd61a20a535524906595e09344505a9bd46f1da7a07e504b315d41cd42eb07"},
-    {file = "pyzmq-25.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:eb7e49a17fb8c77d3119d41a4523e432eb0c6932187c37deb6fbb00cc3028088"},
-    {file = "pyzmq-25.1.2-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:94504ff66f278ab4b7e03e4cba7e7e400cb73bfa9d3d71f58d8972a8dc67e7a6"},
-    {file = "pyzmq-25.1.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6dd0d50bbf9dca1d0bdea219ae6b40f713a3fb477c06ca3714f208fd69e16fd8"},
-    {file = "pyzmq-25.1.2-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:004ff469d21e86f0ef0369717351073e0e577428e514c47c8480770d5e24a565"},
-    {file = "pyzmq-25.1.2-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c0b5ca88a8928147b7b1e2dfa09f3b6c256bc1135a1338536cbc9ea13d3b7add"},
-    {file = "pyzmq-25.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c9a79f1d2495b167119d02be7448bfba57fad2a4207c4f68abc0bab4b92925b"},
-    {file = "pyzmq-25.1.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:518efd91c3d8ac9f9b4f7dd0e2b7b8bf1a4fe82a308009016b07eaa48681af82"},
-    {file = "pyzmq-25.1.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:1ec23bd7b3a893ae676d0e54ad47d18064e6c5ae1fadc2f195143fb27373f7f6"},
-    {file = "pyzmq-25.1.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:db36c27baed588a5a8346b971477b718fdc66cf5b80cbfbd914b4d6d355e44e2"},
-    {file = "pyzmq-25.1.2-cp39-cp39-win32.whl", hash = "sha256:39b1067f13aba39d794a24761e385e2eddc26295826530a8c7b6c6c341584289"},
-    {file = "pyzmq-25.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:8e9f3fabc445d0ce320ea2c59a75fe3ea591fdbdeebec5db6de530dd4b09412e"},
-    {file = "pyzmq-25.1.2-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a8c1d566344aee826b74e472e16edae0a02e2a044f14f7c24e123002dcff1c05"},
-    {file = "pyzmq-25.1.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:759cfd391a0996345ba94b6a5110fca9c557ad4166d86a6e81ea526c376a01e8"},
-    {file = "pyzmq-25.1.2-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7c61e346ac34b74028ede1c6b4bcecf649d69b707b3ff9dc0fab453821b04d1e"},
-    {file = "pyzmq-25.1.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4cb8fc1f8d69b411b8ec0b5f1ffbcaf14c1db95b6bccea21d83610987435f1a4"},
-    {file = "pyzmq-25.1.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:3c00c9b7d1ca8165c610437ca0c92e7b5607b2f9076f4eb4b095c85d6e680a1d"},
-    {file = "pyzmq-25.1.2-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:df0c7a16ebb94452d2909b9a7b3337940e9a87a824c4fc1c7c36bb4404cb0cde"},
-    {file = "pyzmq-25.1.2-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:45999e7f7ed5c390f2e87ece7f6c56bf979fb213550229e711e45ecc7d42ccb8"},
-    {file = "pyzmq-25.1.2-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ac170e9e048b40c605358667aca3d94e98f604a18c44bdb4c102e67070f3ac9b"},
-    {file = "pyzmq-25.1.2-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1b604734bec94f05f81b360a272fc824334267426ae9905ff32dc2be433ab96"},
-    {file = "pyzmq-25.1.2-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:a793ac733e3d895d96f865f1806f160696422554e46d30105807fdc9841b9f7d"},
-    {file = "pyzmq-25.1.2-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:0806175f2ae5ad4b835ecd87f5f85583316b69f17e97786f7443baaf54b9bb98"},
-    {file = "pyzmq-25.1.2-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ef12e259e7bc317c7597d4f6ef59b97b913e162d83b421dd0db3d6410f17a244"},
-    {file = "pyzmq-25.1.2-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ea253b368eb41116011add00f8d5726762320b1bda892f744c91997b65754d73"},
-    {file = "pyzmq-25.1.2-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b9b1f2ad6498445a941d9a4fee096d387fee436e45cc660e72e768d3d8ee611"},
-    {file = "pyzmq-25.1.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:8b14c75979ce932c53b79976a395cb2a8cd3aaf14aef75e8c2cb55a330b9b49d"},
-    {file = "pyzmq-25.1.2-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:889370d5174a741a62566c003ee8ddba4b04c3f09a97b8000092b7ca83ec9c49"},
-    {file = "pyzmq-25.1.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a18fff090441a40ffda8a7f4f18f03dc56ae73f148f1832e109f9bffa85df15"},
-    {file = "pyzmq-25.1.2-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:99a6b36f95c98839ad98f8c553d8507644c880cf1e0a57fe5e3a3f3969040882"},
-    {file = "pyzmq-25.1.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4345c9a27f4310afbb9c01750e9461ff33d6fb74cd2456b107525bbeebcb5be3"},
-    {file = "pyzmq-25.1.2-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:3516e0b6224cf6e43e341d56da15fd33bdc37fa0c06af4f029f7d7dfceceabbc"},
-    {file = "pyzmq-25.1.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:146b9b1f29ead41255387fb07be56dc29639262c0f7344f570eecdcd8d683314"},
-    {file = "pyzmq-25.1.2.tar.gz", hash = "sha256:93f1aa311e8bb912e34f004cf186407a4e90eec4f0ecc0efd26056bf7eda0226"},
+    {file = "pyzmq-26.2.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:ddf33d97d2f52d89f6e6e7ae66ee35a4d9ca6f36eda89c24591b0c40205a3629"},
+    {file = "pyzmq-26.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:dacd995031a01d16eec825bf30802fceb2c3791ef24bcce48fa98ce40918c27b"},
+    {file = "pyzmq-26.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89289a5ee32ef6c439086184529ae060c741334b8970a6855ec0b6ad3ff28764"},
+    {file = "pyzmq-26.2.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5506f06d7dc6ecf1efacb4a013b1f05071bb24b76350832c96449f4a2d95091c"},
+    {file = "pyzmq-26.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ea039387c10202ce304af74def5021e9adc6297067f3441d348d2b633e8166a"},
+    {file = "pyzmq-26.2.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a2224fa4a4c2ee872886ed00a571f5e967c85e078e8e8c2530a2fb01b3309b88"},
+    {file = "pyzmq-26.2.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:28ad5233e9c3b52d76196c696e362508959741e1a005fb8fa03b51aea156088f"},
+    {file = "pyzmq-26.2.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:1c17211bc037c7d88e85ed8b7d8f7e52db6dc8eca5590d162717c654550f7282"},
+    {file = "pyzmq-26.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b8f86dd868d41bea9a5f873ee13bf5551c94cf6bc51baebc6f85075971fe6eea"},
+    {file = "pyzmq-26.2.0-cp310-cp310-win32.whl", hash = "sha256:46a446c212e58456b23af260f3d9fb785054f3e3653dbf7279d8f2b5546b21c2"},
+    {file = "pyzmq-26.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:49d34ab71db5a9c292a7644ce74190b1dd5a3475612eefb1f8be1d6961441971"},
+    {file = "pyzmq-26.2.0-cp310-cp310-win_arm64.whl", hash = "sha256:bfa832bfa540e5b5c27dcf5de5d82ebc431b82c453a43d141afb1e5d2de025fa"},
+    {file = "pyzmq-26.2.0-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:8f7e66c7113c684c2b3f1c83cdd3376103ee0ce4c49ff80a648643e57fb22218"},
+    {file = "pyzmq-26.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3a495b30fc91db2db25120df5847d9833af237546fd59170701acd816ccc01c4"},
+    {file = "pyzmq-26.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77eb0968da535cba0470a5165468b2cac7772cfb569977cff92e240f57e31bef"},
+    {file = "pyzmq-26.2.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ace4f71f1900a548f48407fc9be59c6ba9d9aaf658c2eea6cf2779e72f9f317"},
+    {file = "pyzmq-26.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:92a78853d7280bffb93df0a4a6a2498cba10ee793cc8076ef797ef2f74d107cf"},
+    {file = "pyzmq-26.2.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:689c5d781014956a4a6de61d74ba97b23547e431e9e7d64f27d4922ba96e9d6e"},
+    {file = "pyzmq-26.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0aca98bc423eb7d153214b2df397c6421ba6373d3397b26c057af3c904452e37"},
+    {file = "pyzmq-26.2.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:1f3496d76b89d9429a656293744ceca4d2ac2a10ae59b84c1da9b5165f429ad3"},
+    {file = "pyzmq-26.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5c2b3bfd4b9689919db068ac6c9911f3fcb231c39f7dd30e3138be94896d18e6"},
+    {file = "pyzmq-26.2.0-cp311-cp311-win32.whl", hash = "sha256:eac5174677da084abf378739dbf4ad245661635f1600edd1221f150b165343f4"},
+    {file = "pyzmq-26.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:5a509df7d0a83a4b178d0f937ef14286659225ef4e8812e05580776c70e155d5"},
+    {file = "pyzmq-26.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:c0e6091b157d48cbe37bd67233318dbb53e1e6327d6fc3bb284afd585d141003"},
+    {file = "pyzmq-26.2.0-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:ded0fc7d90fe93ae0b18059930086c51e640cdd3baebdc783a695c77f123dcd9"},
+    {file = "pyzmq-26.2.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:17bf5a931c7f6618023cdacc7081f3f266aecb68ca692adac015c383a134ca52"},
+    {file = "pyzmq-26.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55cf66647e49d4621a7e20c8d13511ef1fe1efbbccf670811864452487007e08"},
+    {file = "pyzmq-26.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4661c88db4a9e0f958c8abc2b97472e23061f0bc737f6f6179d7a27024e1faa5"},
+    {file = "pyzmq-26.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea7f69de383cb47522c9c208aec6dd17697db7875a4674c4af3f8cfdac0bdeae"},
+    {file = "pyzmq-26.2.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7f98f6dfa8b8ccaf39163ce872bddacca38f6a67289116c8937a02e30bbe9711"},
+    {file = "pyzmq-26.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e3e0210287329272539eea617830a6a28161fbbd8a3271bf4150ae3e58c5d0e6"},
+    {file = "pyzmq-26.2.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:6b274e0762c33c7471f1a7471d1a2085b1a35eba5cdc48d2ae319f28b6fc4de3"},
+    {file = "pyzmq-26.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:29c6a4635eef69d68a00321e12a7d2559fe2dfccfa8efae3ffb8e91cd0b36a8b"},
+    {file = "pyzmq-26.2.0-cp312-cp312-win32.whl", hash = "sha256:989d842dc06dc59feea09e58c74ca3e1678c812a4a8a2a419046d711031f69c7"},
+    {file = "pyzmq-26.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:2a50625acdc7801bc6f74698c5c583a491c61d73c6b7ea4dee3901bb99adb27a"},
+    {file = "pyzmq-26.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:4d29ab8592b6ad12ebbf92ac2ed2bedcfd1cec192d8e559e2e099f648570e19b"},
+    {file = "pyzmq-26.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9dd8cd1aeb00775f527ec60022004d030ddc51d783d056e3e23e74e623e33726"},
+    {file = "pyzmq-26.2.0-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:28c812d9757fe8acecc910c9ac9dafd2ce968c00f9e619db09e9f8f54c3a68a3"},
+    {file = "pyzmq-26.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d80b1dd99c1942f74ed608ddb38b181b87476c6a966a88a950c7dee118fdf50"},
+    {file = "pyzmq-26.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8c997098cc65e3208eca09303630e84d42718620e83b733d0fd69543a9cab9cb"},
+    {file = "pyzmq-26.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ad1bc8d1b7a18497dda9600b12dc193c577beb391beae5cd2349184db40f187"},
+    {file = "pyzmq-26.2.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:bea2acdd8ea4275e1278350ced63da0b166421928276c7c8e3f9729d7402a57b"},
+    {file = "pyzmq-26.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:23f4aad749d13698f3f7b64aad34f5fc02d6f20f05999eebc96b89b01262fb18"},
+    {file = "pyzmq-26.2.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:a4f96f0d88accc3dbe4a9025f785ba830f968e21e3e2c6321ccdfc9aef755115"},
+    {file = "pyzmq-26.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ced65e5a985398827cc9276b93ef6dfabe0273c23de8c7931339d7e141c2818e"},
+    {file = "pyzmq-26.2.0-cp313-cp313-win32.whl", hash = "sha256:31507f7b47cc1ead1f6e86927f8ebb196a0bab043f6345ce070f412a59bf87b5"},
+    {file = "pyzmq-26.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:70fc7fcf0410d16ebdda9b26cbd8bf8d803d220a7f3522e060a69a9c87bf7bad"},
+    {file = "pyzmq-26.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:c3789bd5768ab5618ebf09cef6ec2b35fed88709b104351748a63045f0ff9797"},
+    {file = "pyzmq-26.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:034da5fc55d9f8da09015d368f519478a52675e558c989bfcb5cf6d4e16a7d2a"},
+    {file = "pyzmq-26.2.0-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:c92d73464b886931308ccc45b2744e5968cbaade0b1d6aeb40d8ab537765f5bc"},
+    {file = "pyzmq-26.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:794a4562dcb374f7dbbfb3f51d28fb40123b5a2abadee7b4091f93054909add5"},
+    {file = "pyzmq-26.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aee22939bb6075e7afededabad1a56a905da0b3c4e3e0c45e75810ebe3a52672"},
+    {file = "pyzmq-26.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ae90ff9dad33a1cfe947d2c40cb9cb5e600d759ac4f0fd22616ce6540f72797"},
+    {file = "pyzmq-26.2.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:43a47408ac52647dfabbc66a25b05b6a61700b5165807e3fbd40063fcaf46386"},
+    {file = "pyzmq-26.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:25bf2374a2a8433633c65ccb9553350d5e17e60c8eb4de4d92cc6bd60f01d306"},
+    {file = "pyzmq-26.2.0-cp313-cp313t-musllinux_1_1_i686.whl", hash = "sha256:007137c9ac9ad5ea21e6ad97d3489af654381324d5d3ba614c323f60dab8fae6"},
+    {file = "pyzmq-26.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:470d4a4f6d48fb34e92d768b4e8a5cc3780db0d69107abf1cd7ff734b9766eb0"},
+    {file = "pyzmq-26.2.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3b55a4229ce5da9497dd0452b914556ae58e96a4381bb6f59f1305dfd7e53fc8"},
+    {file = "pyzmq-26.2.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:9cb3a6460cdea8fe8194a76de8895707e61ded10ad0be97188cc8463ffa7e3a8"},
+    {file = "pyzmq-26.2.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8ab5cad923cc95c87bffee098a27856c859bd5d0af31bd346035aa816b081fe1"},
+    {file = "pyzmq-26.2.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ed69074a610fad1c2fda66180e7b2edd4d31c53f2d1872bc2d1211563904cd9"},
+    {file = "pyzmq-26.2.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:cccba051221b916a4f5e538997c45d7d136a5646442b1231b916d0164067ea27"},
+    {file = "pyzmq-26.2.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:0eaa83fc4c1e271c24eaf8fb083cbccef8fde77ec8cd45f3c35a9a123e6da097"},
+    {file = "pyzmq-26.2.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:9edda2df81daa129b25a39b86cb57dfdfe16f7ec15b42b19bfac503360d27a93"},
+    {file = "pyzmq-26.2.0-cp37-cp37m-win32.whl", hash = "sha256:ea0eb6af8a17fa272f7b98d7bebfab7836a0d62738e16ba380f440fceca2d951"},
+    {file = "pyzmq-26.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:4ff9dc6bc1664bb9eec25cd17506ef6672d506115095411e237d571e92a58231"},
+    {file = "pyzmq-26.2.0-cp38-cp38-macosx_10_15_universal2.whl", hash = "sha256:2eb7735ee73ca1b0d71e0e67c3739c689067f055c764f73aac4cc8ecf958ee3f"},
+    {file = "pyzmq-26.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1a534f43bc738181aa7cbbaf48e3eca62c76453a40a746ab95d4b27b1111a7d2"},
+    {file = "pyzmq-26.2.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:aedd5dd8692635813368e558a05266b995d3d020b23e49581ddd5bbe197a8ab6"},
+    {file = "pyzmq-26.2.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8be4700cd8bb02cc454f630dcdf7cfa99de96788b80c51b60fe2fe1dac480289"},
+    {file = "pyzmq-26.2.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fcc03fa4997c447dce58264e93b5aa2d57714fbe0f06c07b7785ae131512732"},
+    {file = "pyzmq-26.2.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:402b190912935d3db15b03e8f7485812db350d271b284ded2b80d2e5704be780"},
+    {file = "pyzmq-26.2.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:8685fa9c25ff00f550c1fec650430c4b71e4e48e8d852f7ddcf2e48308038640"},
+    {file = "pyzmq-26.2.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:76589c020680778f06b7e0b193f4b6dd66d470234a16e1df90329f5e14a171cd"},
+    {file = "pyzmq-26.2.0-cp38-cp38-win32.whl", hash = "sha256:8423c1877d72c041f2c263b1ec6e34360448decfb323fa8b94e85883043ef988"},
+    {file = "pyzmq-26.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:76589f2cd6b77b5bdea4fca5992dc1c23389d68b18ccc26a53680ba2dc80ff2f"},
+    {file = "pyzmq-26.2.0-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:b1d464cb8d72bfc1a3adc53305a63a8e0cac6bc8c5a07e8ca190ab8d3faa43c2"},
+    {file = "pyzmq-26.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4da04c48873a6abdd71811c5e163bd656ee1b957971db7f35140a2d573f6949c"},
+    {file = "pyzmq-26.2.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:d049df610ac811dcffdc147153b414147428567fbbc8be43bb8885f04db39d98"},
+    {file = "pyzmq-26.2.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:05590cdbc6b902101d0e65d6a4780af14dc22914cc6ab995d99b85af45362cc9"},
+    {file = "pyzmq-26.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c811cfcd6a9bf680236c40c6f617187515269ab2912f3d7e8c0174898e2519db"},
+    {file = "pyzmq-26.2.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:6835dd60355593de10350394242b5757fbbd88b25287314316f266e24c61d073"},
+    {file = "pyzmq-26.2.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:bc6bee759a6bddea5db78d7dcd609397449cb2d2d6587f48f3ca613b19410cfc"},
+    {file = "pyzmq-26.2.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c530e1eecd036ecc83c3407f77bb86feb79916d4a33d11394b8234f3bd35b940"},
+    {file = "pyzmq-26.2.0-cp39-cp39-win32.whl", hash = "sha256:367b4f689786fca726ef7a6c5ba606958b145b9340a5e4808132cc65759abd44"},
+    {file = "pyzmq-26.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:e6fa2e3e683f34aea77de8112f6483803c96a44fd726d7358b9888ae5bb394ec"},
+    {file = "pyzmq-26.2.0-cp39-cp39-win_arm64.whl", hash = "sha256:7445be39143a8aa4faec43b076e06944b8f9d0701b669df4af200531b21e40bb"},
+    {file = "pyzmq-26.2.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:706e794564bec25819d21a41c31d4df2d48e1cc4b061e8d345d7fb4dd3e94072"},
+    {file = "pyzmq-26.2.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b435f2753621cd36e7c1762156815e21c985c72b19135dac43a7f4f31d28dd1"},
+    {file = "pyzmq-26.2.0-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:160c7e0a5eb178011e72892f99f918c04a131f36056d10d9c1afb223fc952c2d"},
+    {file = "pyzmq-26.2.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c4a71d5d6e7b28a47a394c0471b7e77a0661e2d651e7ae91e0cab0a587859ca"},
+    {file = "pyzmq-26.2.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:90412f2db8c02a3864cbfc67db0e3dcdbda336acf1c469526d3e869394fe001c"},
+    {file = "pyzmq-26.2.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:2ea4ad4e6a12e454de05f2949d4beddb52460f3de7c8b9d5c46fbb7d7222e02c"},
+    {file = "pyzmq-26.2.0-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:fc4f7a173a5609631bb0c42c23d12c49df3966f89f496a51d3eb0ec81f4519d6"},
+    {file = "pyzmq-26.2.0-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:878206a45202247781472a2d99df12a176fef806ca175799e1c6ad263510d57c"},
+    {file = "pyzmq-26.2.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:17c412bad2eb9468e876f556eb4ee910e62d721d2c7a53c7fa31e643d35352e6"},
+    {file = "pyzmq-26.2.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:0d987a3ae5a71c6226b203cfd298720e0086c7fe7c74f35fa8edddfbd6597eed"},
+    {file = "pyzmq-26.2.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:39887ac397ff35b7b775db7201095fc6310a35fdbae85bac4523f7eb3b840e20"},
+    {file = "pyzmq-26.2.0-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:fdb5b3e311d4d4b0eb8b3e8b4d1b0a512713ad7e6a68791d0923d1aec433d919"},
+    {file = "pyzmq-26.2.0-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:226af7dcb51fdb0109f0016449b357e182ea0ceb6b47dfb5999d569e5db161d5"},
+    {file = "pyzmq-26.2.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0bed0e799e6120b9c32756203fb9dfe8ca2fb8467fed830c34c877e25638c3fc"},
+    {file = "pyzmq-26.2.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:29c7947c594e105cb9e6c466bace8532dc1ca02d498684128b339799f5248277"},
+    {file = "pyzmq-26.2.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:cdeabcff45d1c219636ee2e54d852262e5c2e085d6cb476d938aee8d921356b3"},
+    {file = "pyzmq-26.2.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35cffef589bcdc587d06f9149f8d5e9e8859920a071df5a2671de2213bef592a"},
+    {file = "pyzmq-26.2.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:18c8dc3b7468d8b4bdf60ce9d7141897da103c7a4690157b32b60acb45e333e6"},
+    {file = "pyzmq-26.2.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7133d0a1677aec369d67dd78520d3fa96dd7f3dcec99d66c1762870e5ea1a50a"},
+    {file = "pyzmq-26.2.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:6a96179a24b14fa6428cbfc08641c779a53f8fcec43644030328f44034c7f1f4"},
+    {file = "pyzmq-26.2.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:4f78c88905461a9203eac9faac157a2a0dbba84a0fd09fd29315db27be40af9f"},
+    {file = "pyzmq-26.2.0.tar.gz", hash = "sha256:070672c258581c8e4f640b5159297580a9974b026043bd4ab0470be9ed324f1f"},
 ]
 
 [package.dependencies]
@@ -2229,6 +2294,7 @@ description = "Alternative regular expression module, to replace re."
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "regex-2024.11.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ff590880083d60acc0433f9c3f713c51f7ac6ebb9adf889c79a261ecf541aa91"},
     {file = "regex-2024.11.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:658f90550f38270639e83ce492f27d2c8d2cd63805c65a13a14d36ca126753f0"},
@@ -2333,6 +2399,7 @@ description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
     {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
@@ -2355,6 +2422,7 @@ description = "Mock out responses from the requests package"
 optional = false
 python-versions = ">=3.5"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "requests-mock-1.12.1.tar.gz", hash = "sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401"},
     {file = "requests_mock-1.12.1-py2.py3-none-any.whl", hash = "sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563"},
@@ -2373,6 +2441,7 @@ description = "Easily download, build, install, upgrade, and uninstall Python pa
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "setuptools-75.8.0-py3-none-any.whl", hash = "sha256:e3982f444617239225d675215d51f6ba05f845d4eec313da4418fdbb56fb27e3"},
     {file = "setuptools-75.8.0.tar.gz", hash = "sha256:c5afc8f407c626b8313a86e10311dd3f661c6cd9c09d4bf8c15c0e11f9f2b0e6"},
@@ -2394,6 +2463,7 @@ description = "Python 2 and 3 compatibility utilities"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 groups = ["main", "dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
@@ -2406,6 +2476,7 @@ description = "file: README.md"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "super_collections-0.5.3-py3-none-any.whl", hash = "sha256:907d35b25dc4070910e8254bf2f5c928348af1cf8a1f1e8259e06c666e902cff"},
     {file = "super_collections-0.5.3.tar.gz", hash = "sha256:94c1ec96c0a0d5e8e7d389ed8cde6882ac246940507c5e6b86e91945c2968d46"},
@@ -2419,14 +2490,15 @@ test = ["pytest (>=7.0)"]
 
 [[package]]
 name = "tabulate"
-version = "0.8.10"
+version = "0.9.0"
 description = "Pretty-print tabular data"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.7"
 groups = ["main"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "tabulate-0.8.10-py3-none-any.whl", hash = "sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc"},
-    {file = "tabulate-0.8.10.tar.gz", hash = "sha256:6c57f3f3dd7ac2782770155f3adb2db0b1a269637e42f27599925e64b114f519"},
+    {file = "tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f"},
+    {file = "tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c"},
 ]
 
 [package.extras]
@@ -2439,6 +2511,7 @@ description = "ANSI color formatting for output in terminal"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "termcolor-2.5.0-py3-none-any.whl", hash = "sha256:37b17b5fc1e604945c2642c872a3764b5d547a48009871aea3edd3afa180afb8"},
     {file = "termcolor-2.5.0.tar.gz", hash = "sha256:998d8d27da6d48442e8e1f016119076b690d962507531df4890fcd2db2ef8a6f"},
@@ -2504,12 +2577,26 @@ files = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2024.2"
+description = "Provider of IANA time zone data"
+optional = true
+python-versions = ">=2"
+groups = ["main"]
+markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and extra == \"examples\""
+files = [
+    {file = "tzdata-2024.2-py2.py3-none-any.whl", hash = "sha256:a48093786cdcde33cad18c2555e8532f34422074448fbc874186f0abd79565cd"},
+    {file = "tzdata-2024.2.tar.gz", hash = "sha256:7d85cc416e9382e69095b7bdf4afd9e3880418a2413feec7069d533d6b4e31cc"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.3.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"},
     {file = "urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"},
@@ -2528,6 +2615,7 @@ description = "Flexible version handling"
 optional = false
 python-versions = "*"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31"},
     {file = "verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e"},
@@ -2543,6 +2631,7 @@ description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "virtualenv-20.29.0-py3-none-any.whl", hash = "sha256:c12311863497992dc4b8644f8ea82d3b35bb7ef8ee82e6630d76d0197c39baf9"},
     {file = "virtualenv-20.29.0.tar.gz", hash = "sha256:6345e1ff19d4b1296954cee076baaf58ff2a12a84a338c62b02eda39f20aa982"},
@@ -2564,6 +2653,7 @@ description = "Filesystem events monitoring"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26"},
     {file = "watchdog-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bc64ab3bdb6a04d69d4023b29422170b74681784ffb9463ed4870cf2f3e66112"},
@@ -2607,7 +2697,7 @@ description = "Measures the displayed width of unicode strings in a terminal"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"examples\""
+markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and extra == \"examples\""
 files = [
     {file = "wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859"},
     {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
@@ -2620,7 +2710,7 @@ description = "WebDAV client, based on original package https://github.com/desig
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"examples\""
+markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and extra == \"examples\""
 files = [
     {file = "webdavclient3-3.14.6.tar.gz", hash = "sha256:bcd22586bb0d58abc26ca56054fd04228e704bd36073c3080f4597c1556c880d"},
 ]
@@ -2637,7 +2727,7 @@ description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"examples\""
+markers = "(python_version <= \"3.11\" or python_version >= \"3.12\") and extra == \"examples\""
 files = [
     {file = "websockets-14.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a0adf84bc2e7c86e8a202537b4fd50e6f7f0e4a6b6bf64d7ccb96c4cd3330b29"},
     {file = "websockets-14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:90b5d9dfbb6d07a84ed3e696012610b6da074d97453bd01e0e30744b472c8179"},
@@ -2716,12 +2806,12 @@ version = "3.21.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"},
     {file = "zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4"},
 ]
-markers = {main = "extra == \"examples\" and python_version < \"3.10\"", dev = "python_version < \"3.10\""}
 
 [package.extras]
 check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
@@ -2736,5 +2826,5 @@ examples = ["asciimatics", "foxglove_websocket", "inputs", "matplotlib", "pandas
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.9"
-content-hash = "3069d44523cc96775be6772c486c334828cc51c2ed8db32a36fbdccc909cf28d"
+python-versions = "^3.10"
+content-hash = "f201e9d9875f086b86aa4413fadd7ab31fa5e3139630ce378c303a4b3e89f2b5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,29 +19,29 @@ keywords = ["Blueye", "Pioneer", "Pro", "Robotics", "SDK", "Software Development
 python = "^3.10"
 asciimatics = {version = "^1.11.0", optional = true}
 inputs = {version = "^0.5", optional = true}
-pandas = {version = "^1.3", optional = true}
-matplotlib = {version = "^3.1.1", optional = true}
+pandas = {version = "^2.2", optional = true}
+matplotlib = {version = "^3.10", optional = true}
 webdavclient3 = {version = "^3.14.6", optional = true}
 foxglove_websocket = {version= "^0.1.2", optional = true}
 requests = "^2.22.0"
-tabulate = "^0.8.5"
-packaging = ">=22.0"
-"blueye.protocol" = "^2.6"
+tabulate = "^0.9"
+packaging = ">=24.2"
+"blueye.protocol" = "^2.7"
 python-dateutil = "^2.8.2"
-pyzmq = "^25.0.0"
+pyzmq = "^26.0"
 proto-plus = "^1.22.2"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^7.4"
+pytest = "^8.3"
 pytest-mock = "^3.11"
-mike = "^1.1"
+mike = "^2.1"
 mkdocs = "^1.5"
-mkdocs-material = "^9.4"
+mkdocs-material = "^9.5"
 mkdocs-macros-plugin = "^1.0"
-pymdown-extensions = "^10.1"
-pre-commit = "^3.3"
+pymdown-extensions = "^10.14"
+pre-commit = "^4.0"
 black = "^24.3"
-pytest-cov = "^4.1"
+pytest-cov = "^6.0"
 requests-mock = "^1.11"
 freezegun = "^1.2"
 mkdocstrings = {version = "^0.27.0", extras = ["python"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ python-dateutil = "^2.8.2"
 pyzmq = "^25.0.0"
 proto-plus = "^1.22.2"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^7.4"
 pytest-mock = "^3.11"
 mike = "^1.1"
@@ -62,5 +62,5 @@ addopts = "--cov=blueye --cov-report=xml:coverage.xml --cov-report=html --cov-ap
 filterwarnings = ["ignore::DeprecationWarning:blueye","ignore::DeprecationWarning:pkg_resources"]
 
 [build-system]
-requires = ["poetry>=1.3.0"]
+requires = ["poetry>=2.0"]
 build-backend = "poetry.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ homepage ="https://www.blueyerobotics.com"
 keywords = ["Blueye", "Pioneer", "Pro", "Robotics", "SDK", "Software Development Kit"]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 asciimatics = {version = "^1.11.0", optional = true}
 inputs = {version = "^0.5", optional = true}
 pandas = {version = "^1.3", optional = true}
@@ -52,7 +52,7 @@ examples = ["inputs", "asciimatics", "pandas", "matplotlib", "webdavclient3", "f
 
 [tool.black]
 line-length = 100
-target-version = ['py38', 'py39', 'py310', 'py311', 'py312']
+target-version = ['py310', 'py311', 'py312', 'py313']
 
 [tool.pytest.ini_options]
 markers = "connected_to_drone: a mark for test that can only be run when connected to a drone, useful when developing"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blueye.sdk"
-version = "2.3.0"
+version = "2.4.0"
 description = "SDK for controlling a Blueye underwater drone"
 authors = ["Sindre Hansen <sindre.hansen@blueye.no>",
            "Johannes Schrimpf <johannes.schrimpf@blueye.no>",


### PR DESCRIPTION
As is our practice we only maintain support for the last 4 python versions, so this PR drops support for 3.9 and adds support for 3.13. I've also gone through and updated all of the dependencies to the most recent version.

I've branched this out from the `use-mkdocstrings-for-reference-generation`-branch, so we should merge that first and then change the base of this to master.