### PR TITLE
Refactor to a getter/setter API

### DIFF
--- a/blueye/sdk/battery.py
+++ b/blueye/sdk/battery.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING, Optional
 
 import blueye.protocol
 
+from .utils import deprecated_property
+
 # Necessary to avoid cyclic imports
 if TYPE_CHECKING:
     from .drone import Drone
@@ -19,8 +21,7 @@ class Battery:
             parent_drone (Drone): The parent drone instance."""
         self._parent_drone = parent_drone
 
-    @property
-    def state_of_charge(self) -> Optional[float]:
+    def get_state_of_charge(self) -> Optional[float]:
         """Get the battery state of charge.
 
         Returns:
@@ -31,3 +32,5 @@ class Battery:
             return battery_tel.battery.level
         else:
             return None
+
+    state_of_charge = deprecated_property("get_state_of_charge")

--- a/blueye/sdk/camera.py
+++ b/blueye/sdk/camera.py
@@ -9,6 +9,8 @@ import blueye.protocol
 import requests
 from packaging import version
 
+from .utils import deprecated_property
+
 # Necessary to avoid cyclic imports
 if TYPE_CHECKING:
     from .drone import Drone
@@ -49,8 +51,7 @@ class Tilt:
         self._verify_tilt_in_features()
         self._parent_drone._ctrl_client.set_tilt_velocity(velocity)
 
-    @property
-    def angle(self) -> Optional[float]:
+    def get_angle(self) -> Optional[float]:
         """Return the current angle of the camera tilt.
 
         Returns:
@@ -66,8 +67,9 @@ class Tilt:
         else:
             return None
 
-    @property
-    def stabilization_enabled(self) -> Optional[bool]:
+    angle = deprecated_property("get_angle")
+
+    def is_stabilization_enabled(self) -> Optional[bool]:
         """Get the state of active camera stabilization.
 
         Returns:
@@ -83,8 +85,7 @@ class Tilt:
         else:
             return None
 
-    @stabilization_enabled.setter
-    def stabilization_enabled(self, enabled: bool):
+    def enable_stabilization(self, enabled: bool):
         """Set the state of active camera stabilization.
 
         Args:
@@ -95,6 +96,8 @@ class Tilt:
         """
         self._verify_tilt_in_features()
         self._parent_drone._ctrl_client.set_tilt_stabilization(enabled)
+
+    stabilization_enabled = deprecated_property("is_stabilization_enabled", "enable_stabilization")
 
 
 class Overlay:
@@ -113,113 +116,128 @@ class Overlay:
         """Update the overlay parameters from the drone."""
         self._overlay_parametres = self._parent_drone._req_rep_client.get_overlay_parameters()
 
-    @property
-    def temperature_enabled(self) -> bool:
-        """Get or set the state of the temperature overlay.
+    def is_temperature_enabled(self) -> bool:
+        """Get the state of the temperature overlay.
 
         Returns:
             The current state of the temperature overlay.
-
-        Args:
-            enable_temperature (bool): True to enable the temperature overlay, False to disable it.
         """
         self._update_overlay_parameters()
         return self._overlay_parametres.temperature_enabled
 
-    @temperature_enabled.setter
-    def temperature_enabled(self, enable_temperature: bool):
+    def enable_temperature(self, enable_temperature: bool):
+        """Set the state of the temperature overlay.
+
+        Args:
+            enable_temperature (bool): True to enable the temperature overlay, False to disable it.
+        """
         if self._overlay_parametres is None:
             self._update_overlay_parameters()
         self._overlay_parametres.temperature_enabled = enable_temperature
         self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def depth_enabled(self) -> bool:
-        """Get or set the state of the depth overlay.
+    temperature_enabled = deprecated_property("is_temperature_enabled", "enable_temperature")
+
+    def is_depth_enabled(self) -> bool:
+        """Get the state of the depth overlay.
 
         Returns:
             The current state of the depth overlay.
-
-        Args:
-            enable_depth (bool): True to enable the depth overlay, False to disable it.
         """
         self._update_overlay_parameters()
         return self._overlay_parametres.depth_enabled
 
-    @depth_enabled.setter
-    def depth_enabled(self, enable_depth: bool):
+    def enable_depth(self, enable_depth: bool):
+        """Set the state of the depth overlay.
+
+        Args:
+            enable_depth (bool): True to enable the depth overlay, False to disable it.
+        """
         if self._overlay_parametres is None:
             self._update_overlay_parameters()
         self._overlay_parametres.depth_enabled = enable_depth
         self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def heading_enabled(self) -> bool:
-        """Get or set the state of the heading overlay.
+    depth_enabled = deprecated_property("is_depth_enabled", "enable_depth")
+
+    def is_heading_enabled(self) -> bool:
+        """Get the state of the heading overlay.
 
         Returns:
             The current state of the heading overlay.
-
-        Args:
-            enable_heading (bool): True to enable the heading overlay, False to disable it.
         """
         self._update_overlay_parameters()
         return self._overlay_parametres.heading_enabled
 
-    @heading_enabled.setter
-    def heading_enabled(self, enable_heading: bool):
+    def enable_heading(self, enable_heading: bool):
+        """Set the state of the heading overlay.
+
+        Args:
+            enable_heading (bool): True to enable the heading overlay, False to disable it.
+        """
         if self._overlay_parametres is None:
             self._update_overlay_parameters()
         self._overlay_parametres.heading_enabled = enable_heading
         self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def tilt_enabled(self) -> bool:
-        """Get or set the state of the tilt overlay.
+    heading_enabled = deprecated_property("is_heading_enabled", "enable_heading")
+
+    def is_tilt_enabled(self) -> bool:
+        """Get the state of the tilt overlay.
 
         Returns:
             The current state of the tilt overlay.
-
-        Args:
-            enable_tilt (bool): True to enable the tilt overlay, False to disable it.
         """
         self._update_overlay_parameters()
         return self._overlay_parametres.tilt_enabled
 
-    @tilt_enabled.setter
-    def tilt_enabled(self, enable_tilt: bool):
+    def enable_tilt(self, enable_tilt: bool):
+        """Set the state of the tilt overlay.
+
+        Args:
+            enable_tilt (bool): True to enable the tilt overlay, False to disable it.
+        """
         if self._overlay_parametres is None:
             self._update_overlay_parameters()
         self._overlay_parametres.tilt_enabled = enable_tilt
         self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def date_enabled(self) -> bool:
-        """Get or set the state of the date overlay.
+    tilt_enabled = deprecated_property("is_tilt_enabled", "enable_tilt")
+
+    def is_date_enabled(self) -> bool:
+        """Get the state of the date overlay.
 
         Returns:
             The current state of the date overlay.
+        """
+        if self._overlay_parametres is None:
+            self._update_overlay_parameters()
+        return self._overlay_parametres.date_enabled
+
+    def enable_date(self, enable_date: bool):
+        """Set the state of the date overlay.
 
         Args:
             enable_date (bool): True to enable the date overlay, False to disable it.
         """
         if self._overlay_parametres is None:
             self._update_overlay_parameters()
-        return self._overlay_parametres.date_enabled
-
-    @date_enabled.setter
-    def date_enabled(self, enable_date: bool):
-        if self._overlay_parametres is None:
-            self._update_overlay_parameters()
         self._overlay_parametres.date_enabled = enable_date
         self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def logo(self) -> blueye.protocol.LogoType:
-        """Get or set logo overlay selection.
+    date_enabled = deprecated_property("is_date_enabled", "enable_date")
+
+    def get_logo(self) -> blueye.protocol.LogoType:
+        """Get the logo overlay selection.
 
         Returns:
             The current logo type.
+        """
+        self._update_overlay_parameters()
+        return self._overlay_parametres.logo_type
+
+    def set_logo(self, logo_type: blueye.protocol.LogoType):
+        """Set the logo overlay selection.
 
         Args:
             logo_type (blueye.protocol.LogoType): The logo type.
@@ -227,11 +245,6 @@ class Overlay:
         Warns:
             RuntimeWarning: If the logo type is not an instance of blueye.protocol.LogoType.
         """
-        self._update_overlay_parameters()
-        return self._overlay_parametres.logo_type
-
-    @logo.setter
-    def logo(self, logo_type: blueye.protocol.LogoType):
         if not isinstance(logo_type, blueye.protocol.LogoType):
             warnings.warn("Invalid logo type, ignoring", RuntimeWarning)
         else:
@@ -240,12 +253,19 @@ class Overlay:
             self._overlay_parametres.logo_type = logo_type
             self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def depth_unit(self) -> blueye.protocol.DepthUnit:
-        """Get or set the depth unit for the overlay.
+    logo = deprecated_property("get_logo", "set_logo")
+
+    def get_depth_unit(self) -> blueye.protocol.DepthUnit:
+        """Get the depth unit for the overlay.
 
         Returns:
             The current depth unit.
+        """
+        self._update_overlay_parameters()
+        return self._overlay_parametres.depth_unit
+
+    def set_depth_unit(self, unit: blueye.protocol.DepthUnit):
+        """Set the depth unit for the overlay.
 
         Args:
             unit (blueye.protocol.DepthUnit): The depth unit to set.
@@ -253,11 +273,6 @@ class Overlay:
         Warns:
             RuntimeWarning: If the unit is not an instance of blueye.protocol.DepthUnit.
         """
-        self._update_overlay_parameters()
-        return self._overlay_parametres.depth_unit
-
-    @depth_unit.setter
-    def depth_unit(self, unit: blueye.protocol.DepthUnit):
         if not isinstance(unit, blueye.protocol.DepthUnit):
             warnings.warn("Invalid depth unit, ignoring", RuntimeWarning)
         else:
@@ -266,12 +281,19 @@ class Overlay:
             self._overlay_parametres.depth_unit = unit
             self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def temperature_unit(self) -> blueye.protocol.TemperatureUnit:
-        """Get or set the temperature unit for the overlay.
+    depth_unit = deprecated_property("get_depth_unit", "set_depth_unit")
+
+    def get_temperature_unit(self) -> blueye.protocol.TemperatureUnit:
+        """Get the temperature unit for the overlay.
 
         Returns:
             The current temperature unit.
+        """
+        self._update_overlay_parameters()
+        return self._overlay_parametres.temperature_unit
+
+    def set_temperature_unit(self, unit: blueye.protocol.TemperatureUnit):
+        """Set the temperature unit for the overlay.
 
         Args:
             unit (blueye.protocol.TemperatureUnit): The temperature unit to set.
@@ -279,11 +301,6 @@ class Overlay:
         Warns:
             RuntimeWarning: If the unit is not an instance of blueye.protocol.TemperatureUnit.
         """
-        self._update_overlay_parameters()
-        return self._overlay_parametres.temperature_unit
-
-    @temperature_unit.setter
-    def temperature_unit(self, unit: blueye.protocol.TemperatureUnit):
         if not isinstance(unit, blueye.protocol.TemperatureUnit):
             warnings.warn("Invalid temperature unit, ignoring", RuntimeWarning)
         else:
@@ -292,92 +309,107 @@ class Overlay:
             self._overlay_parametres.temperature_unit = unit
             self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def cp_probe_enabled(self) -> bool:
-        """Get or set the state of the CP probe overlay.
+    temperature_unit = deprecated_property("get_temperature_unit", "set_temperature_unit")
+
+    def is_cp_probe_enabled(self) -> bool:
+        """Get the state of the CP probe overlay.
 
         Returns:
             The current state of the CP probe overlay.
-
-        Args:
-            enable_cp_probe (bool): True to enable the CP probe overlay, False to disable it.
         """
         self._update_overlay_parameters()
         return self._overlay_parametres.cp_probe_enabled
 
-    @cp_probe_enabled.setter
-    def cp_probe_enabled(self, enable_cp_probe: bool):
+    def enable_cp_probe(self, enable_cp_probe: bool):
+        """Set the state of the CP probe overlay.
+
+        Args:
+            enable_cp_probe (bool): True to enable the CP probe overlay, False to disable it.
+        """
         if self._overlay_parametres is None:
             self._update_overlay_parameters()
         self._overlay_parametres.cp_probe_enabled = enable_cp_probe
         self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def distance_enabled(self) -> bool:
-        """Get or set the state of the distance overlay.
+    cp_probe_enabled = deprecated_property("is_cp_probe_enabled", "enable_cp_probe")
+
+    def is_distance_enabled(self) -> bool:
+        """Get the state of the distance overlay.
 
         Returns:
             The current state of the distance overlay.
-
-        Args:
-            enable_distance (bool): True to enable the distance overlay, False to disable it.
         """
         self._update_overlay_parameters()
         return self._overlay_parametres.distance_enabled
 
-    @distance_enabled.setter
-    def distance_enabled(self, enable_distance: bool):
+    def enable_distance(self, enable_distance: bool):
+        """Set the state of the distance overlay.
+
+        Args:
+            enable_distance (bool): True to enable the distance overlay, False to disable it.
+        """
         if self._overlay_parametres is None:
             self._update_overlay_parameters()
         self._overlay_parametres.distance_enabled = enable_distance
         self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def altitude_enabled(self) -> bool:
-        """Get or set the state of the altitude overlay.
+    distance_enabled = deprecated_property("is_distance_enabled", "enable_distance")
+
+    def is_altitude_enabled(self) -> bool:
+        """Get the state of the altitude overlay.
 
         Returns:
             The current state of the altitude overlay.
-
-        Args:
-            enable_altitude (bool): True to enable the altitude overlay, False to disable it.
         """
         self._update_overlay_parameters()
         return self._overlay_parametres.altitude_enabled
 
-    @altitude_enabled.setter
-    def altitude_enabled(self, enable_altitude: bool):
+    def enable_altitude(self, enable_altitude: bool):
+        """Set the state of the altitude overlay.
+
+        Args:
+            enable_altitude (bool): True to enable the altitude overlay, False to disable it.
+        """
         if self._overlay_parametres is None:
             self._update_overlay_parameters()
         self._overlay_parametres.altitude_enabled = enable_altitude
         self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def thickness_enabled(self) -> bool:
-        """Get or set the state of the thickness overlay.
+    altitude_enabled = deprecated_property("is_altitude_enabled", "enable_altitude")
+
+    def is_thickness_enabled(self) -> bool:
+        """Get the state of the thickness overlay.
 
         Returns:
             The current state of the thickness overlay.
-
-        Args:
-            enable_thickness (bool): True to enable the thickness overlay, False to disable it.
         """
         self._update_overlay_parameters()
         return self._overlay_parametres.thickness_enabled
 
-    @thickness_enabled.setter
-    def thickness_enabled(self, enable_thickness: bool):
+    def enable_thickness(self, enable_thickness: bool):
+        """Set the state of the thickness overlay.
+
+        Args:
+            enable_thickness (bool): True to enable the thickness overlay, False to disable it.
+        """
         if self._overlay_parametres is None:
             self._update_overlay_parameters()
         self._overlay_parametres.thickness_enabled = enable_thickness
         self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def thickness_unit(self) -> blueye.protocol.ThicknessUnit:
-        """Get or set the thickness unit for the overlay.
+    thickness_enabled = deprecated_property("is_thickness_enabled", "enable_thickness")
+
+    def get_thickness_unit(self) -> blueye.protocol.ThicknessUnit:
+        """Get the thickness unit for the overlay.
 
         Returns:
             The current thickness unit.
+        """
+        self._update_overlay_parameters()
+        return self._overlay_parametres.thickness_unit
+
+    def set_thickness_unit(self, unit: blueye.protocol.ThicknessUnit):
+        """Set the thickness unit for the overlay.
 
         Args:
             unit (blueye.protocol.ThicknessUnit): The thickness unit to set.
@@ -385,11 +417,6 @@ class Overlay:
         Warns:
             RuntimeWarning: If the unit is not an instance of blueye.protocol.ThicknessUnit.
         """
-        self._update_overlay_parameters()
-        return self._overlay_parametres.thickness_unit
-
-    @thickness_unit.setter
-    def thickness_unit(self, unit: blueye.protocol.ThicknessUnit):
         if not isinstance(unit, blueye.protocol.ThicknessUnit):
             warnings.warn("Invalid thickness unit, ignoring", RuntimeWarning)
         else:
@@ -398,33 +425,44 @@ class Overlay:
             self._overlay_parametres.thickness_unit = unit
             self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def drone_location_enabled(self) -> bool:
-        """Get or set the state of the drone location overlay.
+    thickness_unit = deprecated_property("get_thickness_unit", "set_thickness_unit")
+
+    def is_drone_location_enabled(self) -> bool:
+        """Get the state of the drone location overlay.
 
         Returns:
             The current state of the drone location overlay.
+        """
+        self._update_overlay_parameters()
+        return self._overlay_parametres.drone_location_enabled
+
+    def enable_drone_location(self, enable_drone_location: bool):
+        """Set the state of the drone location overlay.
 
         Args:
             enable_drone_location (bool): True to enable the drone location overlay,
                                           False to disable it.
         """
-        self._update_overlay_parameters()
-        return self._overlay_parametres.drone_location_enabled
-
-    @drone_location_enabled.setter
-    def drone_location_enabled(self, enable_drone_location: bool):
         if self._overlay_parametres is None:
             self._update_overlay_parameters()
         self._overlay_parametres.drone_location_enabled = enable_drone_location
         self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def shading(self) -> float:
-        """Get or set the pixel intensity to subtract from text background.
+    drone_location_enabled = deprecated_property(
+        "is_drone_location_enabled", "enable_drone_location"
+    )
+
+    def get_shading(self) -> float:
+        """Get the pixel intensity to subtract from text background.
 
         Returns:
             The current shading intensity.
+        """
+        self._update_overlay_parameters()
+        return self._overlay_parametres.shading
+
+    def set_shading(self, intensity: float):
+        """Set the pixel intensity to subtract from text background.
 
         Args:
             intensity (float): The shading intensity to set. Valid range is 0.0 to 1.0.
