### PR TITLE
Add codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,11 @@
 github_checks:
   annotations: false
 
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
This PR adds a configuration file for the codecov integration, allowing us to disable the annotations in the "Files changed" tab as well as to remove the strict coverage requirment.