### PR TITLE
Deprecate /picture/thumbnail endpoint

### DIFF
--- a/http-api.yml
+++ b/http-api.yml
@@ -1153,9 +1153,12 @@ paths:
     get:
       operationId: picture_thumbnail_retrieve
       description: |-
+        **Deprecated.**
+
         Downloads a picture (jpg) with EXIF metadata from when the photo was
         captured.
       summary: Download a thumbnail of a picture
+      deprecated: true
       parameters:
       - in: query
         name: file


### PR DESCRIPTION
## Summary
- Mark `/picture/thumbnail` as deprecated in the HTTP API spec (`deprecated: true` + description)

## Test plan
- [x] Verify the endpoint renders as deprecated in the generated docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)