@@ -433,11 +471,6 @@ class Overlay:
         Warns:
             RuntimeWarning: If the shading intensity is not a float between 0.0 and 1.0.
         """
-        self._update_overlay_parameters()
-        return self._overlay_parametres.shading
-
-    @shading.setter
-    def shading(self, intensity: float):
         if intensity < 0.0 or intensity > 1.0:
             warnings.warn("Invalid shading intensity, ignoring", RuntimeWarning)
         else:
@@ -446,57 +479,70 @@ class Overlay:
             self._overlay_parametres.shading = intensity
             self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def gamma_ray_measurement_enabled(self) -> bool:
-        """Get or set the state of the gamma-ray measurement overlay.
+    shading = deprecated_property("get_shading", "set_shading")
+
+    def is_gamma_ray_measurement_enabled(self) -> bool:
+        """Get the state of the gamma-ray measurement overlay.
 
         Returns:
             The current state of the gamma-ray measurement overlay.
+        """
+        self._update_overlay_parameters()
+        return self._overlay_parametres.medusa_enabled
+
+    def enable_gamma_ray_measurement(self, enable_gamma_ray_measurement: bool):
+        """Set the state of the gamma-ray measurement overlay.
 
         Args:
             enable_gamma_ray_measurement (bool): True to enable the gamma-ray measurement overlay,
                                                  False to disable it.
         """
-        self._update_overlay_parameters()
-        return self._overlay_parametres.medusa_enabled
-
-    @gamma_ray_measurement_enabled.setter
-    def gamma_ray_measurement_enabled(self, enable_gamma_ray_measurement: bool):
         if self._overlay_parametres is None:
             self._update_overlay_parameters()
         self._overlay_parametres.medusa_enabled = enable_gamma_ray_measurement
         self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def timezone_offset(self) -> int:
-        """Get or set the timezone offset for the overlay.
+    gamma_ray_measurement_enabled = deprecated_property(
+        "is_gamma_ray_measurement_enabled", "enable_gamma_ray_measurement"
+    )
 
-        Set to the number of minutes (either positive or negative) the timestamp should be offset.
+    def get_timezone_offset(self) -> int:
+        """Get the timezone offset for the overlay.
 
         Returns:
             The current timezone offset.
-
-        Args:
-            offset (int): The timezone offset to set.
         """
         self._update_overlay_parameters()
         return self._overlay_parametres.timezone_offset
 
-    @timezone_offset.setter
-    def timezone_offset(self, offset: int):
+    def set_timezone_offset(self, offset: int):
+        """Set the timezone offset for the overlay.
+
+        Set to the number of minutes (either positive or negative) the timestamp should be offset.
+
+        Args:
+            offset (int): The timezone offset to set.
+        """
         if self._overlay_parametres is None:
             self._update_overlay_parameters()
         self._overlay_parametres.timezone_offset = offset
         self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def margin_width(self) -> int:
-        """Get or set the margin width for the overlay.
+    timezone_offset = deprecated_property("get_timezone_offset", "set_timezone_offset")
 
-        The amount of pixels to use as margin on the right and left side of the overlay.
+    def get_margin_width(self) -> int:
+        """Get the margin width for the overlay.
 
         Returns:
             The current margin width.
+        """
+        self._update_overlay_parameters()
+        return self._overlay_parametres.margin_width
+
+    def set_margin_width(self, width: int):
+        """Set the margin width for the overlay.
+
+        The amount of pixels to use as margin on the right and left side of the overlay.
 
         Args:
             width (int): The margin width to set. Needs to be a positive integer.
@@ -504,11 +550,6 @@ class Overlay:
         Warns:
             RuntimeWarning: If the margin width is not a positive integer.
         """
-        self._update_overlay_parameters()
-        return self._overlay_parametres.margin_width
-
-    @margin_width.setter
-    def margin_width(self, width: int):
         if width < 0:
             warnings.warn("Invalid margin width, ignoring", RuntimeWarning)
         else:
@@ -517,23 +558,28 @@ class Overlay:
             self._overlay_parametres.margin_width = width
             self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def margin_height(self) -> int:
-        """Get or set the margin height for the overlay.
+    margin_width = deprecated_property("get_margin_width", "set_margin_width")
 
-        The amount of pixels to use as margin on the top and bottom side of the overlay.
+    def get_margin_height(self) -> int:
+        """Get the margin height for the overlay.
 
         Returns:
             The current margin height.
-
-        Args:
-            height (int): The margin height to set. Needs to be a positive integer.
         """
         self._update_overlay_parameters()
         return self._overlay_parametres.margin_height
 
-    @margin_height.setter
-    def margin_height(self, height: int):
+    def set_margin_height(self, height: int):
+        """Set the margin height for the overlay.
+
+        The amount of pixels to use as margin on the top and bottom side of the overlay.
+
+        Args:
+            height (int): The margin height to set. Needs to be a positive integer.
+
+        Warns:
+            RuntimeWarning: If the margin height is not a positive integer.
+        """
         if height < 0:
             warnings.warn("Invalid margin height, ignoring", RuntimeWarning)
         else:
@@ -542,14 +588,21 @@ class Overlay:
             self._overlay_parametres.margin_height = height
             self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def font_size(self) -> blueye.protocol.FontSize:
-        """Get or set the font size for the overlay.
+    margin_height = deprecated_property("get_margin_height", "set_margin_height")
 
-        Needs to be an instance of the `blueye.protocol.FontSize` enum.
+    def get_font_size(self) -> blueye.protocol.FontSize:
+        """Get the font size for the overlay.
 
         Returns:
             The current font size.
+        """
+        self._update_overlay_parameters()
+        return self._overlay_parametres.font_size
+
+    def set_font_size(self, size: blueye.protocol.FontSize):
+        """Set the font size for the overlay.
+
+        Needs to be an instance of the `blueye.protocol.FontSize` enum.
 
         Args:
             size (blueye.protocol.FontSize): The font size to set.
@@ -557,11 +610,6 @@ class Overlay:
         Warns:
             RuntimeWarning: If the font size is not an instance of blueye.protocol.FontSize.
         """
-        self._update_overlay_parameters()
-        return self._overlay_parametres.font_size
-
-    @font_size.setter
-    def font_size(self, size: blueye.protocol.FontSize):
         if not isinstance(size, blueye.protocol.FontSize):
             warnings.warn("Invalid font size, ignoring", RuntimeWarning)
         else:
@@ -570,17 +618,24 @@ class Overlay:
             self._overlay_parametres.font_size = size
             self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def title(self) -> str:
-        """Get or set the title for the overlay.
+    font_size = deprecated_property("get_font_size", "set_font_size")
+
+    def get_title(self) -> str:
+        """Get the title for the overlay.
+
+        Returns:
+            The current title.
+        """
+        self._update_overlay_parameters()
+        return self._overlay_parametres.title
+
+    def set_title(self, input_title: str):
+        """Set the title for the overlay.
 
         The title needs to be a string of only ASCII characters with a maximum length of 63
         characters.
 
         Set to an empty string to disable title.
-
-        Returns:
-            The current title.
 
         Args:
             input_title (str): The title to set. Truncated to 63 characters if longer.
@@ -588,11 +643,6 @@ class Overlay:
         Warns:
             RuntimeWarning: If the title is too long or contains non-ASCII characters.
         """
-        self._update_overlay_parameters()
-        return self._overlay_parametres.title
-
-    @title.setter
-    def title(self, input_title: str):
         new_title = input_title
         if len(input_title) > 63:
             warnings.warn("Too long title, truncating to 63 characters", RuntimeWarning)
@@ -607,17 +657,24 @@ class Overlay:
         self._overlay_parametres.title = new_title
         self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def subtitle(self) -> str:
-        """Get or set the subtitle for the overlay.
+    title = deprecated_property("get_title", "set_title")
+
+    def get_subtitle(self) -> str:
+        """Get the subtitle for the overlay.
+
+        Returns:
+            The current subtitle.
+        """
+        self._update_overlay_parameters()
+        return self._overlay_parametres.subtitle
+
+    def set_subtitle(self, input_subtitle: str):
+        """Set the subtitle for the overlay.
 
         The subtitle needs to be a string of only ASCII characters with a maximum length of 63
         characters.
 
         Set to an empty string to disable the subtitle.
-
-        Returns:
-            The current subtitle.
 
         Args:
             input_subtitle (str): The subtitle to set. Set to an empty string to disable.
@@ -626,11 +683,6 @@ class Overlay:
         Warns:
             RuntimeWarning: If the subtitle is too long or contains non-ASCII characters.
         """
-        self._update_overlay_parameters()
-        return self._overlay_parametres.subtitle
-
-    @subtitle.setter
-    def subtitle(self, input_subtitle: str):
         new_subtitle = input_subtitle
         if len(input_subtitle) > 63:
             warnings.warn("Too long subtitle, truncating to 63 characters", RuntimeWarning)
@@ -645,9 +697,19 @@ class Overlay:
         self._overlay_parametres.subtitle = new_subtitle
         self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
 
-    @property
-    def date_format(self) -> str:
-        """Get or set the format string for the time displayed in the overlay.
+    subtitle = deprecated_property("get_subtitle", "set_subtitle")
+
+    def get_date_format(self) -> str:
+        """Get the format string for the time displayed in the overlay.
+
+        Returns:
+            The current date format.
+        """
+        self._update_overlay_parameters()
+        return self._overlay_parametres.date_format
+
+    def set_date_format(self, input_format_str: str):
+        """Set the format string for the time displayed in the overlay.
 
         Must be a string containing only ASCII characters, with a max length of 63 characters.
 
@@ -655,20 +717,12 @@ class Overlay:
         https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes for an
         overview of the available codes.
 
-        Returns:
-            The current date format.
-
         Args:
             input_format_str (str): The date format string to set.
 
         Warns:
             RuntimeWarning: If the date format is too long or contains non-ASCII characters.
         """
-        self._update_overlay_parameters()
-        return self._overlay_parametres.date_format
-
-    @date_format.setter
-    def date_format(self, input_format_str: str):
         format_str = input_format_str
         if len(format_str) > 63:
             warnings.warn(
@@ -686,6 +740,8 @@ class Overlay:
             self._update_overlay_parameters()
         self._overlay_parametres.date_format = format_str
         self._parent_drone._req_rep_client.set_overlay_parameters(self._overlay_parametres)
+
+    date_format = deprecated_property("get_date_format", "set_date_format")
 
     def upload_logo(self, path_to_logo: str, timeout: float = 1.0):
         """Upload user selectable logo for watermarking videos and pictures.
@@ -848,20 +904,12 @@ class Camera:
         """
         return self._ParamsBatch(self, timeout=timeout)
 
-    @property
-    def is_recording(self) -> Optional[bool]:
-        """Get or set the camera recording state.
-
-        Args:
-            start_recording (bool): Set to True to start a recording, set to False to stop the
-                                    current recording.
+    def is_recording_active(self) -> Optional[bool]:
+        """Get the camera recording state.
 
         Returns:
             True if the camera is currently recording, False if not. Returns None if the SDK
             hasn't received a RecordState telemetry message.
-
-        Warns:
-            RuntimeWarning: If no recording state telemetry data is received.
         """
         record_state = self._get_record_state()
         if record_state is None:
@@ -871,8 +919,16 @@ class Camera:
         else:
             return record_state.main_is_recording
 
-    @is_recording.setter
-    def is_recording(self, start_recording: bool):
+    def set_recording(self, start_recording: bool):
+        """Set the camera recording state.
+
+        Args:
+            start_recording (bool): Set to True to start a recording, set to False to stop the
+                                    current recording.
+
+        Warns:
+            RuntimeWarning: If no recording state telemetry data is received.
+        """
         record_state = self._get_record_state()
         if record_state is None:
             logger.warning("Unable to set recording state, no record state telemetry received")
@@ -886,13 +942,10 @@ class Camera:
                 start_recording, record_state.guestport_is_recording
             )
 
-    @property
-    def bitrate(self) -> int:
-        """Set or get the video stream bitrate.
+    is_recording = deprecated_property("is_recording_active", "set_recording")
 
-        Args:
-            bitrate (int): Set the video stream bitrate in bits, valid values are in range
-                           (1 000 000 .. 16 000 000).
+    def get_bitrate(self) -> int:
+        """Get the video stream bitrate.
 
         Returns:
             The H264 video stream bitrate.
@@ -900,20 +953,22 @@ class Camera:
         self._update_camera_parameters()
         return self._camera_parameters.h264_bitrate
 
-    @bitrate.setter
-    def bitrate(self, bitrate: int):
+    def set_bitrate(self, bitrate: int):
+        """Set the video stream bitrate.
+
+        Args:
+            bitrate (int): Set the video stream bitrate in bits, valid values are in range
+                           (1 000 000 .. 16 000 000).
+        """
         if self._camera_parameters is None:
             self._update_camera_parameters()
         self._camera_parameters.h264_bitrate = bitrate
         self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
 
-    @property
-    def bitrate_still_picture(self) -> int:
-        """Set or get the bitrate for the still picture stream.
+    bitrate = deprecated_property("get_bitrate", "set_bitrate")
 
-        Args:
-            bitrate (int): Set the still picture stream bitrate in bits, valid values are in range
-                           (1 000 000 .. 300 000 000). Default value is 100 000 000.
+    def get_bitrate_still_picture(self) -> int:
+        """Get the bitrate for the still picture stream.
 
         Returns:
             The still picture stream bitrate.
@@ -921,21 +976,24 @@ class Camera:
         self._update_camera_parameters()
         return self._camera_parameters.mjpg_bitrate
 
-    @bitrate_still_picture.setter
-    def bitrate_still_picture(self, bitrate: int):
+    def set_bitrate_still_picture(self, bitrate: int):
+        """Set the bitrate for the still picture stream.
+
+        Args:
+            bitrate (int): Set the still picture stream bitrate in bits, valid values are in range
+                           (1 000 000 .. 300 000 000). Default value is 100 000 000.
+        """
         if self._camera_parameters is None:
             self._update_camera_parameters()
         self._camera_parameters.mjpg_bitrate = bitrate
         self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
 
-    @property
-    def exposure(self) -> int:
-        """Set or get the camera exposure.
+    bitrate_still_picture = deprecated_property(
+        "get_bitrate_still_picture", "set_bitrate_still_picture"
+    )
 
-        Args:
-            exposure (int): Set the camera exposure time. Unit is thousandths of a second,
-                            ie. 5 = 5s/1000. Valid values are in the range (1 .. 5000) or -1
-                            for auto exposure.
+    def get_exposure(self) -> int:
+        """Get the camera exposure.
 
         Returns:
             The camera exposure.
@@ -943,20 +1001,23 @@ class Camera:
         self._update_camera_parameters()
         return self._camera_parameters.exposure
 
-    @exposure.setter
-    def exposure(self, exposure: int):
+    def set_exposure(self, exposure: int):
+        """Set the camera exposure.
+
+        Args:
+            exposure (int): Set the camera exposure time. Unit is thousandths of a second,
+                            ie. 5 = 5s/1000. Valid values are in the range (1 .. 5000) or -1
+                            for auto exposure.
+        """
         if self._camera_parameters is None:
             self._update_camera_parameters()
         self._camera_parameters.exposure = exposure
         self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
 
-    @property
-    def whitebalance(self) -> int:
-        """Set or get the camera white balance.
+    exposure = deprecated_property("get_exposure", "set_exposure")
 
-        Args:
-            white_balance (int): Set the camera white balance. Valid values are in the range
-                                 (2800..9300) or -1 for auto white balance.
+    def get_whitebalance(self) -> int:
+        """Get the camera white balance.
 
         Returns:
             The camera white balance.
@@ -964,19 +1025,22 @@ class Camera:
         self._update_camera_parameters()
         return self._camera_parameters.white_balance
 
-    @whitebalance.setter
-    def whitebalance(self, white_balance: int):
+    def set_whitebalance(self, white_balance: int):
+        """Set the camera white balance.
+
+        Args:
+            white_balance (int): Set the camera white balance. Valid values are in the range
+                                 (2800..9300) or -1 for auto white balance.
+        """
         if self._camera_parameters is None:
             self._update_camera_parameters()
         self._camera_parameters.white_balance = white_balance
         self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
 
-    @property
-    def hue(self) -> int:
-        """Set or get the camera hue.
+    whitebalance = deprecated_property("get_whitebalance", "set_whitebalance")
 
-        Args:
-            hue (int): Set the camera hue. Valid values are in the range (-40..40).
+    def get_hue(self) -> int:
+        """Get the camera hue.
 
         Returns:
             The camera hue.
@@ -984,19 +1048,21 @@ class Camera:
         self._update_camera_parameters()
         return self._camera_parameters.hue
 
-    @hue.setter
-    def hue(self, hue: int):
+    def set_hue(self, hue: int):
+        """Set the camera hue.
+
+        Args:
+            hue (int): Set the camera hue. Valid values are in the range (-40..40).
+        """
         if self._camera_parameters is None:
             self._update_camera_parameters()
         self._camera_parameters.hue = hue
         self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
 
-    @property
-    def resolution(self) -> int:
-        """Set or get the camera resolution.
+    hue = deprecated_property("get_hue", "set_hue")
 
-        Args:
-            resolution (int): Set the camera in vertical pixels. Valid values are 720 or 1080.
+    def get_resolution(self) -> int:
+        """Get the camera resolution.
 
         Returns:
             The camera resolution.
@@ -1009,8 +1075,15 @@ class Camera:
         ):
             return 1080
 
-    @resolution.setter
-    def resolution(self, resolution: int):
+    def set_resolution(self, resolution: int):
+        """Set the camera resolution.
+
+        Args:
+            resolution (int): Set the camera in vertical pixels. Valid values are 720 or 1080.
+
+        Raises:
+            ValueError: If the resolution is not 720 or 1080.
+        """
         if resolution not in (720, 1080):
             raise ValueError(
                 f"{resolution} is not a valid resolution. Valid values are 720 or 1080"
@@ -1024,18 +1097,13 @@ class Camera:
 
         self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
 
-    @property
-    def stream_resolution(self) -> blueye.protocol.Resolution:
-        """Set or get the camera stream resolution.
+    resolution = deprecated_property("get_resolution", "set_resolution")
+
+    def get_stream_resolution(self) -> blueye.protocol.Resolution:
+        """Get the camera stream resolution.
 
         For drones running blunux version < 4.4.1 this is the same as the
-        [`resolution`][blueye.sdk.camera.Camera.resolution] property.
-
-        Args:
-            resolution (blueye.protocol.Resolution): Set the camera stream resolution.
-
-        Raises:
-            ValueError: If the resolution is not a valid `blueye.protocol.Resolution` type
+        [`get_resolution`][blueye.sdk.camera.Camera.get_resolution] method.
 
         Returns:
             The camera stream resolution
@@ -1049,8 +1117,18 @@ class Camera:
         else:
             return self._camera_parameters.stream_resolution
 
-    @stream_resolution.setter
-    def stream_resolution(self, resolution: blueye.protocol.Resolution):
+    def set_stream_resolution(self, resolution: blueye.protocol.Resolution):
+        """Set the camera stream resolution.
+
+        For drones running blunux version < 4.4.1 this is the same as the
+        [`set_resolution`][blueye.sdk.camera.Camera.set_resolution] method.
+
+        Args:
+            resolution (blueye.protocol.Resolution): Set the camera stream resolution.
+
+        Raises:
+            ValueError: If the resolution is not a valid `blueye.protocol.Resolution` type
+        """
         if not isinstance(resolution, blueye.protocol.Resolution):
             raise ValueError(f"{resolution} is not a valid resolution type")
         if self._camera_parameters is None:
@@ -1060,12 +1138,13 @@ class Camera:
         self._camera_parameters.resolution = resolution
         self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
 
-    @property
-    def recording_resolution(self) -> blueye.protocol.Resolution:
-        """Set or get the camera recording resolution.
+    stream_resolution = deprecated_property("get_stream_resolution", "set_stream_resolution")
+
+    def get_recording_resolution(self) -> blueye.protocol.Resolution:
+        """Get the camera recording resolution.
 
         For drones running Blunux version < 4.4.1 this is the same as the
-        [`resolution`][blueye.sdk.camera.Camera.resolution] property.
+        [`get_resolution`][blueye.sdk.camera.Camera.get_resolution] method.
 
         Returns:
             The camera recording resolution.
@@ -1079,8 +1158,18 @@ class Camera:
         else:
             return self._camera_parameters.recording_resolution
 
-    @recording_resolution.setter
-    def recording_resolution(self, resolution: blueye.protocol.Resolution):
+    def set_recording_resolution(self, resolution: blueye.protocol.Resolution):
+        """Set the camera recording resolution.
+
+        For drones running Blunux version < 4.4.1 this is the same as the
+        [`set_resolution`][blueye.sdk.camera.Camera.set_resolution] method.
+
+        Args:
+            resolution (blueye.protocol.Resolution): Set the camera recording resolution.
+
+        Raises:
+            ValueError: If the resolution is not a valid `blueye.protocol.Resolution` type
+        """
         if not isinstance(resolution, blueye.protocol.Resolution):
             raise ValueError(f"{resolution} is not a valid resolution type")
         if self._camera_parameters is None:
@@ -1090,13 +1179,12 @@ class Camera:
         self._camera_parameters.resolution = resolution
         self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
 
-    @property
-    def framerate(self) -> int:
-        """Set or get the camera frame rate.
+    recording_resolution = deprecated_property(
+        "get_recording_resolution", "set_recording_resolution"
+    )
 
-        Args:
-            framerate (int): Set the camera frame rate in frames per second.
-                             Valid values are 25 or 30.
+    def get_framerate(self) -> int:
+        """Get the camera frame rate.
 
         Returns:
             The camera frame rate.
@@ -1107,8 +1195,16 @@ class Camera:
         elif self._camera_parameters.framerate == blueye.protocol.Framerate.FRAMERATE_FPS_30:
             return 30
 
-    @framerate.setter
-    def framerate(self, framerate: int):
+    def set_framerate(self, framerate: int):
+        """Set the camera frame rate.
+
+        Args:
+            framerate (int): Set the camera frame rate in frames per second.
+                             Valid values are 25 or 30.
+
+        Raises:
+            ValueError: If the framerate is not 25 or 30.
+        """
         if framerate not in (25, 30):
             raise ValueError(f"{framerate} is not a valid framerate. Valid values are 25 or 30")
         if self._camera_parameters is None:
@@ -1119,14 +1215,10 @@ class Camera:
             self._camera_parameters.framerate = blueye.protocol.Framerate.FRAMERATE_FPS_30
         self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
 
-    @property
-    def recording_codec(self) -> blueye.protocol.RecordingCodec:
-        """Set or get the recording video codec.
+    framerate = deprecated_property("get_framerate", "set_framerate")
 
-        Args:
-            codec (blueye.protocol.RecordingCodec): Set the recording codec.
-                RECORDING_CODEC_UNSPECIFIED uses the platform default (H.264).
-                RECORDING_CODEC_H265 is only available on Ultra.
+    def get_recording_codec(self) -> blueye.protocol.RecordingCodec:
+        """Get the recording video codec.
 
         Returns:
             The current recording codec setting.
@@ -1134,8 +1226,18 @@ class Camera:
         self._update_camera_parameters()
         return self._camera_parameters.recording_codec
 
-    @recording_codec.setter
-    def recording_codec(self, codec: blueye.protocol.RecordingCodec):
+    def set_recording_codec(self, codec: blueye.protocol.RecordingCodec):
+        """Set the recording video codec.
+
+        Args:
+            codec (blueye.protocol.RecordingCodec): Set the recording codec.
+                RECORDING_CODEC_UNSPECIFIED uses the platform default (H.264).
+                RECORDING_CODEC_H265 is only available on Ultra.
+
+        Raises:
+            ValueError: If the codec is not a valid `blueye.protocol.RecordingCodec` type.
+            RuntimeError: If the connected drone is running Blunux older than 5.0.0.
+        """
         self._parent_drone._verify_required_blunux_version("5.0.0")
         if not isinstance(codec, blueye.protocol.RecordingCodec):
             raise ValueError(f"{codec} is not a valid RecordingCodec type")
@@ -1144,15 +1246,13 @@ class Camera:
         self._camera_parameters.recording_codec = codec
         self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
 
-    @property
-    def recording_bitrate(self) -> int:
-        """Set or get the recording bitrate in bits per second.
+    recording_codec = deprecated_property("get_recording_codec", "set_recording_codec")
+
+    def get_recording_bitrate(self) -> int:
+        """Get the recording bitrate in bits per second.
 
         A value of 0 means the drone will auto-compute a default bitrate based on the current
         resolution, framerate, and codec.
-
-        Args:
-            bitrate (int): Set the recording bitrate in bits per second. Use 0 for automatic.
 
         Returns:
             The current recording bitrate in bits per second (0 if automatic).
@@ -1160,20 +1260,28 @@ class Camera:
         self._update_camera_parameters()
         return self._camera_parameters.recording_bitrate
 
-    @recording_bitrate.setter
-    def recording_bitrate(self, bitrate: int):
+    def set_recording_bitrate(self, bitrate: int):
+        """Set the recording bitrate in bits per second.
+
+        A value of 0 means the drone will auto-compute a default bitrate based on the current
+        resolution, framerate, and codec.
+
+        Args:
+            bitrate (int): Set the recording bitrate in bits per second. Use 0 for automatic.
+
+        Raises:
+            RuntimeError: If the connected drone is running Blunux older than 5.0.0.
+        """
         self._parent_drone._verify_required_blunux_version("5.0.0")
         if self._camera_parameters is None:
             self._update_camera_parameters()
         self._camera_parameters.recording_bitrate = bitrate
         self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
 
-    @property
-    def streaming_protocol(self) -> blueye.protocol.StreamingProtocol:
-        """Set or get the streaming protocol (codec used for the RTSP stream).
+    recording_bitrate = deprecated_property("get_recording_bitrate", "set_recording_bitrate")
 
-        Args:
-            protocol (blueye.protocol.StreamingProtocol): Set the streaming protocol.
+    def get_streaming_protocol(self) -> blueye.protocol.StreamingProtocol:
+        """Get the streaming protocol (codec used for the RTSP stream).
 
         Returns:
             The current streaming protocol.
@@ -1181,8 +1289,15 @@ class Camera:
         self._update_camera_parameters()
         return self._camera_parameters.streaming_protocol
 
-    @streaming_protocol.setter
-    def streaming_protocol(self, protocol: blueye.protocol.StreamingProtocol):
+    def set_streaming_protocol(self, protocol: blueye.protocol.StreamingProtocol):
+        """Set the streaming protocol (codec used for the RTSP stream).
+
+        Args:
+            protocol (blueye.protocol.StreamingProtocol): Set the streaming protocol.
+
+        Raises:
+            ValueError: If the protocol is not a valid `blueye.protocol.StreamingProtocol` type.
+        """
         if not isinstance(protocol, blueye.protocol.StreamingProtocol):
             raise ValueError(f"{protocol} is not a valid StreamingProtocol type")
         if self._camera_parameters is None:
@@ -1190,8 +1305,9 @@ class Camera:
         self._camera_parameters.streaming_protocol = protocol
         self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
 
-    @property
-    def record_time(self) -> Optional[int]:
+    streaming_protocol = deprecated_property("get_streaming_protocol", "set_streaming_protocol")
+
+    def get_record_time(self) -> Optional[int]:
         """Get the duration of the current camera recording.
 
         Returns:
@@ -1205,6 +1321,8 @@ class Camera:
             return record_state.guestport_seconds
         else:
             return record_state.main_seconds
+
+    record_time = deprecated_property("get_record_time")
 
     def take_picture(self):
         """Take a still picture and store it locally on the drone.

--- a/blueye/sdk/drone.py
+++ b/blueye/sdk/drone.py
@@ -543,7 +543,10 @@ class Drone:
             The intensity of the drone light (0..1). `None` if no telemetry message has been
             received.
         """
-        return self.telemetry.get(blueye.protocol.LightsTel).lights.value
+        lights_tel = self.telemetry.get(blueye.protocol.LightsTel)
+        if lights_tel is None:
+            return None
+        return lights_tel.lights.value
 
     def set_lights(self, brightness: float):
         """Set the intensity of the drone lights.

--- a/blueye/sdk/drone.py
+++ b/blueye/sdk/drone.py
@@ -30,7 +30,7 @@ from .guestport import (
 from .logs import LegacyLogs, Logs
 from .mission import Mission
 from .motion import Motion
-from .utils import deserialize_any_to_message, is_scalar_type
+from .utils import deprecated_property, deserialize_any_to_message, is_scalar_type
 
 logger = logging.getLogger(__name__)
 
@@ -47,9 +47,19 @@ class Config:
         self._parent_drone = parent_drone
         self._water_density = WaterDensities.salty
 
-    @property
-    def water_density(self):
-        """Get or set the current water density for increased pressure sensor accuracy.
+    def get_water_density(self) -> float:
+        """Get the water density used for increased pressure sensor accuracy.
+
+        The [WaterDensities][blueye.sdk.constants.WaterDensities] class contains typical densities
+        for salty-, brackish-, and fresh water (these are the same values that the Blueye app uses).
+
+        Returns:
+            The currently configured water density in grams per liter.
+        """
+        return self._water_density
+
+    def set_water_density(self, density: float):
+        """Set the current water density for increased pressure sensor accuracy.
 
         Older software versions will assume a water density of 1025 grams per liter.
 
@@ -59,12 +69,10 @@ class Config:
         Args:
             density (float): The water density to set.
         """
-        return self._water_density
-
-    @water_density.setter
-    def water_density(self, density: float):
         self._water_density = density
         self._parent_drone._ctrl_client.set_water_density(density)
+
+    water_density = deprecated_property("get_water_density", "set_water_density")
 
     def set_drone_time(self, time: int):
         """Set the system time for the drone.
@@ -480,8 +488,7 @@ class Drone:
 
         self.connected = False
 
-    @property
-    def connected_clients(self) -> Optional[List[blueye.protocol.ConnectedClient]]:
+    def get_connected_clients(self) -> Optional[List[blueye.protocol.ConnectedClient]]:
         """Get a list of connected clients.
 
         Returns:
@@ -493,8 +500,9 @@ class Drone:
         else:
             return list(clients_tel.connected_clients)
 
-    @property
-    def client_in_control(self) -> Optional[int]:
+    connected_clients = deprecated_property("get_connected_clients")
+
+    def get_client_in_control(self) -> Optional[int]:
         """Get the client ID of the client in control of the drone.
 
         Returns:
@@ -505,6 +513,8 @@ class Drone:
             return None
         else:
             return clients_tel.client_id_in_control
+
+    client_in_control = deprecated_property("get_client_in_control")
 
     def take_control(self, timeout=1):
         """Take control of the drone, disconnecting other clients.
@@ -518,7 +528,7 @@ class Drone:
             RuntimeError: If the client could not take control of the drone in the given time.
         """
         start_time = time.time()
-        client_in_control = self.client_in_control
+        client_in_control = self.get_client_in_control()
         while self.client_id != client_in_control:
             if time.time() - start_time > timeout:
                 raise RuntimeError("Could not take control of the drone in the given time")
@@ -526,30 +536,31 @@ class Drone:
             client_in_control = resp.client_id_in_control
         self.in_control = True
 
-    @property
-    def lights(self) -> Optional[float]:
-        """Get or set the intensity of the drone lights.
-
-        Args:
-            brightness (float): Set the intensity of the drone light (0..1).
+    def get_lights(self) -> Optional[float]:
+        """Get the intensity of the drone lights.
 
         Returns:
             The intensity of the drone light (0..1). `None` if no telemetry message has been
             received.
-
-        Raises:
-            ValueError: If the brightness is not in the range
         """
         return self.telemetry.get(blueye.protocol.LightsTel).lights.value
 
-    @lights.setter
-    def lights(self, brightness: float):
+    def set_lights(self, brightness: float):
+        """Set the intensity of the drone lights.
+
+        Args:
+            brightness (float): Set the intensity of the drone light (0..1).
+
+        Raises:
+            ValueError: If the brightness is not in the range (0..1).
+        """
         if not 0 <= brightness <= 1:
             raise ValueError("Error occurred while trying to set lights to: " f"{brightness}")
         self._ctrl_client.set_lights(brightness)
 
-    @property
-    def depth(self) -> Optional[float]:
+    lights = deprecated_property("get_lights", "set_lights")
+
+    def get_depth(self) -> Optional[float]:
         """Get the current depth in meters.
 
         Returns:
@@ -561,8 +572,9 @@ class Drone:
         else:
             return depth_tel.depth.value
 
-    @property
-    def pose(self) -> Optional[Dict[str, float]]:
+    depth = deprecated_property("get_depth")
+
+    def get_pose(self) -> Optional[Dict[str, float]]:
         """Get the current orientation of the drone.
 
         Returns:
@@ -579,11 +591,12 @@ class Drone:
         }
         return pose
 
-    @property
-    def altitude(self) -> Optional[float]:
+    pose = deprecated_property("get_pose")
+
+    def get_altitude(self) -> Optional[float]:
         """Get the current altitude in meters.
 
-        If the drone has a DVL or a positioning system with a valid reading, this property will
+        If the drone has a DVL or a positioning system with a valid reading, this method will
         return the current altitude.
 
         Returns:
@@ -595,8 +608,9 @@ class Drone:
         else:
             return altitude_tel.altitude.value
 
-    @property
-    def error_flags(self) -> Dict[str, bool]:
+    altitude = deprecated_property("get_altitude")
+
+    def get_error_flags(self) -> Dict[str, bool]:
         """Get the error flags.
 
         Returns:
@@ -612,8 +626,9 @@ class Drone:
             error_flags[flag] = getattr(error_flags_msg, flag)
         return error_flags
 
-    @property
-    def active_video_streams(self) -> Dict[str, int]:
+    error_flags = deprecated_property("get_error_flags")
+
+    def get_active_video_streams(self) -> Dict[str, int]:
         """Get the number of currently active connections to the video stream.
 
         Every client connected to the RTSP stream (does not matter if it's directly from GStreamer,
@@ -629,6 +644,8 @@ class Drone:
         n_streamers_msg = n_streamers_msg_tel.n_streamers
         return {"main": n_streamers_msg.main, "guestport": n_streamers_msg.guestport}
 
+    active_video_streams = deprecated_property("get_active_video_streams")
+
     def ping(self, timeout: float = 1.0):
         """Ping the drone.
 
@@ -641,8 +658,7 @@ class Drone:
         """
         self._req_rep_client.ping(timeout)
 
-    @property
-    def water_temperature(self) -> Optional[float]:
+    def get_water_temperature(self) -> Optional[float]:
         """Get the water temperature in degrees Celsius.
 
         Returns:
@@ -653,8 +669,9 @@ class Drone:
             return None
         return water_temperature_tel.temperature.value
 
-    @property
-    def dive_time(self) -> Optional[int]:
+    water_temperature = deprecated_property("get_water_temperature")
+
+    def get_dive_time(self) -> Optional[int]:
         """Get the amount of time the drone has been submerged.
 
         The drone starts incrementing this value when the depth is above 250 mm.
@@ -667,3 +684,5 @@ class Drone:
             return None
         else:
             return dive_time_tel.dive_time.value
+
+    dive_time = deprecated_property("get_dive_time")

--- a/blueye/sdk/drone.py
+++ b/blueye/sdk/drone.py
@@ -545,7 +545,10 @@ class Drone:
             The intensity of the drone light (0..1). `None` if no telemetry message has been
             received.
         """
-        return self.telemetry.get(blueye.protocol.LightsTel).lights.value
+        lights_tel = self.telemetry.get(blueye.protocol.LightsTel)
+        if lights_tel is None:
+            return None
+        return lights_tel.lights.value
 
     def set_lights(self, brightness: float):
         """Set the intensity of the drone lights.

--- a/blueye/sdk/drone.py
+++ b/blueye/sdk/drone.py
@@ -31,7 +31,7 @@ from .cv_models import CvModels
 from .logs import LegacyLogs, Logs
 from .mission import Mission
 from .motion import Motion
-from .utils import deserialize_any_to_message, is_scalar_type
+from .utils import deprecated_property, deserialize_any_to_message, is_scalar_type
 
 logger = logging.getLogger(__name__)
 
@@ -48,9 +48,19 @@ class Config:
         self._parent_drone = parent_drone
         self._water_density = WaterDensities.salty
 
-    @property
-    def water_density(self):
-        """Get or set the current water density for increased pressure sensor accuracy.
+    def get_water_density(self) -> float:
+        """Get the water density used for increased pressure sensor accuracy.
+
+        The [WaterDensities][blueye.sdk.constants.WaterDensities] class contains typical densities
+        for salty-, brackish-, and fresh water (these are the same values that the Blueye app uses).
+
+        Returns:
+            The currently configured water density in grams per liter.
+        """
+        return self._water_density
+
+    def set_water_density(self, density: float):
+        """Set the current water density for increased pressure sensor accuracy.
 
         Older software versions will assume a water density of 1025 grams per liter.
 
@@ -60,12 +70,10 @@ class Config:
         Args:
             density (float): The water density to set.
         """
-        return self._water_density
-
-    @water_density.setter
-    def water_density(self, density: float):
         self._water_density = density
         self._parent_drone._ctrl_client.set_water_density(density)
+
+    water_density = deprecated_property("get_water_density", "set_water_density")
 
     def set_drone_time(self, time: int):
         """Set the system time for the drone.
@@ -482,8 +490,7 @@ class Drone:
 
         self.connected = False
 
-    @property
-    def connected_clients(self) -> Optional[List[blueye.protocol.ConnectedClient]]:
+    def get_connected_clients(self) -> Optional[List[blueye.protocol.ConnectedClient]]:
         """Get a list of connected clients.
 
         Returns:
@@ -495,8 +502,9 @@ class Drone:
         else:
             return list(clients_tel.connected_clients)
 
-    @property
-    def client_in_control(self) -> Optional[int]:
+    connected_clients = deprecated_property("get_connected_clients")
+
+    def get_client_in_control(self) -> Optional[int]:
         """Get the client ID of the client in control of the drone.
 
         Returns:
@@ -507,6 +515,8 @@ class Drone:
             return None
         else:
             return clients_tel.client_id_in_control
+
+    client_in_control = deprecated_property("get_client_in_control")
 
     def take_control(self, timeout=1):
         """Take control of the drone, disconnecting other clients.
@@ -520,7 +530,7 @@ class Drone:
             RuntimeError: If the client could not take control of the drone in the given time.
         """
         start_time = time.time()
-        client_in_control = self.client_in_control
+        client_in_control = self.get_client_in_control()
         while self.client_id != client_in_control:
             if time.time() - start_time > timeout:
                 raise RuntimeError("Could not take control of the drone in the given time")
@@ -528,30 +538,31 @@ class Drone:
             client_in_control = resp.client_id_in_control
         self.in_control = True
 
-    @property
-    def lights(self) -> Optional[float]:
-        """Get or set the intensity of the drone lights.
-
-        Args:
-            brightness (float): Set the intensity of the drone light (0..1).
+    def get_lights(self) -> Optional[float]:
+        """Get the intensity of the drone lights.
 
         Returns:
             The intensity of the drone light (0..1). `None` if no telemetry message has been
             received.
-
-        Raises:
-            ValueError: If the brightness is not in the range
         """
         return self.telemetry.get(blueye.protocol.LightsTel).lights.value
 
-    @lights.setter
-    def lights(self, brightness: float):
+    def set_lights(self, brightness: float):
+        """Set the intensity of the drone lights.
+
+        Args:
+            brightness (float): Set the intensity of the drone light (0..1).
+
+        Raises:
+            ValueError: If the brightness is not in the range (0..1).
+        """
         if not 0 <= brightness <= 1:
             raise ValueError("Error occurred while trying to set lights to: " f"{brightness}")
         self._ctrl_client.set_lights(brightness)
 
-    @property
-    def depth(self) -> Optional[float]:
+    lights = deprecated_property("get_lights", "set_lights")
+
+    def get_depth(self) -> Optional[float]:
         """Get the current depth in meters.
 
         Returns:
@@ -563,8 +574,9 @@ class Drone:
         else:
             return depth_tel.depth.value
 
-    @property
-    def pose(self) -> Optional[Dict[str, float]]:
+    depth = deprecated_property("get_depth")
+
+    def get_pose(self) -> Optional[Dict[str, float]]:
         """Get the current orientation of the drone.
 
         Returns:
@@ -581,11 +593,12 @@ class Drone:
         }
         return pose
 
-    @property
-    def altitude(self) -> Optional[float]:
+    pose = deprecated_property("get_pose")
+
+    def get_altitude(self) -> Optional[float]:
         """Get the current altitude in meters.
 
-        If the drone has a DVL or a positioning system with a valid reading, this property will
+        If the drone has a DVL or a positioning system with a valid reading, this method will
         return the current altitude.
 
         Returns:
@@ -597,8 +610,9 @@ class Drone:
         else:
             return altitude_tel.altitude.value
 
-    @property
-    def error_flags(self) -> Dict[str, bool]:
+    altitude = deprecated_property("get_altitude")
+
+    def get_error_flags(self) -> Dict[str, bool]:
         """Get the error flags.
 
         Returns:
@@ -614,8 +628,9 @@ class Drone:
             error_flags[flag] = getattr(error_flags_msg, flag)
         return error_flags
 
-    @property
-    def active_video_streams(self) -> Dict[str, int]:
+    error_flags = deprecated_property("get_error_flags")
+
+    def get_active_video_streams(self) -> Dict[str, int]:
         """Get the number of currently active connections to the video stream.
 
         Every client connected to the RTSP stream (does not matter if it's directly from GStreamer,
@@ -631,6 +646,8 @@ class Drone:
         n_streamers_msg = n_streamers_msg_tel.n_streamers
         return {"main": n_streamers_msg.main, "guestport": n_streamers_msg.guestport}
 
+    active_video_streams = deprecated_property("get_active_video_streams")
+
     def ping(self, timeout: float = 1.0):
         """Ping the drone.
 
@@ -643,8 +660,7 @@ class Drone:
         """
         self._req_rep_client.ping(timeout)
 
-    @property
-    def water_temperature(self) -> Optional[float]:
+    def get_water_temperature(self) -> Optional[float]:
         """Get the water temperature in degrees Celsius.
 
         Returns:
@@ -655,8 +671,9 @@ class Drone:
             return None
         return water_temperature_tel.temperature.value
 
-    @property
-    def dive_time(self) -> Optional[int]:
+    water_temperature = deprecated_property("get_water_temperature")
+
+    def get_dive_time(self) -> Optional[int]:
         """Get the amount of time the drone has been submerged.
 
         The drone starts incrementing this value when the depth is above 250 mm.
@@ -669,3 +686,5 @@ class Drone:
             return None
         else:
             return dive_time_tel.dive_time.value
+
+    dive_time = deprecated_property("get_dive_time")

--- a/blueye/sdk/guestport.py
+++ b/blueye/sdk/guestport.py
@@ -5,6 +5,7 @@ import blueye.protocol as bp
 from packaging import version
 
 from .camera import Camera
+from .utils import deprecated_property
 
 if TYPE_CHECKING:
     from .drone import Drone
@@ -118,23 +119,23 @@ class Gripper(Peripheral):
         self._grip_velocity = 0
         self._rotation_velocity = 0
 
-    @property
-    def grip_velocity(self) -> float:
-        """Get or set the current grip velocity of the Gripper.
+    def get_grip_velocity(self) -> float:
+        """Get the current grip velocity of the Gripper.
+
+        Returns:
+            The current grip velocity of the Gripper.
+        """
+        return self._grip_velocity
+
+    def set_grip_velocity(self, value: float):
+        """Set the current grip velocity of the Gripper.
 
         Args:
             value (float): The new grip velocity to set. Must be a float between -1.0 and 1.0.
 
-        Returns:
-            The current grip velocity of the Gripper.
-
         Raises:
             ValueError: If the grip velocity is not between -1.0 and 1.0.
         """
-        return self._grip_velocity
-
-    @grip_velocity.setter
-    def grip_velocity(self, value: float):
         if value < -1.0 or value > 1.0:
             raise ValueError("Grip velocity must be between -1.0 and 1.0.")
         self._grip_velocity = value
@@ -142,29 +143,33 @@ class Gripper(Peripheral):
             self._grip_velocity, self._rotation_velocity
         )
 
-    @property
-    def rotation_velocity(self) -> float:
-        """Get or set the current rotation velocity of the Gripper.
+    grip_velocity = deprecated_property("get_grip_velocity", "set_grip_velocity")
+
+    def get_rotation_velocity(self) -> float:
+        """Get the current rotation velocity of the Gripper.
+
+        Returns:
+            The current rotation velocity of the Gripper.
+        """
+        return self._rotation_velocity
+
+    def set_rotation_velocity(self, value: float):
+        """Set the current rotation velocity of the Gripper.
 
         Args:
             value (float): The new rotation velocity to set. Must be a float between -1.0 and 1.0.
 
-        Returns:
-            The current rotation velocity of the Gripper.
-
         Raises:
             ValueError: If the rotation velocity is not between -1.0 and 1.0.
         """
-        return self._rotation_velocity
-
-    @rotation_velocity.setter
-    def rotation_velocity(self, value: float):
         if value < -1.0 or value > 1.0:
             raise ValueError("Rotation velocity must be between -1.0 and 1.0.")
         self._rotation_velocity = value
         self.parent_drone._ctrl_client.set_gripper_velocities(
             self._grip_velocity, self._rotation_velocity
         )
+
+    rotation_velocity = deprecated_property("get_rotation_velocity", "set_rotation_velocity")
 
 
 class Laser(Peripheral):

--- a/blueye/sdk/motion.py
+++ b/blueye/sdk/motion.py
@@ -1,15 +1,18 @@
 import threading
+import warnings
 from typing import Optional
 
 import blueye.protocol
+
+from .utils import deprecated_property
 
 
 class Motion:
     """Control the motion of the drone, and set automatic control modes
 
-    Motion can be set one degree of freedom at a time by using the 4 motion properties
-    (surge, sway, heave and yaw) or for all 4 degrees of freedom in one go through the
-    `send_thruster_setpoint` method.
+    Motion can be set one degree of freedom at a time by using the 4 motion setters
+    (set_surge, set_sway, set_heave and set_yaw) or for all 4 degrees of freedom in one go through
+    the `send_thruster_setpoint` method.
     """
 
     def __init__(self, parent_drone):
@@ -18,99 +21,125 @@ class Motion:
         self._current_thruster_setpoints = {"surge": 0, "sway": 0, "heave": 0, "yaw": 0}
         self._current_boost_setpoints = {"slow": 0, "boost": 0}
 
-    @property
-    def current_thruster_setpoints(self):
+    def get_current_thruster_setpoints(self):
         """Returns the current setpoints for the thrusters
 
         We maintain this state in the SDK since the drone expects to receive all of the setpoints at
         once.
 
-        For setting the setpoints you should use the dedicated properties/functions for that, trying
-        to set them directly with this property will raise an AttributeError.
+        For setting the setpoints you should use the dedicated setters/functions for that, trying
+        to set them directly will raise an AttributeError.
         """
 
         return self._current_thruster_setpoints
 
+    @property
+    def current_thruster_setpoints(self):
+        """Deprecated, use `get_current_thruster_setpoints` instead."""
+        warnings.warn(
+            "`Motion.current_thruster_setpoints` is deprecated and will be removed in the next "
+            "major version. Use `Motion.get_current_thruster_setpoints()` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_current_thruster_setpoints()
+
     @current_thruster_setpoints.setter
     def current_thruster_setpoints(self, *args, **kwargs):
         raise AttributeError(
-            "Do not set the setpoints directly, use the surge, sway, heave, yaw properties or the "
+            "Do not set the setpoints directly, use the surge, sway, heave, yaw setters or the "
             "send_thruster_setpoint function for that."
         )
 
     def _send_motion_input_message(self):
         """Small helper function for building argument list to motion_input command"""
-        thruster_setpoints = self.current_thruster_setpoints.values()
+        thruster_setpoints = self._current_thruster_setpoints.values()
         boost_setpoints = self._current_boost_setpoints.values()
         self._parent_drone._ctrl_client.set_motion_input(*thruster_setpoints, *boost_setpoints)
 
-    @property
-    def surge(self) -> float:
+    def get_surge(self) -> float:
+        """Get the force reference for the surge direction
+
+        Returns:
+            Force set point in the surge direction in range <-1, 1>.
+        """
+        return self._current_thruster_setpoints["surge"]
+
+    def set_surge(self, surge_value: float):
         """Set force reference for the surge direction
 
-        Arguments:
-
-        * **surge** (float): Force set point in the surge direction in range <-1, 1>,
-                             a positive set point makes the drone move forward
+        Args:
+            surge_value (float): Force set point in the surge direction in range <-1, 1>,
+                                 a positive set point makes the drone move forward.
         """
-        return self.current_thruster_setpoints["surge"]
-
-    @surge.setter
-    def surge(self, surge_value: float):
         with self.thruster_lock:
             self._current_thruster_setpoints["surge"] = surge_value
             self._send_motion_input_message()
 
-    @property
-    def sway(self) -> float:
+    surge = deprecated_property("get_surge", "set_surge")
+
+    def get_sway(self) -> float:
+        """Get the force reference for the sway direction
+
+        Returns:
+            Force set point in the sway direction in range <-1, 1>.
+        """
+        return self._current_thruster_setpoints["sway"]
+
+    def set_sway(self, sway_value: float):
         """Set force reference for the sway direction
 
-        Arguments:
-
-        * **sway** (float): Force set point in the sway direction in range <-1, 1>,
-                            a positive set point makes the drone move to the right
+        Args:
+            sway_value (float): Force set point in the sway direction in range <-1, 1>,
+                                a positive set point makes the drone move to the right.
         """
-        return self.current_thruster_setpoints["sway"]
-
-    @sway.setter
-    def sway(self, sway_value: float):
         with self.thruster_lock:
             self._current_thruster_setpoints["sway"] = sway_value
             self._send_motion_input_message()
 
-    @property
-    def heave(self) -> float:
+    sway = deprecated_property("get_sway", "set_sway")
+
+    def get_heave(self) -> float:
+        """Get the force reference for the heave direction
+
+        Returns:
+            Force set point in the heave direction in range <-1, 1>.
+        """
+        return self._current_thruster_setpoints["heave"]
+
+    def set_heave(self, heave_value: float):
         """Set force reference for the heave direction
 
-        Arguments:
-
-        * **heave** (float): Force set point in the heave direction in range <-1, 1>,
-                             a positive set point makes the drone move downwards
+        Args:
+            heave_value (float): Force set point in the heave direction in range <-1, 1>,
+                                 a positive set point makes the drone move downwards.
         """
-        return self.current_thruster_setpoints["heave"]
-
-    @heave.setter
-    def heave(self, heave_value: float):
         with self.thruster_lock:
             self._current_thruster_setpoints["heave"] = heave_value
             self._send_motion_input_message()
 
-    @property
-    def yaw(self) -> float:
-        """Set force reference for the yaw direction
+    heave = deprecated_property("get_heave", "set_heave")
 
-        Arguments:
+    def get_yaw(self) -> float:
+        """Get the moment reference for the yaw direction
 
-        * **yaw** (float): Moment set point in the sway direction in range <-1, 1>,
-                           a positive set point makes the drone rotate clockwise.
+        Returns:
+            Moment set point in the yaw direction in range <-1, 1>.
         """
-        return self.current_thruster_setpoints["yaw"]
+        return self._current_thruster_setpoints["yaw"]
 
-    @yaw.setter
-    def yaw(self, yaw_value: float):
+    def set_yaw(self, yaw_value: float):
+        """Set moment reference for the yaw direction
+
+        Args:
+            yaw_value (float): Moment set point in the yaw direction in range <-1, 1>,
+                               a positive set point makes the drone rotate clockwise.
+        """
         with self.thruster_lock:
             self._current_thruster_setpoints["yaw"] = yaw_value
             self._send_motion_input_message()
+
+    yaw = deprecated_property("get_yaw", "set_yaw")
 
     def send_thruster_setpoint(self, surge, sway, heave, yaw):
         """Control the thrusters of the drone
@@ -140,54 +169,57 @@ class Motion:
             self._current_thruster_setpoints["yaw"] = yaw
             self._send_motion_input_message()
 
-    @property
-    def boost(self) -> float:
-        """Get or set the boost gain
+    def get_boost(self) -> float:
+        """Get the boost gain
 
-        Arguments:
-
-        * **boost_gain** (float): Range from 0 to 1.
+        Returns:
+            The current boost gain, range from 0 to 1.
         """
         return self._current_boost_setpoints["boost"]
 
-    @boost.setter
-    def boost(self, boost_gain: float):
+    def set_boost(self, boost_gain: float):
+        """Set the boost gain
+
+        Args:
+            boost_gain (float): Range from 0 to 1.
+        """
         with self.thruster_lock:
             self._current_boost_setpoints["boost"] = boost_gain
             self._send_motion_input_message()
 
-    @property
-    def slow(self) -> float:
-        """Get or set the "slow gain" (inverse of boost)
+    boost = deprecated_property("get_boost", "set_boost")
 
-        Arguments:
+    def get_slow(self) -> float:
+        """Get the "slow gain" (inverse of boost)
 
-        * **slow_gain** (float): Range from 0 to 1.
+        Returns:
+            The current slow gain, range from 0 to 1.
         """
         return self._current_boost_setpoints["slow"]
 
-    @slow.setter
-    def slow(self, slow_gain: float):
+    def set_slow(self, slow_gain: float):
+        """Set the "slow gain" (inverse of boost)
+
+        Args:
+            slow_gain (float): Range from 0 to 1.
+        """
         with self.thruster_lock:
             self._current_boost_setpoints["slow"] = slow_gain
             self._send_motion_input_message()
 
-    @property
-    def auto_depth_active(self) -> Optional[bool]:
-        """Enable or disable the auto depth control mode
+    slow = deprecated_property("get_slow", "set_slow")
+
+    def is_auto_depth_active(self) -> Optional[bool]:
+        """Get the state of the auto depth control mode
 
         When auto depth is active, input for the heave direction to the thruster_setpoint function
         specifies a speed set point instead of a force set point. A control loop on the drone will
         then attempt to maintain the wanted speed in the heave direction as long as auto depth is
         active.
 
-        *Arguments*:
-
-        * Enable (bool): Activate auto depth mode if true, de-activate if false
-
-        *Returns*:
-
-        * Auto depth state (bool): True if auto depth is active, false if not
+        Returns:
+            Auto depth state (bool): True if auto depth is active, false if not. None if no
+            telemetry message has been received.
         """
         control_mode_tel = self._parent_drone.telemetry.get(blueye.protocol.ControlModeTel)
         if control_mode_tel is None:
@@ -195,26 +227,32 @@ class Motion:
         else:
             return control_mode_tel.state.auto_depth
 
-    @auto_depth_active.setter
-    def auto_depth_active(self, enable: bool):
+    def enable_auto_depth(self, enable: bool):
+        """Enable or disable the auto depth control mode
+
+        When auto depth is active, input for the heave direction to the thruster_setpoint function
+        specifies a speed set point instead of a force set point. A control loop on the drone will
+        then attempt to maintain the wanted speed in the heave direction as long as auto depth is
+        active.
+
+        Args:
+            enable (bool): Activate auto depth mode if true, de-activate if false.
+        """
         self._parent_drone._ctrl_client.set_auto_depth_state(enable)
 
-    @property
-    def auto_heading_active(self) -> Optional[bool]:
-        """Enable or disable the auto heading control mode
+    auto_depth_active = deprecated_property("is_auto_depth_active", "enable_auto_depth")
+
+    def is_auto_heading_active(self) -> Optional[bool]:
+        """Get the state of the auto heading control mode
 
         When auto heading is active, input for the yaw direction to the thruster_setpoint function
         specifies a angular speed set point instead of a moment set point. A control loop on the
         drone will then attempt to maintain the wanted angular velocity in the yaw direction as
         long as auto heading is active.
 
-        *Arguments*:
-
-        * Enable (bool): Activate auto heading mode if true, de-activate if false
-
-        *Returns*:
-
-        * Auto heading state (bool): True if auto heading mode is active, false if not
+        Returns:
+            Auto heading state (bool): True if auto heading mode is active, false if not. None if no
+            telemetry message has been received.
         """
         control_mode_tel = self._parent_drone.telemetry.get(blueye.protocol.ControlModeTel)
         if control_mode_tel is None:
@@ -222,26 +260,32 @@ class Motion:
         else:
             return control_mode_tel.state.auto_heading
 
-    @auto_heading_active.setter
-    def auto_heading_active(self, enable: bool):
+    def enable_auto_heading(self, enable: bool):
+        """Enable or disable the auto heading control mode
+
+        When auto heading is active, input for the yaw direction to the thruster_setpoint function
+        specifies a angular speed set point instead of a moment set point. A control loop on the
+        drone will then attempt to maintain the wanted angular velocity in the yaw direction as
+        long as auto heading is active.
+
+        Args:
+            enable (bool): Activate auto heading mode if true, de-activate if false.
+        """
         self._parent_drone._ctrl_client.set_auto_heading_state(enable)
 
-    @property
-    def auto_altitude_active(self) -> Optional[bool]:
-        """Enable or disable the auto altitude control mode
+    auto_heading_active = deprecated_property("is_auto_heading_active", "enable_auto_heading")
+
+    def is_auto_altitude_active(self) -> Optional[bool]:
+        """Get the state of the auto altitude control mode
 
         When auto altitude is active, the drone will attempt to maintain its current altitude above
         the seabed. Input for the heave direction to the thruster_setpoint function specifies a
         speed set point instead of a force set point. A control loop on the drone will then attempt
         to maintain the wanted speed in the heave direction as long as auto altitude is active.
 
-        *Arguments*:
-        * Enable (bool): Activate auto altitude mode if true, de-activate if false. If the drone
-                         does not have a valid altitude reading this command will be ignored.
-
-        *Returns*:
-
-        * Auto altitude state (bool): True if auto altitude is active, false if not
+        Returns:
+            Auto altitude state (bool): True if auto altitude is active, false if not. None if no
+            telemetry message has been received.
         """
         control_mode_tel = self._parent_drone.telemetry.get(blueye.protocol.ControlModeTel)
         if control_mode_tel is None:
@@ -249,24 +293,31 @@ class Motion:
         else:
             return control_mode_tel.state.auto_altitude
 
-    @auto_altitude_active.setter
-    def auto_altitude_active(self, enable: bool):
+    def enable_auto_altitude(self, enable: bool):
+        """Enable or disable the auto altitude control mode
+
+        When auto altitude is active, the drone will attempt to maintain its current altitude above
+        the seabed. Input for the heave direction to the thruster_setpoint function specifies a
+        speed set point instead of a force set point. A control loop on the drone will then attempt
+        to maintain the wanted speed in the heave direction as long as auto altitude is active.
+
+        Args:
+            enable (bool): Activate auto altitude mode if true, de-activate if false. If the drone
+                           does not have a valid altitude reading this command will be ignored.
+        """
         self._parent_drone._ctrl_client.set_auto_altitude_state(enable)
 
-    @property
-    def station_keeping_active(self) -> Optional[bool]:
-        """Enable or disable the station keeping control mode
+    auto_altitude_active = deprecated_property("is_auto_altitude_active", "enable_auto_altitude")
+
+    def is_station_keeping_active(self) -> Optional[bool]:
+        """Get the state of the station keeping control mode
 
         When station keeping is active, the drone will attempt to maintain its current position
         and orientation in the water as long as the mode is active.
 
-        *Arguments*:
-
-        * Enable (bool): Activate station keeping mode if true, de-activate if false
-
-        *Returns*:
-
-        * Station keeping state (bool): True if station keeping mode is active, false if not
+        Returns:
+            Station keeping state (bool): True if station keeping mode is active, false if not. None
+            if no telemetry message has been received.
         """
         control_mode_tel = self._parent_drone.telemetry.get(blueye.protocol.ControlModeTel)
         if control_mode_tel is None:
@@ -274,25 +325,30 @@ class Motion:
         else:
             return control_mode_tel.state.station_keeping
 
-    @station_keeping_active.setter
-    def station_keeping_active(self, enable: bool):
+    def enable_station_keeping(self, enable: bool):
+        """Enable or disable the station keeping control mode
+
+        When station keeping is active, the drone will attempt to maintain its current position
+        and orientation in the water as long as the mode is active.
+
+        Args:
+            enable (bool): Activate station keeping mode if true, de-activate if false.
+        """
         self._parent_drone._ctrl_client.set_station_keeping_state(enable)
 
-    @property
-    def weather_vaning_active(self) -> Optional[bool]:
-        """Enable or disable the weather vaning control mode
+    station_keeping_active = deprecated_property(
+        "is_station_keeping_active", "enable_station_keeping"
+    )
+
+    def is_weather_vaning_active(self) -> Optional[bool]:
+        """Get the state of the weather vaning control mode
 
         When weather vaning is active, the drone will attempt to maintain its current position
         in the water and orient itself parallel to the current.
 
-        *Arguments*:
-
-        * Enable (bool): Activate weather vaning mode if true, de-activate if false. If the drone
-                         does not have a valid altitude reading this command will be ignored.
-
-        *Returns*:
-
-        * Weather vaning state (bool): True if weather vaning mode is active, false if not
+        Returns:
+            Weather vaning state (bool): True if weather vaning mode is active, false if not. None
+            if no telemetry message has been received.
         """
         control_mode_tel = self._parent_drone.telemetry.get(blueye.protocol.ControlModeTel)
         if control_mode_tel is None:
@@ -300,6 +356,16 @@ class Motion:
         else:
             return control_mode_tel.state.weather_vaning
 
-    @weather_vaning_active.setter
-    def weather_vaning_active(self, enable: bool):
+    def enable_weather_vaning(self, enable: bool):
+        """Enable or disable the weather vaning control mode
+
+        When weather vaning is active, the drone will attempt to maintain its current position
+        in the water and orient itself parallel to the current.
+
+        Args:
+            enable (bool): Activate weather vaning mode if true, de-activate if false. If the drone
+                           does not have a valid altitude reading this command will be ignored.
+        """
         self._parent_drone._ctrl_client.set_weather_vaning_state(enable)
+
+    weather_vaning_active = deprecated_property("is_weather_vaning_active", "enable_weather_vaning")

--- a/blueye/sdk/utils.py
+++ b/blueye/sdk/utils.py
@@ -26,8 +26,8 @@ class deprecated_property:
     """Property shim that warns and delegates to the new getter/setter methods.
 
     `fget`/`fset` are the *names* of the replacement methods on the owning class. This is always a
-    data descriptor (it defines `__set__`) so that a typo'd assignment to a read-only property still
-    raises an AttributeError instead of silently shadowing the descriptor with an instance attribute.
+    data descriptor (it defines `__set__`) so that assignments to read-only deprecated properties
+    raise an AttributeError instead of silently shadowing the descriptor with an instance attribute.
     """
 
     def __init__(self, fget: str, fset: Optional[str] = None, doc: Optional[str] = None):

--- a/blueye/sdk/utils.py
+++ b/blueye/sdk/utils.py
@@ -1,6 +1,7 @@
 import os
+import warnings
 import webbrowser
-from typing import Tuple
+from typing import Optional, Tuple
 
 import blueye.protocol as bp
 import google.protobuf.wrappers_pb2 as wrappers
@@ -19,6 +20,46 @@ from google.protobuf.wrappers_pb2 import (
 )
 
 import blueye.sdk
+
+
+class deprecated_property:
+    """Property shim that warns and delegates to the new getter/setter methods.
+
+    `fget`/`fset` are the *names* of the replacement methods on the owning class. This is always a
+    data descriptor (it defines `__set__`) so that a typo'd assignment to a read-only property still
+    raises an AttributeError instead of silently shadowing the descriptor with an instance attribute.
+    """
+
+    def __init__(self, fget: str, fset: Optional[str] = None, doc: Optional[str] = None):
+        self.fget = fget
+        self.fset = fset
+        self.__doc__ = doc
+
+    def __set_name__(self, owner, name):
+        self.owner = owner.__name__
+        self.name = name
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        warnings.warn(
+            f"`{self.owner}.{self.name}` is deprecated and will be removed in the next major "
+            f"version. Use `{self.owner}.{self.fget}()` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return getattr(obj, self.fget)()
+
+    def __set__(self, obj, value):
+        if self.fset is None:
+            raise AttributeError(f"can't set attribute `{self.name}`")
+        warnings.warn(
+            f"`{self.owner}.{self.name}` is deprecated and will be removed in the next major "
+            f"version. Use `{self.owner}.{self.fset}()` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        getattr(obj, self.fset)(value)
 
 
 def open_local_documentation():

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,16 +39,16 @@ from blueye.sdk import Drone, WaterDensities
 myDrone = Drone()
 
 # Salt water
-myDrone.config.water_density = WaterDensities.salty  # 1025 g/L
+myDrone.config.set_water_density(WaterDensities.salty)  # 1025 g/L
 
 # Brackish water
-myDrone.config.water_density = WaterDensities.brackish  # 1011 g/L
+myDrone.config.set_water_density(WaterDensities.brackish)  # 1011 g/L
 
 # Fresh water
-myDrone.config.water_density = WaterDensities.fresh  # 997 g/L
+myDrone.config.set_water_density(WaterDensities.fresh)  # 997 g/L
 
 # Can also be set to arbitrary values
-myDrone.config.water_density = 1234
+myDrone.config.set_water_density(1234)
 ```
 
 ### Configure camera parameters
@@ -62,7 +62,7 @@ from blueye.sdk import Drone
 
 myDrone = Drone()
 
-myDrone.camera.bitrate = 8_000_000 # 8 Mbit bitrate
+myDrone.camera.set_bitrate(8_000_000)  # 8 Mbit bitrate
 ```
 
 To change multiple parameters at once, use the `configure()` context manager. This batches all changes into a single request, avoiding multiple pipeline restarts:

--- a/docs/movement/from-the-CLI.md
+++ b/docs/movement/from-the-CLI.md
@@ -6,7 +6,7 @@ This is a super simple example showing how you make the drone move from the comm
 import time
 from blueye.sdk import Drone
 myDrone = Drone()
-myDrone.motion.surge = 0.4
+myDrone.motion.set_surge(0.4)
 time.sleep(1)
-myDrone.motion.surge = 0
+myDrone.motion.set_surge(0)
 ```

--- a/docs/peripherals.md
+++ b/docs/peripherals.md
@@ -14,10 +14,10 @@ If the drone has a camera attached, the `Drone` class will have an `external_cam
 drone.external_camera.take_picture()
 
 # Set bitrate for external camera to 2 Mbps
-drone.external_camera.bitrate = 2_000_000
+drone.external_camera.set_bitrate(2_000_000)
 
 # Start recording video from the external camera
-drone.external_camera.is_recording = True
+drone.external_camera.set_recording(True)
 ```
 
 ## External light
@@ -45,20 +45,20 @@ drone.laser.set_intensity(0.5)
 ## Gripper
 If the drone has a gripper attached, the `Drone` class will have a `gripper` attribute that is a [`Gripper`][blueye.sdk.guestport.Gripper] object. This object can be used to control the grip and rotation of the gripper.
 
-If the connected gripper does not support rotation, the `rotation_velocity` property will be ignored.
+If the connected gripper does not support rotation, the rotation velocity will be ignored.
 
 ```python
 # Open the gripper
-drone.gripper.grip_velocity = 1.0
+drone.gripper.set_grip_velocity(1.0)
 
 # Close the gripper
-drone.gripper.grip_velocity = -1.0
+drone.gripper.set_grip_velocity(-1.0)
 
 # Rotate the gripper clockwise
-drone.gripper.rotation_velocity = 1.0
+drone.gripper.set_rotation_velocity(1.0)
 
 # Rotate the gripper counterclockwise
-drone.gripper.rotation_velocity = -1.0
+drone.gripper.set_rotation_velocity(-1.0)
 ```
 
 ## Servo

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -97,8 +97,8 @@ on how to turn on the drone and surface unit, you can watch the
 [quick start video](https://support.blueye.no/hc/en-us/articles/360006901473-Quick-Start-Guide).
 
 ## Control the drone
-Most of the functionality is controlled using Python properties. We will illustrate the use of
-properties by showing how to control the lights:
+Most of the functionality is controlled using getter and setter methods. We will illustrate their
+use by showing how to control the lights:
 
 ``` python
 import time
@@ -107,32 +107,32 @@ from blueye.sdk import Drone
 # When the Drone object is instantiated, a connection to the drone is established
 myDrone = Drone()
 
-# Setting the lights property to 0.1 (10 %)
-myDrone.lights = 0.1
+# Setting the lights to 0.1 (10 %)
+myDrone.set_lights(0.1)
 
 time.sleep(2)
 
-# We can also get the current brightness of the lights through the lights property
-print(f"Current light intensity: {myDrone.lights}")
-myDrone.lights = 0
+# We can also get the current brightness of the lights with the get_lights method
+print(f"Current light intensity: {myDrone.get_lights()}")
+myDrone.set_lights(0)
 
-# Properties can also be used for reading telemetry data from the drone
-print(f"Current depth in meters: {myDrone.depth}")
+# Getter methods are also used for reading telemetry data from the drone
+print(f"Current depth in meters: {myDrone.get_depth()}")
 ```
-For an overview of the properties that are available for controlling and reading data from the drone, go to the
+For an overview of the methods that are available for controlling and reading data from the drone, go to the
 [`Reference section`](reference/blueye/sdk/drone.md) of the documentation.
-The valid input ranges and descriptions of the different properties can also be found there.
+The valid input ranges and descriptions of the different methods can also be found there.
 
 
 /// admonition | Tip
     type: tip
-You can explore the properties of the drone interactively using an interactive Python interpreter like
+You can explore the methods of the drone interactively using an interactive Python interpreter like
 [`iPython`](https://ipython.readthedocs.io/en/stable/interactive/tutorial.html), which can be installed with:
 ```shell
 uv pip install ipython
 ```
 By instantiating a Drone object and using the completion key (normally the `tab-key ↹`), you can get an interactive list of
-the available properties on the drone, making it easy to try setting and getting the different properties.
+the available methods on the drone, making it easy to try setting and getting the different values.
 ![`iPython`](https://blueyenostorage.blob.core.windows.net/sdkimages/ipython-exploration.gif)
 ///
 

--- a/examples/gamepad_controller.py
+++ b/examples/gamepad_controller.py
@@ -23,25 +23,25 @@ class JoystickHandler:
 
     def handle_x_button(self, value):
         """Starts/stops the video recording"""
-        self.drone.camera.is_recording = value
+        self.drone.camera.set_recording(value)
 
     def handle_y_button(self, value):
         """Turns lights on or off"""
         if value:
-            if self.drone.lights > 0:
-                self.drone.lights = 0
+            if self.drone.get_lights() > 0:
+                self.drone.set_lights(0)
             else:
-                self.drone.lights = 0.1
+                self.drone.set_lights(0.1)
 
     def handle_b_button(self, value):
         """Toggles autoheading"""
         if value:
-            self.drone.motion.auto_heading_active = not self.drone.motion.auto_heading_active
+            self.drone.motion.enable_auto_heading(not self.drone.motion.is_auto_heading_active())
 
     def handle_a_button(self, value):
         """Toggles autodepth"""
         if value:
-            self.drone.motion.auto_depth_active = not self.drone.motion.auto_depth_active
+            self.drone.motion.enable_auto_depth(not self.drone.motion.is_auto_depth_active())
 
     def filter_and_normalize(self, value, lower=5000, upper=32768):
         """Normalizing the joystick axis range from (default) -32768<->32678 to -1<->1
@@ -59,22 +59,22 @@ class JoystickHandler:
             return 0
 
     def handle_left_x_axis(self, value):
-        self.drone.motion.yaw = self.filter_and_normalize(value)
+        self.drone.motion.set_yaw(self.filter_and_normalize(value))
 
     def handle_left_y_axis(self, value):
-        self.drone.motion.heave = self.filter_and_normalize(value)
+        self.drone.motion.set_heave(self.filter_and_normalize(value))
 
     def handle_right_x_axis(self, value):
-        self.drone.motion.sway = self.filter_and_normalize(value)
+        self.drone.motion.set_sway(self.filter_and_normalize(value))
 
     def handle_right_y_axis(self, value):
-        self.drone.motion.surge = -self.filter_and_normalize(value)
+        self.drone.motion.set_surge(-self.filter_and_normalize(value))
 
     def handle_left_trigger(self, value):
-        self.drone.motion.slow = self.filter_and_normalize(value, lower=0, upper=255)
+        self.drone.motion.set_slow(self.filter_and_normalize(value, lower=0, upper=255))
 
     def handle_right_trigger(self, value):
-        self.drone.motion.boost = self.filter_and_normalize(value, lower=0, upper=255)
+        self.drone.motion.set_boost(self.filter_and_normalize(value, lower=0, upper=255))
 
 
 if __name__ == "__main__":

--- a/examples/print_status.py
+++ b/examples/print_status.py
@@ -10,16 +10,21 @@ from blueye.sdk import Drone
 
 def print_state(screen: ManagedScreen, drone: Drone):
     """Updates and prints some of the information from the drone"""
-    screen.print_at(f"Lights: {drone.lights * 100:5.1f} %", 2, 1)
+    screen.print_at(f"Lights: {drone.get_lights() * 100:5.1f} %", 2, 1)
 
-    screen.print_at(f"Auto-depth: {'On' if drone.motion.auto_depth_active else 'Off':>5}", 2, 3)
-    screen.print_at(f"Auto-heading: {'On' if drone.motion.auto_heading_active else 'Off':>3}", 2, 4)
+    screen.print_at(
+        f"Auto-depth: {'On' if drone.motion.is_auto_depth_active() else 'Off':>5}", 2, 3
+    )
+    screen.print_at(
+        f"Auto-heading: {'On' if drone.motion.is_auto_heading_active() else 'Off':>3}", 2, 4
+    )
 
-    screen.print_at(f"Depth: {drone.depth:3.3f} m ", 2, 6)
+    screen.print_at(f"Depth: {drone.get_depth():3.3f} m ", 2, 6)
 
-    screen.print_at(f"Roll: {drone.pose['roll']:7.2f}°", 2, 8)
-    screen.print_at(f"Pitch: {drone.pose['pitch']:6.2f}°", 2, 9)
-    screen.print_at(f"Yaw: {drone.pose['yaw']:8.2f}°", 2, 10)
+    pose = drone.get_pose()
+    screen.print_at(f"Roll: {pose['roll']:7.2f}°", 2, 8)
+    screen.print_at(f"Pitch: {pose['pitch']:6.2f}°", 2, 9)
+    screen.print_at(f"Yaw: {pose['yaw']:8.2f}°", 2, 10)
 
 
 def state_printer(drone: Drone):

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -22,7 +22,7 @@ def test_stream_resolution_getter(mocked_camera):
     mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
         mocked_camera_parameters
     )
-    assert mocked_camera.stream_resolution == bp.Resolution.RESOLUTION_FULLHD_1080P
+    assert mocked_camera.get_stream_resolution() == bp.Resolution.RESOLUTION_FULLHD_1080P
 
 
 def test_stream_resolution_setter(mocked_camera):
@@ -34,7 +34,7 @@ def test_stream_resolution_setter(mocked_camera):
     )
     mocked_camera._camera_parameters = old_camera_parameters
 
-    mocked_camera.stream_resolution = bp.Resolution.RESOLUTION_FULLHD_1080P
+    mocked_camera.set_stream_resolution(bp.Resolution.RESOLUTION_FULLHD_1080P)
     mocked_camera._parent_drone._req_rep_client.set_camera_parameters.assert_called_once_with(
         new_camera_parameters
     )
@@ -45,7 +45,7 @@ def test_stream_resolution_setter(mocked_camera):
 
 def test_stream_resolution_invalid_type(mocked_camera):
     with pytest.raises(ValueError):
-        mocked_camera.stream_resolution = "invalid_resolution"
+        mocked_camera.set_stream_resolution("invalid_resolution")
 
 
 def test_recording_resolution_getter(mocked_camera):
@@ -55,7 +55,7 @@ def test_recording_resolution_getter(mocked_camera):
     mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
         mocked_camera_parameters
     )
-    assert mocked_camera.recording_resolution == bp.Resolution.RESOLUTION_FULLHD_1080P
+    assert mocked_camera.get_recording_resolution() == bp.Resolution.RESOLUTION_FULLHD_1080P
 
 
 def test_recording_resolution_setter(mocked_camera):
@@ -69,7 +69,7 @@ def test_recording_resolution_setter(mocked_camera):
     )
     mocked_camera._camera_parameters = old_camera_parameters
 
-    mocked_camera.recording_resolution = bp.Resolution.RESOLUTION_FULLHD_1080P
+    mocked_camera.set_recording_resolution(bp.Resolution.RESOLUTION_FULLHD_1080P)
     mocked_camera._parent_drone._req_rep_client.set_camera_parameters.assert_called_once_with(
         new_camera_parameters
     )
@@ -81,7 +81,7 @@ def test_recording_resolution_setter(mocked_camera):
 
 def test_recording_resolution_invalid_type(mocked_camera):
     with pytest.raises(ValueError):
-        mocked_camera.recording_resolution = "invalid_resolution"
+        mocked_camera.set_recording_resolution("invalid_resolution")
 
 
 def test_old_drones_use_resolution_field(mocked_camera):
@@ -93,8 +93,8 @@ def test_old_drones_use_resolution_field(mocked_camera):
         mocked_camera_parameters
     )
 
-    assert mocked_camera.recording_resolution == bp.Resolution.RESOLUTION_FULLHD_1080P
-    assert mocked_camera.stream_resolution == bp.Resolution.RESOLUTION_FULLHD_1080P
+    assert mocked_camera.get_recording_resolution() == bp.Resolution.RESOLUTION_FULLHD_1080P
+    assert mocked_camera.get_stream_resolution() == bp.Resolution.RESOLUTION_FULLHD_1080P
 
 
 def test_configure_batches_changes(mocked_camera):

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,189 @@
+"""Tests for the deprecated property shims.
+
+Every property that used to expose drone state/control has been replaced by an explicit
+getter/setter method. The old property names are kept as thin shims that emit a
+``DeprecationWarning`` and delegate to the new method. This module verifies, for every shim, that:
+
+* reading it warns and delegates to the new getter,
+* writing it (when writable) warns and delegates to the new setter,
+* writing a read-only shim raises ``AttributeError`` (the original footgun this migration fixes).
+"""
+
+import blueye.protocol as bp
+import pytest
+
+from blueye.sdk.guestport import Gripper
+
+
+def _make_gripper(drone):
+    return Gripper(
+        drone,
+        bp.GuestPortNumber.GUEST_PORT_NUMBER_PORT_1,
+        bp.GuestPortDevice(),
+    )
+
+
+# Each entry: (accessor, property_name, getter_method, setter_method_or_None)
+# `accessor` takes the mocked drone and returns the object that owns the deprecated property.
+DEPRECATED_PROPERTIES = [
+    # Drone
+    (lambda d: d, "lights", "get_lights", "set_lights"),
+    (lambda d: d, "connected_clients", "get_connected_clients", None),
+    (lambda d: d, "client_in_control", "get_client_in_control", None),
+    (lambda d: d, "depth", "get_depth", None),
+    (lambda d: d, "pose", "get_pose", None),
+    (lambda d: d, "altitude", "get_altitude", None),
+    (lambda d: d, "error_flags", "get_error_flags", None),
+    (lambda d: d, "active_video_streams", "get_active_video_streams", None),
+    (lambda d: d, "water_temperature", "get_water_temperature", None),
+    (lambda d: d, "dive_time", "get_dive_time", None),
+    # Config
+    (lambda d: d.config, "water_density", "get_water_density", "set_water_density"),
+    # Battery
+    (lambda d: d.battery, "state_of_charge", "get_state_of_charge", None),
+    # Motion
+    (lambda d: d.motion, "surge", "get_surge", "set_surge"),
+    (lambda d: d.motion, "sway", "get_sway", "set_sway"),
+    (lambda d: d.motion, "heave", "get_heave", "set_heave"),
+    (lambda d: d.motion, "yaw", "get_yaw", "set_yaw"),
+    (lambda d: d.motion, "boost", "get_boost", "set_boost"),
+    (lambda d: d.motion, "slow", "get_slow", "set_slow"),
+    (
+        lambda d: d.motion,
+        "current_thruster_setpoints",
+        "get_current_thruster_setpoints",
+        None,
+    ),
+    (lambda d: d.motion, "auto_depth_active", "is_auto_depth_active", "enable_auto_depth"),
+    (lambda d: d.motion, "auto_heading_active", "is_auto_heading_active", "enable_auto_heading"),
+    (lambda d: d.motion, "auto_altitude_active", "is_auto_altitude_active", "enable_auto_altitude"),
+    (
+        lambda d: d.motion,
+        "station_keeping_active",
+        "is_station_keeping_active",
+        "enable_station_keeping",
+    ),
+    (
+        lambda d: d.motion,
+        "weather_vaning_active",
+        "is_weather_vaning_active",
+        "enable_weather_vaning",
+    ),
+    # Gripper
+    (_make_gripper, "grip_velocity", "get_grip_velocity", "set_grip_velocity"),
+    (_make_gripper, "rotation_velocity", "get_rotation_velocity", "set_rotation_velocity"),
+    # Tilt
+    (lambda d: d.camera.tilt, "angle", "get_angle", None),
+    (
+        lambda d: d.camera.tilt,
+        "stabilization_enabled",
+        "is_stabilization_enabled",
+        "enable_stabilization",
+    ),
+    # Overlay
+    (
+        lambda d: d.camera.overlay,
+        "temperature_enabled",
+        "is_temperature_enabled",
+        "enable_temperature",
+    ),
+    (lambda d: d.camera.overlay, "depth_enabled", "is_depth_enabled", "enable_depth"),
+    (lambda d: d.camera.overlay, "heading_enabled", "is_heading_enabled", "enable_heading"),
+    (lambda d: d.camera.overlay, "tilt_enabled", "is_tilt_enabled", "enable_tilt"),
+    (lambda d: d.camera.overlay, "date_enabled", "is_date_enabled", "enable_date"),
+    (lambda d: d.camera.overlay, "logo", "get_logo", "set_logo"),
+    (lambda d: d.camera.overlay, "depth_unit", "get_depth_unit", "set_depth_unit"),
+    (
+        lambda d: d.camera.overlay,
+        "temperature_unit",
+        "get_temperature_unit",
+        "set_temperature_unit",
+    ),
+    (lambda d: d.camera.overlay, "cp_probe_enabled", "is_cp_probe_enabled", "enable_cp_probe"),
+    (lambda d: d.camera.overlay, "distance_enabled", "is_distance_enabled", "enable_distance"),
+    (lambda d: d.camera.overlay, "altitude_enabled", "is_altitude_enabled", "enable_altitude"),
+    (lambda d: d.camera.overlay, "thickness_enabled", "is_thickness_enabled", "enable_thickness"),
+    (lambda d: d.camera.overlay, "thickness_unit", "get_thickness_unit", "set_thickness_unit"),
+    (
+        lambda d: d.camera.overlay,
+        "drone_location_enabled",
+        "is_drone_location_enabled",
+        "enable_drone_location",
+    ),
+    (lambda d: d.camera.overlay, "shading", "get_shading", "set_shading"),
+    (
+        lambda d: d.camera.overlay,
+        "gamma_ray_measurement_enabled",
+        "is_gamma_ray_measurement_enabled",
+        "enable_gamma_ray_measurement",
+    ),
+    (lambda d: d.camera.overlay, "timezone_offset", "get_timezone_offset", "set_timezone_offset"),
+    (lambda d: d.camera.overlay, "margin_width", "get_margin_width", "set_margin_width"),
+    (lambda d: d.camera.overlay, "margin_height", "get_margin_height", "set_margin_height"),
+    (lambda d: d.camera.overlay, "font_size", "get_font_size", "set_font_size"),
+    (lambda d: d.camera.overlay, "title", "get_title", "set_title"),
+    (lambda d: d.camera.overlay, "subtitle", "get_subtitle", "set_subtitle"),
+    (lambda d: d.camera.overlay, "date_format", "get_date_format", "set_date_format"),
+    # Camera
+    (lambda d: d.camera, "is_recording", "is_recording_active", "set_recording"),
+    (lambda d: d.camera, "record_time", "get_record_time", None),
+    (lambda d: d.camera, "bitrate", "get_bitrate", "set_bitrate"),
+    (
+        lambda d: d.camera,
+        "bitrate_still_picture",
+        "get_bitrate_still_picture",
+        "set_bitrate_still_picture",
+    ),
+    (lambda d: d.camera, "exposure", "get_exposure", "set_exposure"),
+    (lambda d: d.camera, "whitebalance", "get_whitebalance", "set_whitebalance"),
+    (lambda d: d.camera, "hue", "get_hue", "set_hue"),
+    (lambda d: d.camera, "resolution", "get_resolution", "set_resolution"),
+    (lambda d: d.camera, "stream_resolution", "get_stream_resolution", "set_stream_resolution"),
+    (
+        lambda d: d.camera,
+        "recording_resolution",
+        "get_recording_resolution",
+        "set_recording_resolution",
+    ),
+    (lambda d: d.camera, "framerate", "get_framerate", "set_framerate"),
+    (lambda d: d.camera, "recording_codec", "get_recording_codec", "set_recording_codec"),
+    (lambda d: d.camera, "recording_bitrate", "get_recording_bitrate", "set_recording_bitrate"),
+    (lambda d: d.camera, "streaming_protocol", "get_streaming_protocol", "set_streaming_protocol"),
+]
+
+_WRITABLE = [p for p in DEPRECATED_PROPERTIES if p[3] is not None]
+_READ_ONLY = [p for p in DEPRECATED_PROPERTIES if p[3] is None]
+
+
+@pytest.mark.parametrize(
+    "accessor,prop,getter,setter", DEPRECATED_PROPERTIES, ids=[p[1] for p in DEPRECATED_PROPERTIES]
+)
+def test_getter_warns_and_delegates(mocked_drone, mocker, accessor, prop, getter, setter):
+    obj = accessor(mocked_drone)
+    mock = mocker.patch.object(obj, getter, return_value=mocker.sentinel.value)
+    with pytest.warns(DeprecationWarning, match=getter):
+        result = getattr(obj, prop)
+    assert result is mocker.sentinel.value
+    mock.assert_called_once_with()
+
+
+@pytest.mark.parametrize("accessor,prop,getter,setter", _WRITABLE, ids=[p[1] for p in _WRITABLE])
+def test_setter_warns_and_delegates(mocked_drone, mocker, accessor, prop, getter, setter):
+    obj = accessor(mocked_drone)
+    mock = mocker.patch.object(obj, setter)
+    with pytest.warns(DeprecationWarning, match=setter):
+        setattr(obj, prop, True)
+    mock.assert_called_once_with(True)
+
+
+@pytest.mark.parametrize("accessor,prop,getter,setter", _READ_ONLY, ids=[p[1] for p in _READ_ONLY])
+def test_readonly_assignment_raises(mocked_drone, accessor, prop, getter, setter):
+    obj = accessor(mocked_drone)
+    with pytest.raises(AttributeError):
+        setattr(obj, prop, True)
+
+
+def test_setpoints_setter_keeps_helpful_error_message(mocked_drone):
+    """The current_thruster_setpoints shim keeps its dedicated, helpful error message."""
+    with pytest.raises(AttributeError, match="Do not set the setpoints directly"):
+        mocked_drone.motion.current_thruster_setpoints = {}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,28 +3,27 @@ from time import time
 import pytest
 
 
-def polling_assert_with_timeout(cls, property_name, value_to_wait_for, timeout):
-    """Waits for a property to change on the given class"""
+def polling_assert_with_timeout(getter, value_to_wait_for, timeout):
+    """Waits for a getter to return the value we are waiting for"""
     start_time = time()
-    property_getter = type(cls).__dict__[property_name].__get__
-    value = property_getter(cls)
+    value = getter()
     while value != value_to_wait_for:
         if time() - start_time > timeout:
             assert value == value_to_wait_for
-        value = property_getter(cls)
+        value = getter()
 
 
 @pytest.mark.connected_to_drone
 class TestFunctionsWhenConnectedToDrone:
     @pytest.mark.parametrize("new_state", [True, False])
     def test_auto_heading(self, real_drone, new_state):
-        real_drone.motion.auto_heading_active = new_state
-        polling_assert_with_timeout(real_drone.motion, "auto_heading_active", new_state, 3)
+        real_drone.motion.enable_auto_heading(new_state)
+        polling_assert_with_timeout(real_drone.motion.is_auto_heading_active, new_state, 3)
 
     @pytest.mark.parametrize("new_state", [True, False])
     def test_auto_depth(self, real_drone, new_state):
-        real_drone.motion.auto_depth_active = new_state
-        polling_assert_with_timeout(real_drone.motion, "auto_depth_active", new_state, 3)
+        real_drone.motion.enable_auto_depth(new_state)
+        polling_assert_with_timeout(real_drone.motion.is_auto_depth_active, new_state, 3)
 
     def test_run_ping(self, real_drone):
         real_drone.ping()
@@ -33,58 +32,58 @@ class TestFunctionsWhenConnectedToDrone:
         reason="a camera stream must have been run before camera recording is possible"
     )
     def test_camera_recording(self, real_drone):
-        _ = real_drone.camera.is_recording
-        real_drone.camera.is_recording = True
-        polling_assert_with_timeout(real_drone.camera, "is_recording", True, 1)
-        real_drone.camera.is_recording = False
-        polling_assert_with_timeout(real_drone.camera, "is_recording", False, 1)
+        _ = real_drone.camera.is_recording_active()
+        real_drone.camera.set_recording(True)
+        polling_assert_with_timeout(real_drone.camera.is_recording_active, True, 1)
+        real_drone.camera.set_recording(False)
+        polling_assert_with_timeout(real_drone.camera.is_recording_active, False, 1)
 
     @pytest.mark.skip(
         reason="a camera stream must have been run before camera recording is possible"
     )
     def test_camera_record_time(self, real_drone):
-        _ = real_drone.camera.record_time
-        real_drone.camera.is_recording = True
-        polling_assert_with_timeout(real_drone.camera, "record_time", 1, 3)
+        _ = real_drone.camera.get_record_time()
+        real_drone.camera.set_recording(True)
+        polling_assert_with_timeout(real_drone.camera.get_record_time, 1, 3)
 
     def test_camera_bitrate(self, real_drone):
-        _ = real_drone.camera.bitrate
-        real_drone.camera.bitrate = 2000000
-        polling_assert_with_timeout(real_drone.camera, "bitrate", 2000000, 1)
-        real_drone.camera.bitrate = 3000000
-        polling_assert_with_timeout(real_drone.camera, "bitrate", 3000000, 1)
+        _ = real_drone.camera.get_bitrate()
+        real_drone.camera.set_bitrate(2000000)
+        polling_assert_with_timeout(real_drone.camera.get_bitrate, 2000000, 1)
+        real_drone.camera.set_bitrate(3000000)
+        polling_assert_with_timeout(real_drone.camera.get_bitrate, 3000000, 1)
 
     def test_camera_exposure(self, real_drone):
-        _ = real_drone.camera.exposure
-        real_drone.camera.exposure = 1200
-        polling_assert_with_timeout(real_drone.camera, "exposure", 1200, 1)
-        real_drone.camera.exposure = 1400
-        polling_assert_with_timeout(real_drone.camera, "exposure", 1400, 1)
+        _ = real_drone.camera.get_exposure()
+        real_drone.camera.set_exposure(1200)
+        polling_assert_with_timeout(real_drone.camera.get_exposure, 1200, 1)
+        real_drone.camera.set_exposure(1400)
+        polling_assert_with_timeout(real_drone.camera.get_exposure, 1400, 1)
 
     def test_camera_whitebalance(self, real_drone):
-        _ = real_drone.camera.whitebalance
-        real_drone.camera.whitebalance = 3200
-        polling_assert_with_timeout(real_drone.camera, "whitebalance", 3200, 1)
-        real_drone.camera.whitebalance = 3400
-        polling_assert_with_timeout(real_drone.camera, "whitebalance", 3400, 1)
+        _ = real_drone.camera.get_whitebalance()
+        real_drone.camera.set_whitebalance(3200)
+        polling_assert_with_timeout(real_drone.camera.get_whitebalance, 3200, 1)
+        real_drone.camera.set_whitebalance(3400)
+        polling_assert_with_timeout(real_drone.camera.get_whitebalance, 3400, 1)
 
     def test_camera_hue(self, real_drone):
-        _ = real_drone.camera.hue
-        real_drone.camera.hue = 20
-        polling_assert_with_timeout(real_drone.camera, "hue", 20, 1)
-        real_drone.camera.hue = 30
-        polling_assert_with_timeout(real_drone.camera, "hue", 30, 1)
+        _ = real_drone.camera.get_hue()
+        real_drone.camera.set_hue(20)
+        polling_assert_with_timeout(real_drone.camera.get_hue, 20, 1)
+        real_drone.camera.set_hue(30)
+        polling_assert_with_timeout(real_drone.camera.get_hue, 30, 1)
 
     def test_camera_resolution(self, real_drone):
-        _ = real_drone.camera.resolution
-        real_drone.camera.resolution = 720
-        polling_assert_with_timeout(real_drone.camera, "resolution", 720, 1)
-        real_drone.camera.resolution = 1080
-        polling_assert_with_timeout(real_drone.camera, "resolution", 1080, 1)
+        _ = real_drone.camera.get_resolution()
+        real_drone.camera.set_resolution(720)
+        polling_assert_with_timeout(real_drone.camera.get_resolution, 720, 1)
+        real_drone.camera.set_resolution(1080)
+        polling_assert_with_timeout(real_drone.camera.get_resolution, 1080, 1)
 
     def test_camera_framerate(self, real_drone):
-        _ = real_drone.camera.framerate
-        real_drone.camera.framerate = 25
-        polling_assert_with_timeout(real_drone.camera, "framerate", 25, 1)
-        real_drone.camera.framerate = 30
-        polling_assert_with_timeout(real_drone.camera, "framerate", 30, 1)
+        _ = real_drone.camera.get_framerate()
+        real_drone.camera.set_framerate(25)
+        polling_assert_with_timeout(real_drone.camera.get_framerate, 25, 1)
+        real_drone.camera.set_framerate(30)
+        polling_assert_with_timeout(real_drone.camera.get_framerate, 30, 1)

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -3,23 +3,23 @@ import blueye.protocol as bp
 
 def test_boost_getter_returns_expected_value(mocked_drone):
     mocked_drone.motion._current_boost_setpoints["boost"] = 1
-    assert mocked_drone.motion.boost == 1
+    assert mocked_drone.motion.get_boost() == 1
 
 
 def test_boost_setter_produces_correct_motion_input_arguments(mocked_drone):
     boost_gain = 0.5
-    mocked_drone.motion.boost = boost_gain
+    mocked_drone.motion.set_boost(boost_gain)
     mocked_drone._ctrl_client.set_motion_input.assert_called_with(0, 0, 0, 0, 0, boost_gain)
 
 
 def test_slow_getter_returns_expected_value(mocked_drone):
     mocked_drone.motion._current_boost_setpoints["slow"] = 1
-    assert mocked_drone.motion.slow == 1
+    assert mocked_drone.motion.get_slow() == 1
 
 
 def test_slow_setter_produces_correct_motion_input_arguments(mocked_drone):
     slow_gain = 0.3
-    mocked_drone.motion.slow = slow_gain
+    mocked_drone.motion.set_slow(slow_gain)
     mocked_drone._ctrl_client.set_motion_input.assert_called_with(0, 0, 0, 0, slow_gain, 0)
 
 
@@ -27,15 +27,15 @@ def test_auto_heading_returns_expected_value(mocked_drone):
     mocked_drone._telemetry_watcher._state[bp.ControlModeTel] = bp.ControlModeTel.serialize(
         bp.ControlModeTel(state=bp.ControlMode(auto_heading=True))
     )
-    assert mocked_drone.motion.auto_heading_active is True
+    assert mocked_drone.motion.is_auto_heading_active() is True
 
 
 def test_auto_heading_returns_none_on_missing_telemetry(mocked_drone):
-    assert mocked_drone.motion.auto_heading_active is None
+    assert mocked_drone.motion.is_auto_heading_active() is None
 
 
 def test_auto_heading_produces_correct_control_message(mocked_drone):
-    mocked_drone.motion.auto_heading_active = True
+    mocked_drone.motion.enable_auto_heading(True)
     mocked_drone._ctrl_client.set_auto_heading_state.assert_called_with(True)
 
 
@@ -43,15 +43,15 @@ def test_auto_depth_returns_expected_value(mocked_drone):
     mocked_drone._telemetry_watcher._state[bp.ControlModeTel] = bp.ControlModeTel.serialize(
         bp.ControlModeTel(state=bp.ControlMode(auto_depth=True))
     )
-    assert mocked_drone.motion.auto_depth_active is True
+    assert mocked_drone.motion.is_auto_depth_active() is True
 
 
 def test_auto_depth_returns_none_on_missing_telemetry(mocked_drone):
-    assert mocked_drone.motion.auto_depth_active is None
+    assert mocked_drone.motion.is_auto_depth_active() is None
 
 
 def test_auto_depth_production_correct_control_message(mocked_drone):
-    mocked_drone.motion.auto_depth_active = True
+    mocked_drone.motion.enable_auto_depth(True)
     mocked_drone._ctrl_client.set_auto_depth_state.assert_called_with(True)
 
 
@@ -59,15 +59,15 @@ def test_auto_altitude_returns_expected_value(mocked_drone):
     mocked_drone._telemetry_watcher._state[bp.ControlModeTel] = bp.ControlModeTel.serialize(
         bp.ControlModeTel(state=bp.ControlMode(auto_altitude=True))
     )
-    assert mocked_drone.motion.auto_altitude_active is True
+    assert mocked_drone.motion.is_auto_altitude_active() is True
 
 
 def test_auto_altitude_returns_none_on_missing_telemetry(mocked_drone):
-    assert mocked_drone.motion.auto_altitude_active is None
+    assert mocked_drone.motion.is_auto_altitude_active() is None
 
 
 def test_auto_altitude_produces_correct_control_message(mocked_drone):
-    mocked_drone.motion.auto_altitude_active = True
+    mocked_drone.motion.enable_auto_altitude(True)
     mocked_drone._ctrl_client.set_auto_altitude_state.assert_called_with(True)
 
 
@@ -75,15 +75,15 @@ def test_station_keeping_returns_expected_value(mocked_drone):
     mocked_drone._telemetry_watcher._state[bp.ControlModeTel] = bp.ControlModeTel.serialize(
         bp.ControlModeTel(state=bp.ControlMode(station_keeping=True))
     )
-    assert mocked_drone.motion.station_keeping_active is True
+    assert mocked_drone.motion.is_station_keeping_active() is True
 
 
 def test_station_keeping_returns_none_on_missing_telemetry(mocked_drone):
-    assert mocked_drone.motion.station_keeping_active is None
+    assert mocked_drone.motion.is_station_keeping_active() is None
 
 
 def test_station_keeping_produces_correct_control_message(mocked_drone):
-    mocked_drone.motion.station_keeping_active = True
+    mocked_drone.motion.enable_station_keeping(True)
     mocked_drone._ctrl_client.set_station_keeping_state.assert_called_with(True)
 
 
@@ -91,13 +91,13 @@ def test_weather_vaning_returns_expected_value(mocked_drone):
     mocked_drone._telemetry_watcher._state[bp.ControlModeTel] = bp.ControlModeTel.serialize(
         bp.ControlModeTel(state=bp.ControlMode(weather_vaning=True))
     )
-    assert mocked_drone.motion.weather_vaning_active is True
+    assert mocked_drone.motion.is_weather_vaning_active() is True
 
 
 def test_weather_vaning_returns_none_on_missing_telemetry(mocked_drone):
-    assert mocked_drone.motion.weather_vaning_active is None
+    assert mocked_drone.motion.is_weather_vaning_active() is None
 
 
 def test_weather_vaning_produces_correct_control_message(mocked_drone):
-    mocked_drone.motion.weather_vaning_active = True
+    mocked_drone.motion.enable_weather_vaning(True)
     mocked_drone._ctrl_client.set_weather_vaning_state.assert_called_with(True)

--- a/tests/test_overlay_control.py
+++ b/tests/test_overlay_control.py
@@ -6,256 +6,258 @@ from blueye.sdk import Drone
 
 class TestOverlay:
     def test_enable_temperature(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.temperature_enabled = True
+        mocked_drone.camera.overlay.enable_temperature(True)
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_get_temperature_state(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.temperature_enabled is False
+        assert mocked_drone.camera.overlay.is_temperature_enabled() is False
 
     def test_enable_depth(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.depth_enabled = True
+        mocked_drone.camera.overlay.enable_depth(True)
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_get_depth_state(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.depth_enabled is False
+        assert mocked_drone.camera.overlay.is_depth_enabled() is False
 
     def test_enable_heading(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.heading_enabled = True
+        mocked_drone.camera.overlay.enable_heading(True)
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_get_heading_state(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.heading_enabled is False
+        assert mocked_drone.camera.overlay.is_heading_enabled() is False
 
     def test_enable_tilt(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.tilt_enabled = True
+        mocked_drone.camera.overlay.enable_tilt(True)
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_get_tilt_state(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.tilt_enabled is False
+        assert mocked_drone.camera.overlay.is_tilt_enabled() is False
 
     def test_enable_date(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.date_enabled = True
+        mocked_drone.camera.overlay.enable_date(True)
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_get_date_state(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.date_enabled is False
+        assert mocked_drone.camera.overlay.is_date_enabled() is False
 
     def test_select_depth_unit(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.depth_unit = bp.DepthUnit.DEPTH_UNIT_METERS
+        mocked_drone.camera.overlay.set_depth_unit(bp.DepthUnit.DEPTH_UNIT_METERS)
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_select_depth_unit_warns_and_ignores_for_wrong_type(self, mocked_drone: Drone):
         with pytest.warns(RuntimeWarning):
-            mocked_drone.camera.overlay.depth_unit = "wrong type"
+            mocked_drone.camera.overlay.set_depth_unit("wrong type")
         assert mocked_drone._req_rep_client.set_overlay_parameters.called is False
 
     def test_get_depth_unit(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.depth_unit == bp.DepthUnit.DEPTH_UNIT_METERS
+        assert mocked_drone.camera.overlay.get_depth_unit() == bp.DepthUnit.DEPTH_UNIT_METERS
 
     def test_select_temp_unit(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.temperature_unit = bp.TemperatureUnit.TEMPERATURE_UNIT_CELSIUS
+        mocked_drone.camera.overlay.set_temperature_unit(
+            bp.TemperatureUnit.TEMPERATURE_UNIT_CELSIUS
+        )
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_select_temp_unit_warns_and_ignores_for_wrong_type(self, mocked_drone: Drone):
         with pytest.warns(RuntimeWarning):
-            mocked_drone.camera.overlay.temperature_unit = "wrong type"
+            mocked_drone.camera.overlay.set_temperature_unit("wrong type")
         assert mocked_drone._req_rep_client.set_overlay_parameters.called is False
 
     def test_get_temp_unit(self, mocked_drone: Drone):
         assert (
-            mocked_drone.camera.overlay.temperature_unit
+            mocked_drone.camera.overlay.get_temperature_unit()
             == bp.TemperatureUnit.TEMPERATURE_UNIT_CELSIUS
         )
 
     def test_enable_cp_probe(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.cp_probe_enabled = True
+        mocked_drone.camera.overlay.enable_cp_probe(True)
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_get_cp_probe_state(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.cp_probe_enabled is False
+        assert mocked_drone.camera.overlay.is_cp_probe_enabled() is False
 
     def test_distance_enabled(self, mocked_drone):
-        mocked_drone.camera.overlay.distance_enabled = True
-        assert mocked_drone.camera.overlay.distance_enabled
+        mocked_drone.camera.overlay.enable_distance(True)
+        assert mocked_drone.camera.overlay.is_distance_enabled()
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_get_distance_enabled(self, mocked_drone):
-        assert mocked_drone.camera.overlay.distance_enabled is False
+        assert mocked_drone.camera.overlay.is_distance_enabled() is False
 
     def test_get_altitude_state(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.altitude_enabled is False
+        assert mocked_drone.camera.overlay.is_altitude_enabled() is False
 
     def test_enable_altitude(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.altitude_enabled = True
-        assert mocked_drone.camera.overlay.altitude_enabled
+        mocked_drone.camera.overlay.enable_altitude(True)
+        assert mocked_drone.camera.overlay.is_altitude_enabled()
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_enable_thickness(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.thickness_enabled = True
-        assert mocked_drone.camera.overlay.thickness_enabled
+        mocked_drone.camera.overlay.enable_thickness(True)
+        assert mocked_drone.camera.overlay.is_thickness_enabled()
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_get_thickness_state(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.thickness_enabled is False
+        assert mocked_drone.camera.overlay.is_thickness_enabled() is False
 
     def test_select_thickness_unit(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.thickness_unit = bp.ThicknessUnit.THICKNESS_UNIT_MILLIMETERS
+        mocked_drone.camera.overlay.set_thickness_unit(bp.ThicknessUnit.THICKNESS_UNIT_MILLIMETERS)
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_select_thickness_unit_warns_and_ignores_for_wrong_type(self, mocked_drone: Drone):
         with pytest.warns(RuntimeWarning):
-            mocked_drone.camera.overlay.thickness_unit = "wrong type"
+            mocked_drone.camera.overlay.set_thickness_unit("wrong type")
         assert mocked_drone._req_rep_client.set_overlay_parameters.called is False
 
     def test_get_thickness_unit(self, mocked_drone: Drone):
         assert (
-            mocked_drone.camera.overlay.thickness_unit
+            mocked_drone.camera.overlay.get_thickness_unit()
             == bp.ThicknessUnit.THICKNESS_UNIT_MILLIMETERS
         )
 
     def test_get_drone_location_state(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.drone_location_enabled is False
+        assert mocked_drone.camera.overlay.is_drone_location_enabled() is False
 
     def test_enable_drone_location(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.drone_location_enabled = True
-        assert mocked_drone.camera.overlay.drone_location_enabled is True
+        mocked_drone.camera.overlay.enable_drone_location(True)
+        assert mocked_drone.camera.overlay.is_drone_location_enabled() is True
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_get_shading(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.shading == 0
+        assert mocked_drone.camera.overlay.get_shading() == 0
 
     def test_set_valid_shading(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.shading = 0
-        assert mocked_drone.camera.overlay.shading == 0
+        mocked_drone.camera.overlay.set_shading(0)
+        assert mocked_drone.camera.overlay.get_shading() == 0
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_set_invalid_shading_warns_and_ignores(self, mocked_drone: Drone):
         with pytest.warns(RuntimeWarning):
-            mocked_drone.camera.overlay.shading = 1.5
-            mocked_drone.camera.overlay.shading = -0.5
+            mocked_drone.camera.overlay.set_shading(1.5)
+            mocked_drone.camera.overlay.set_shading(-0.5)
         assert mocked_drone._req_rep_client.set_overlay_parameters.called is False
 
     def test_get_gamma_ray_measurement_state(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.gamma_ray_measurement_enabled is False
+        assert mocked_drone.camera.overlay.is_gamma_ray_measurement_enabled() is False
 
     def test_enable_gamma_ray_measurement(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.gamma_ray_measurement_enabled = True
-        assert mocked_drone.camera.overlay.gamma_ray_measurement_enabled
+        mocked_drone.camera.overlay.enable_gamma_ray_measurement(True)
+        assert mocked_drone.camera.overlay.is_gamma_ray_measurement_enabled()
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_set_timezone_offset(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.timezone_offset = 120
+        mocked_drone.camera.overlay.set_timezone_offset(120)
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_get_timezone_offset(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.timezone_offset == 60
+        assert mocked_drone.camera.overlay.get_timezone_offset() == 60
 
     def test_set_margin_width(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.margin_width = 10
+        mocked_drone.camera.overlay.set_margin_width(10)
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_get_margin_width(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.margin_width == 30
+        assert mocked_drone.camera.overlay.get_margin_width() == 30
 
     def test_sub_zero_margin_width_is_warned_and_ignored(self, mocked_drone: Drone):
         with pytest.warns(RuntimeWarning):
-            mocked_drone.camera.overlay.margin_width = -10
+            mocked_drone.camera.overlay.set_margin_width(-10)
         mocked_drone._req_rep_client.set_overlay_parameters.called is False
 
     def test_set_margin_height(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.margin_height = 10
+        mocked_drone.camera.overlay.set_margin_height(10)
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_get_margin_height(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.margin_height == 15
+        assert mocked_drone.camera.overlay.get_margin_height() == 15
 
     def test_sub_zero_margin_height_is_warned_and_ignored(self, mocked_drone: Drone):
         with pytest.warns(RuntimeWarning):
-            mocked_drone.camera.overlay.margin_height = -10
+            mocked_drone.camera.overlay.set_margin_height(-10)
         mocked_drone._req_rep_client.set_overlay_parameters.called is False
 
     def test_select_font_size(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.font_size = bp.FontSize.FONT_SIZE_PX15
+        mocked_drone.camera.overlay.set_font_size(bp.FontSize.FONT_SIZE_PX15)
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_select_font_size_warns_and_ignores_for_wrong_type(self, mocked_drone: Drone):
         with pytest.warns(RuntimeWarning):
-            mocked_drone.camera.overlay.font_size = "wrong type"
+            mocked_drone.camera.overlay.set_font_size("wrong type")
         assert mocked_drone._req_rep_client.set_overlay_parameters.called is False
 
     def test_get_font_size(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.font_size == bp.FontSize.FONT_SIZE_PX25
+        assert mocked_drone.camera.overlay.get_font_size() == bp.FontSize.FONT_SIZE_PX25
 
     def test_set_title(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.title = "a" * 63
+        mocked_drone.camera.overlay.set_title("a" * 63)
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_set_title_warns_and_ignores_non_ascii(self, mocked_drone: Drone):
         with pytest.warns(RuntimeWarning):
-            mocked_drone.camera.overlay.title = "æøå"
+            mocked_drone.camera.overlay.set_title("æøå")
         assert mocked_drone._req_rep_client.set_overlay_parameters.called is False
 
     def test_set_title_warns_and_truncates_too_long_title(self, mocked_drone: Drone):
         with pytest.warns(RuntimeWarning):
-            mocked_drone.camera.overlay.title = "a" * 64
+            mocked_drone.camera.overlay.set_title("a" * 64)
         expected_params = mocked_drone._req_rep_client.get_overlay_parameters.return_value
         expected_params.title = "a" * 63
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_with(expected_params)
 
     def test_get_title(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.title == ""
+        assert mocked_drone.camera.overlay.get_title() == ""
 
     def test_set_subtitle(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.subtitle = "a" * 63
+        mocked_drone.camera.overlay.set_subtitle("a" * 63)
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_set_subtitle_warns_and_ignores_non_ascii(self, mocked_drone: Drone):
         with pytest.warns(RuntimeWarning):
-            mocked_drone.camera.overlay.subtitle = "æøå"
+            mocked_drone.camera.overlay.set_subtitle("æøå")
         assert mocked_drone._req_rep_client.set_overlay_parameters.called is False
 
     def test_set_subtitle_warns_and_truncates_too_long_subtitle(self, mocked_drone: Drone):
         with pytest.warns(RuntimeWarning):
-            mocked_drone.camera.overlay.subtitle = "a" * 64
+            mocked_drone.camera.overlay.set_subtitle("a" * 64)
         expected_params = mocked_drone._req_rep_client.get_overlay_parameters.return_value
         expected_params.subtitle = "a" * 63
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_with(expected_params)
 
     def test_get_subtitle(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.subtitle == ""
+        assert mocked_drone.camera.overlay.get_subtitle() == ""
 
     def test_set_date_format(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.date_format = "a" * 63
+        mocked_drone.camera.overlay.set_date_format("a" * 63)
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_set_date_format_warns_and_ignores_non_ascii(self, mocked_drone: Drone):
         with pytest.warns(RuntimeWarning):
-            mocked_drone.camera.overlay.date_format = "æøå"
+            mocked_drone.camera.overlay.set_date_format("æøå")
         assert mocked_drone._req_rep_client.set_overlay_parameters.called is False
 
     def test_set_date_format_warns_and_truncates_too_long_date_format(self, mocked_drone: Drone):
         with pytest.warns(RuntimeWarning):
-            mocked_drone.camera.overlay.date_format = "a" * 64
+            mocked_drone.camera.overlay.set_date_format("a" * 64)
         expected_params = mocked_drone._req_rep_client.get_overlay_parameters.return_value
         expected_params.date_format = "a" * 63
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_with(expected_params)
 
     def test_get_date_format(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.date_format == "%m/%d/%Y %I:%M:%S %p"
+        assert mocked_drone.camera.overlay.get_date_format() == "%m/%d/%Y %I:%M:%S %p"
 
 
 class TestOverlayLogoControl:
     def test_select_logo(self, mocked_drone: Drone):
-        mocked_drone.camera.overlay.logo = bp.LogoType.LOGO_TYPE_NONE
+        mocked_drone.camera.overlay.set_logo(bp.LogoType.LOGO_TYPE_NONE)
         mocked_drone._req_rep_client.set_overlay_parameters.assert_called_once()
 
     def test_select_logo_warns_and_ignores_on_invalid_type(self, mocked_drone: Drone):
         with pytest.warns(RuntimeWarning):
-            mocked_drone.camera.overlay.logo = "wrong type"
+            mocked_drone.camera.overlay.set_logo("wrong type")
         assert mocked_drone._req_rep_client.set_overlay_parameters.called is False
 
     def test_get_logo_state(self, mocked_drone: Drone):
-        assert mocked_drone.camera.overlay.logo == bp.LogoType.LOGO_TYPE_NONE
+        assert mocked_drone.camera.overlay.get_logo() == bp.LogoType.LOGO_TYPE_NONE
 
     def test_upload_logo(self, mocked_drone: Drone, requests_mock, mocker):
         mocked_drone.software_version_short = "1.8.72"

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -16,7 +16,7 @@ class TestLights:
         lights_tel = bp.LightsTel(lights={"value": 0})
         lights_tel_serialized = lights_tel.__class__.serialize(lights_tel)
         mocked_drone._telemetry_watcher._state[bp.LightsTel] = lights_tel_serialized
-        assert mocked_drone.lights == 0
+        assert mocked_drone.get_lights() == 0
 
 
 class TestPose:
@@ -27,7 +27,7 @@ class TestPose:
         )
         attitude_tel_serialized = attitude_tel.__class__.serialize(attitude_tel)
         mocked_drone._telemetry_watcher._state[bp.AttitudeTel] = attitude_tel_serialized
-        pose = mocked_drone.pose
+        pose = mocked_drone.get_pose()
         assert pose["roll"] == new_angle
         assert pose["pitch"] == new_angle
         assert pose["yaw"] == new_angle
@@ -96,14 +96,14 @@ def test_depth_reading(mocked_drone):
     depthTel = bp.DepthTel(depth={"value": depth})
     depthTel_serialized = depthTel.__class__.serialize(depthTel)
     mocked_drone._telemetry_watcher._state[bp.DepthTel] = depthTel_serialized
-    assert mocked_drone.depth == depth
+    assert mocked_drone.get_depth() == depth
 
 
 def test_error_flags(mocked_drone):
     error_flags_tel = bp.ErrorFlagsTel(error_flags={"depth_read": True})
     error_flags_serialized = error_flags_tel.__class__.serialize(error_flags_tel)
     mocked_drone._telemetry_watcher._state[bp.ErrorFlagsTel] = error_flags_serialized
-    assert mocked_drone.error_flags["depth_read"] == True
+    assert mocked_drone.get_error_flags()["depth_read"] == True
 
 
 def test_battery_state_of_charge_reading(mocked_drone):
@@ -111,7 +111,7 @@ def test_battery_state_of_charge_reading(mocked_drone):
     batteryTel = bp.BatteryTel(battery={"level": SoC})
     batteryTel_msg = batteryTel.__class__.serialize(batteryTel)
     mocked_drone._telemetry_watcher._state[bp.BatteryTel] = batteryTel_msg
-    assert mocked_drone.battery.state_of_charge == pytest.approx(SoC)
+    assert mocked_drone.battery.get_state_of_charge() == pytest.approx(SoC)
 
 
 def test_still_picture_works(mocked_drone):
@@ -140,8 +140,8 @@ def test_active_video_streams_return_correct_number(mocked_drone: Drone):
     NStreamersTel_serialized = NStreamersTel.__class__.serialize(NStreamersTel)
     mocked_drone._telemetry_watcher._state[bp.NStreamersTel] = NStreamersTel_serialized
 
-    assert mocked_drone.active_video_streams["main"] == 1
-    assert mocked_drone.active_video_streams["guestport"] == 2
+    assert mocked_drone.get_active_video_streams()["main"] == 1
+    assert mocked_drone.get_active_video_streams()["guestport"] == 2
 
 
 class TestTilt:
@@ -150,11 +150,11 @@ class TestTilt:
         with pytest.raises(RuntimeError):
             mocked_drone.camera.tilt.set_velocity(0)
         with pytest.raises(RuntimeError):
-            _ = mocked_drone.camera.tilt.angle
+            _ = mocked_drone.camera.tilt.get_angle()
         with pytest.raises(RuntimeError):
-            _ = mocked_drone.camera.tilt.stabilization_enabled
+            _ = mocked_drone.camera.tilt.is_stabilization_enabled()
         with pytest.raises(RuntimeError):
-            mocked_drone.camera.tilt.stabilization_enabled = True
+            mocked_drone.camera.tilt.enable_stabilization(True)
 
     @pytest.mark.parametrize(
         "tilt_velocity",
@@ -183,7 +183,7 @@ class TestTilt:
         TiltAngleTel = bp.TiltAngleTel(angle={"value": expected_angle})
         TiltAngleTel_serialized = bp.TiltAngleTel.serialize(TiltAngleTel)
         mocked_drone._telemetry_watcher._state[bp.TiltAngleTel] = TiltAngleTel_serialized
-        assert mocked_drone.camera.tilt.angle == expected_angle
+        assert mocked_drone.camera.tilt.get_angle() == expected_angle
 
     @pytest.mark.parametrize(
         "expected_state",
@@ -199,24 +199,24 @@ class TestTilt:
         mocked_drone._telemetry_watcher._state[bp.TiltStabilizationTel] = (
             TiltStabilizationTel_serialized
         )
-        assert mocked_drone.camera.tilt.stabilization_enabled == expected_state
+        assert mocked_drone.camera.tilt.is_stabilization_enabled() == expected_state
 
     def test_set_tilt_stabilization(self, mocked_drone: Drone):
         mocked_drone.features = ["tilt"]
-        mocked_drone.camera.tilt.stabilization_enabled = True
+        mocked_drone.camera.tilt.enable_stabilization(True)
         assert mocked_drone._ctrl_client.set_tilt_stabilization.call_count == 1
 
 
 class TestConfig:
-    def test_water_density_property_returns_correct_value(self, mocked_drone: Drone):
+    def test_water_density_returns_correct_value(self, mocked_drone: Drone):
         mocked_drone.config._water_density = 1000.0
-        assert mocked_drone.config.water_density == 1000.0
+        assert mocked_drone.config.get_water_density() == 1000.0
 
     def test_setting_density(self, mocked_drone: Drone):
-        old_value = mocked_drone.config.water_density
+        old_value = mocked_drone.config.get_water_density()
         new_value = old_value + 10
-        mocked_drone.config.water_density = new_value
-        assert mocked_drone.config.water_density == new_value
+        mocked_drone.config.set_water_density(new_value)
+        assert mocked_drone.config.get_water_density() == new_value
         mocked_drone._ctrl_client.set_water_density.assert_called_once()
 
     def test_set_drone_time_is_called_on_connection(self, mocked_drone: Drone):
@@ -230,18 +230,18 @@ def test_altitude_is_none_on_invalid_readings(mocked_drone):
     mocked_drone._telemetry_watcher._state[bp.AltitudeTel] = bp.AltitudeTel.serialize(
         bp.AltitudeTel(altitude={"value": 10, "is_valid": False})
     )
-    assert mocked_drone.altitude is None
+    assert mocked_drone.get_altitude() is None
 
 
 def test_altitude_is_none_on_missing_readings(mocked_drone):
-    assert mocked_drone.altitude is None
+    assert mocked_drone.get_altitude() is None
 
 
 def test_altitude_is_correct_on_valid_readings(mocked_drone):
     mocked_drone._telemetry_watcher._state[bp.AltitudeTel] = bp.AltitudeTel.serialize(
         bp.AltitudeTel(altitude={"value": 10.5, "is_valid": True})
     )
-    assert mocked_drone.altitude == 10.5
+    assert mocked_drone.get_altitude() == 10.5
 
 
 def test_gp_cam_recording(mocked_drone):
@@ -252,7 +252,7 @@ def test_gp_cam_recording(mocked_drone):
     mocked_drone._telemetry_watcher._state[bp.RecordStateTel] = bp.RecordStateTel.serialize(
         record_state_tel
     )
-    mocked_drone.gp_cam.is_recording = True
+    mocked_drone.gp_cam.set_recording(True)
     mocked_drone._ctrl_client.set_recording_state.assert_called_with(False, True)
 
 
@@ -295,22 +295,22 @@ def test_water_temperature_returns_expected_value(mocked_drone):
     water_temp_tel = bp.WaterTemperatureTel(temperature={"value": water_temp})
     water_temp_tel_serialized = bp.WaterTemperatureTel.serialize(water_temp_tel)
     mocked_drone._telemetry_watcher._state[bp.WaterTemperatureTel] = water_temp_tel_serialized
-    assert mocked_drone.water_temperature == water_temp
+    assert mocked_drone.get_water_temperature() == water_temp
 
 
 def test_water_temperature_returns_none_on_missing_telemetry(mocked_drone):
-    assert mocked_drone.water_temperature is None
+    assert mocked_drone.get_water_temperature() is None
 
 
 def test_dive_time_returns_expected_value(mocked_drone):
     dive_time_tel = bp.DiveTimeTel(dive_time={"value": 10})
     dive_time_tel_serialized = bp.DiveTimeTel.serialize(dive_time_tel)
     mocked_drone._telemetry_watcher._state[bp.DiveTimeTel] = dive_time_tel_serialized
-    assert mocked_drone.dive_time == 10
+    assert mocked_drone.get_dive_time() == 10
 
 
 def test_dive_time_returns_none_on_missing_telemetry(mocked_drone):
-    assert mocked_drone.dive_time is None
+    assert mocked_drone.get_dive_time() is None
 
 
 def test_connect_as_observer(mocked_drone_not_connected):


### PR DESCRIPTION
This PR introduces getters (and optionally setters) for all of the properties. So now instead of doing

```python
my_drone.lights = 0.5
```
you'll do

```python
my_drone.set_lights(0.5)
```

There are a few benefits with doing this way:

- With the old api there was a bit of a footgun where if you had a typo in the property you would silently set an attribute instead of the calling the actual function. 
- The docs are much better since we don't need to force the docstring of the setter property in with the dosctring of the getter property.
- Using getters/setters is more the "expected" way to do things, so I imagine it will be easier for new users use the SDK. 

Note: This is **not** a breaking changing, there is a shim that translates all of the old properties into the new functions. I do, however, intend to remove the old properties in the next major version, so if one uses the old properties a DeprecationWarning is raised.

#### Checklist before merging

- [ ] Run the tests while connected to a drone
- [ ] Update the package version according to [semver](https://semver.org/)
