### PR TITLE
Complete the camera parameter coverage, add VGA/2K/4K and 60 fps

### DIFF
--- a/blueye/sdk/camera.py
+++ b/blueye/sdk/camera.py
@@ -996,31 +996,45 @@ class Camera:
         """Set or get the camera resolution.
 
         Args:
-            resolution (int): Set the camera in vertical pixels. Valid values are 720 or 1080.
+            resolution (int): Set the camera in vertical pixels. Valid values are 480, 720, 1080,
+                1440 or 2160.
 
         Returns:
             The camera resolution.
         """
         self._update_camera_parameters()
-        if self._camera_parameters.resolution == blueye.protocol.Resolution.RESOLUTION_HD_720P:
+        if self._camera_parameters.resolution == blueye.protocol.Resolution.RESOLUTION_VGA_480P:
+            return 480
+        elif self._camera_parameters.resolution == blueye.protocol.Resolution.RESOLUTION_HD_720P:
             return 720
         elif (
             self._camera_parameters.resolution == blueye.protocol.Resolution.RESOLUTION_FULLHD_1080P
         ):
             return 1080
+        elif self._camera_parameters.resolution == blueye.protocol.Resolution.RESOLUTION_QHD_2K:
+            return 1440
+        elif self._camera_parameters.resolution == blueye.protocol.Resolution.RESOLUTION_UHD_4K:
+            return 2160
 
     @resolution.setter
     def resolution(self, resolution: int):
-        if resolution not in (720, 1080):
+        if resolution not in (480, 720, 1080, 1440, 2160):
             raise ValueError(
-                f"{resolution} is not a valid resolution. Valid values are 720 or 1080"
+                f"{resolution} is not a valid resolution. "
+                "Valid values are 480, 720, 1080, 1440 or 2160"
             )
         if self._camera_parameters is None:
             self._update_camera_parameters()
-        if resolution == 720:
+        if resolution == 480:
+            self._camera_parameters.resolution = blueye.protocol.Resolution.RESOLUTION_VGA_480P
+        elif resolution == 720:
             self._camera_parameters.resolution = blueye.protocol.Resolution.RESOLUTION_HD_720P
         elif resolution == 1080:
             self._camera_parameters.resolution = blueye.protocol.Resolution.RESOLUTION_FULLHD_1080P
+        elif resolution == 1440:
+            self._camera_parameters.resolution = blueye.protocol.Resolution.RESOLUTION_QHD_2K
+        elif resolution == 2160:
+            self._camera_parameters.resolution = blueye.protocol.Resolution.RESOLUTION_UHD_4K
 
         self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
 

--- a/blueye/sdk/camera.py
+++ b/blueye/sdk/camera.py
@@ -1068,32 +1068,46 @@ class Camera:
             The camera resolution.
         """
         self._update_camera_parameters()
-        if self._camera_parameters.resolution == blueye.protocol.Resolution.RESOLUTION_HD_720P:
+        if self._camera_parameters.resolution == blueye.protocol.Resolution.RESOLUTION_VGA_480P:
+            return 480
+        elif self._camera_parameters.resolution == blueye.protocol.Resolution.RESOLUTION_HD_720P:
             return 720
         elif (
             self._camera_parameters.resolution == blueye.protocol.Resolution.RESOLUTION_FULLHD_1080P
         ):
             return 1080
+        elif self._camera_parameters.resolution == blueye.protocol.Resolution.RESOLUTION_QHD_2K:
+            return 1440
+        elif self._camera_parameters.resolution == blueye.protocol.Resolution.RESOLUTION_UHD_4K:
+            return 2160
 
     def set_resolution(self, resolution: int):
         """Set the camera resolution.
 
         Args:
-            resolution (int): Set the camera in vertical pixels. Valid values are 720 or 1080.
+            resolution (int): Set the camera in vertical pixels. Valid values are 480, 720, 1080,
+                1440 or 2160.
 
         Raises:
-            ValueError: If the resolution is not 720 or 1080.
+            ValueError: If the resolution is not one of the valid values.
         """
-        if resolution not in (720, 1080):
+        if resolution not in (480, 720, 1080, 1440, 2160):
             raise ValueError(
-                f"{resolution} is not a valid resolution. Valid values are 720 or 1080"
+                f"{resolution} is not a valid resolution. "
+                "Valid values are 480, 720, 1080, 1440 or 2160"
             )
         if self._camera_parameters is None:
             self._update_camera_parameters()
-        if resolution == 720:
+        if resolution == 480:
+            self._camera_parameters.resolution = blueye.protocol.Resolution.RESOLUTION_VGA_480P
+        elif resolution == 720:
             self._camera_parameters.resolution = blueye.protocol.Resolution.RESOLUTION_HD_720P
         elif resolution == 1080:
             self._camera_parameters.resolution = blueye.protocol.Resolution.RESOLUTION_FULLHD_1080P
+        elif resolution == 1440:
+            self._camera_parameters.resolution = blueye.protocol.Resolution.RESOLUTION_QHD_2K
+        elif resolution == 2160:
+            self._camera_parameters.resolution = blueye.protocol.Resolution.RESOLUTION_UHD_4K
 
         self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
 

--- a/blueye/sdk/camera.py
+++ b/blueye/sdk/camera.py
@@ -826,12 +826,19 @@ class Camera:
 
         Changes are accumulated and sent as a single request on scope exit.
 
+        Parameters take the same names and the same values as the corresponding setters, so
+        `params.whitebalance` and `params.framerate = 60` work here just as
+        [`set_whitebalance`][blueye.sdk.camera.Camera.set_whitebalance] and
+        [`set_framerate`][blueye.sdk.camera.Camera.set_framerate] do, and invalid values are
+        rejected the same way. The underlying protobuf field names (`white_balance`,
+        `h264_bitrate`, `mjpg_bitrate`) and the `blueye.protocol` enums are accepted too.
+
         Usage::
 
             with drone.camera.configure() as params:
                 params.recording_codec = bp.RecordingCodec.RECORDING_CODEC_H265
                 params.recording_bitrate = 20_000_000
-                params.framerate = bp.Framerate.FRAMERATE_FPS_30
+                params.framerate = 30
             # All three fields are sent in one set_camera_parameters call here.
         """
 
@@ -841,8 +848,65 @@ class Camera:
             self._camera._update_camera_parameters(timeout=timeout)
             self._params = camera._camera_parameters
 
+        # SDK accessor names whose protobuf field is spelled differently. The batch API accepts
+        # both, so code written against the setters works, and the protobuf names that shipped
+        # in 2.7.0 keep working.
+        _FIELD_ALIASES = {
+            "whitebalance": "white_balance",
+            "bitrate": "h264_bitrate",
+            "bitrate_still_picture": "mjpg_bitrate",
+        }
+
+        # Fields the setters expose as plain ints, with the tables translating to and from the
+        # protocol enum, and the enum type that is accepted as-is.
+        _INT_VALUED_FIELDS = {
+            "framerate": (_FPS_TO_FRAMERATE, _FRAMERATE_TO_FPS, blueye.protocol.Framerate),
+            "resolution": (
+                _HEIGHT_TO_RESOLUTION,
+                _RESOLUTION_TO_HEIGHT,
+                blueye.protocol.Resolution,
+            ),
+        }
+
+        _DEPRECATED_FIELDS = {
+            "resolution": (
+                "`resolution` is deprecated and is ignored by drones running Blunux 4.4 or newer, "
+                "use stream_resolution or recording_resolution instead"
+            ),
+        }
+
+        def _resolve(self, name: str) -> str:
+            """Translate an SDK accessor name into the protobuf field it reads or writes."""
+            field = self._FIELD_ALIASES.get(name, name)
+            if field in self._DEPRECATED_FIELDS:
+                warnings.warn(self._DEPRECATED_FIELDS[field], DeprecationWarning, stacklevel=3)
+            return field
+
+        def _to_enum(self, field: str, value):
+            """Map a plain int to its protocol enum, passing enum values through untouched."""
+            to_enum, _, enum_type = self._INT_VALUED_FIELDS[field]
+            if isinstance(value, enum_type):
+                return value
+            try:
+                return to_enum[value]
+            except (KeyError, TypeError):
+                valid = ", ".join(str(v) for v in sorted(to_enum))
+                raise ValueError(
+                    f"{value} is not a valid {field}. Valid values are {valid}"
+                ) from None
+
         def __getattr__(self, name):
-            return getattr(self._params, name)
+            field = self._resolve(name)
+            value = getattr(self._params, field)
+            if field in self._INT_VALUED_FIELDS:
+                _, from_enum, _ = self._INT_VALUED_FIELDS[field]
+                try:
+                    return from_enum[value]
+                except KeyError:
+                    raise RuntimeError(
+                        f"Drone reported an unsupported {field}: {value.name}"
+                    ) from None
+            return value
 
         _VERSION_GATED_PARAMS = {
             "recording_bitrate": "5.0.0",
@@ -863,12 +927,15 @@ class Camera:
         def __setattr__(self, name, value):
             if name.startswith("_"):
                 super().__setattr__(name, value)
-            else:
-                if name in self._VERSION_GATED_PARAMS:
-                    self._camera._parent_drone._verify_required_blunux_version(
-                        self._VERSION_GATED_PARAMS[name]
-                    )
-                setattr(self._params, name, value)
+                return
+            field = self._resolve(name)
+            if field in self._VERSION_GATED_PARAMS:
+                self._camera._parent_drone._verify_required_blunux_version(
+                    self._VERSION_GATED_PARAMS[field]
+                )
+            if field in self._INT_VALUED_FIELDS:
+                value = self._to_enum(field, value)
+            setattr(self._params, field, value)
 
         def __enter__(self):
             return self
@@ -918,9 +985,16 @@ class Camera:
         ``set_camera_parameters`` request when the ``with`` block exits.  If an exception is
         raised inside the block the changes are discarded.
 
+        Parameters take the same names and values as the corresponding setters; the protobuf
+        field names and enums are accepted as well.
+
         Args:
             timeout (float, optional): Timeout in seconds for the request. Increase when changing
                 parameters that trigger pipeline restarts (e.g. codec, resolution).
+
+        Raises:
+            ValueError: If a value is not valid for the parameter being set.
+            RuntimeError: If a parameter requires a newer Blunux version than the drone runs.
 
         Usage::
 

--- a/blueye/sdk/camera.py
+++ b/blueye/sdk/camera.py
@@ -18,6 +18,22 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_RESOLUTION_TO_HEIGHT = {
+    blueye.protocol.Resolution.RESOLUTION_VGA_480P: 480,
+    blueye.protocol.Resolution.RESOLUTION_HD_720P: 720,
+    blueye.protocol.Resolution.RESOLUTION_FULLHD_1080P: 1080,
+    blueye.protocol.Resolution.RESOLUTION_QHD_2K: 1440,
+    blueye.protocol.Resolution.RESOLUTION_UHD_4K: 2160,
+}
+_HEIGHT_TO_RESOLUTION = {height: res for res, height in _RESOLUTION_TO_HEIGHT.items()}
+
+_FRAMERATE_TO_FPS = {
+    blueye.protocol.Framerate.FRAMERATE_FPS_25: 25,
+    blueye.protocol.Framerate.FRAMERATE_FPS_30: 30,
+    blueye.protocol.Framerate.FRAMERATE_FPS_60: 60,
+}
+_FPS_TO_FRAMERATE = {fps: framerate for framerate, fps in _FRAMERATE_TO_FPS.items()}
+
 
 class Tilt:
     """Handles the camera tilt functionality for the Blueye drone."""
@@ -831,6 +847,17 @@ class Camera:
         _VERSION_GATED_PARAMS = {
             "recording_bitrate": "5.0.0",
             "recording_codec": "5.0.0",
+            "brightness": "5.0.0",
+            "contrast": "5.0.0",
+            "saturation": "5.0.0",
+            "gamma": "5.0.0",
+            "sharpness": "5.0.0",
+            "backlight_compensation": "5.0.0",
+            "denoise": "5.0.0",
+            "ehdr_enabled": "5.0.0",
+            "ehdr_exposure_min_number": "5.0.0",
+            "ehdr_exposure_max_number": "5.0.0",
+            "mtu_size": "5.1.0",
         }
 
         def __setattr__(self, name, value):
@@ -1061,28 +1088,351 @@ class Camera:
 
     hue = deprecated_property("get_hue", "set_hue")
 
+    def get_gain(self) -> float:
+        """Get the camera gain.
+
+        Only available on Pioneer/Pro/X1/X3.
+
+        Returns:
+            The camera ISO gain.
+        """
+        self._update_camera_parameters()
+        return self._camera_parameters.gain
+
+    def set_gain(self, gain: float):
+        """Set the camera gain.
+
+        Only available on Pioneer/Pro/X1/X3.
+
+        Args:
+            gain (float): Set the ISO gain (0..1).
+        """
+        if self._camera_parameters is None:
+            self._update_camera_parameters()
+        self._camera_parameters.gain = gain
+        self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
+
+    def get_brightness(self) -> int:
+        """Get the camera brightness.
+
+        Only available on Ultra.
+
+        Returns:
+            The camera brightness.
+        """
+        self._update_camera_parameters()
+        return self._camera_parameters.brightness
+
+    def set_brightness(self, brightness: int):
+        """Set the camera brightness.
+
+        Only available on Ultra.
+
+        Args:
+            brightness (int): Set the brightness (-10..10), 0 is the default.
+
+        Raises:
+            RuntimeError: If the connected drone is running a Blunux version older than 5.0.0.
+        """
+        self._parent_drone._verify_required_blunux_version("5.0.0")
+        if self._camera_parameters is None:
+            self._update_camera_parameters()
+        self._camera_parameters.brightness = brightness
+        self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
+
+    def get_contrast(self) -> int:
+        """Get the camera contrast.
+
+        Only available on Ultra.
+
+        Returns:
+            The camera contrast.
+        """
+        self._update_camera_parameters()
+        return self._camera_parameters.contrast
+
+    def set_contrast(self, contrast: int):
+        """Set the camera contrast.
+
+        Only available on Ultra.
+
+        Args:
+            contrast (int): Set the contrast (-50..50), 0 is the default.
+
+        Raises:
+            RuntimeError: If the connected drone is running a Blunux version older than 5.0.0.
+        """
+        self._parent_drone._verify_required_blunux_version("5.0.0")
+        if self._camera_parameters is None:
+            self._update_camera_parameters()
+        self._camera_parameters.contrast = contrast
+        self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
+
+    def get_saturation(self) -> int:
+        """Get the camera saturation.
+
+        Only available on Ultra.
+
+        Returns:
+            The camera saturation.
+        """
+        self._update_camera_parameters()
+        return self._camera_parameters.saturation
+
+    def set_saturation(self, saturation: int):
+        """Set the camera saturation.
+
+        Only available on Ultra.
+
+        Args:
+            saturation (int): Set the saturation (0..50), 8 is the default.
+
+        Raises:
+            RuntimeError: If the connected drone is running a Blunux version older than 5.0.0.
+        """
+        self._parent_drone._verify_required_blunux_version("5.0.0")
+        if self._camera_parameters is None:
+            self._update_camera_parameters()
+        self._camera_parameters.saturation = saturation
+        self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
+
+    def get_gamma(self) -> int:
+        """Get the camera gamma.
+
+        Only available on Ultra.
+
+        Returns:
+            The camera gamma.
+        """
+        self._update_camera_parameters()
+        return self._camera_parameters.gamma
+
+    def set_gamma(self, gamma: int):
+        """Set the camera gamma.
+
+        Only available on Ultra.
+
+        Args:
+            gamma (int): Set the gamma (4..79), 22 is the default.
+
+        Raises:
+            RuntimeError: If the connected drone is running a Blunux version older than 5.0.0.
+        """
+        self._parent_drone._verify_required_blunux_version("5.0.0")
+        if self._camera_parameters is None:
+            self._update_camera_parameters()
+        self._camera_parameters.gamma = gamma
+        self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
+
+    def get_sharpness(self) -> int:
+        """Get the camera sharpness.
+
+        Only available on Ultra.
+
+        Returns:
+            The camera sharpness.
+        """
+        self._update_camera_parameters()
+        return self._camera_parameters.sharpness
+
+    def set_sharpness(self, sharpness: int):
+        """Set the camera sharpness.
+
+        Only available on Ultra.
+
+        Args:
+            sharpness (int): Set the sharpness (-20..20), -20 is the default.
+
+        Raises:
+            RuntimeError: If the connected drone is running a Blunux version older than 5.0.0.
+        """
+        self._parent_drone._verify_required_blunux_version("5.0.0")
+        if self._camera_parameters is None:
+            self._update_camera_parameters()
+        self._camera_parameters.sharpness = sharpness
+        self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
+
+    def get_backlight_compensation(self) -> int:
+        """Get the camera backlight compensation.
+
+        Only available on Ultra.
+
+        Returns:
+            The camera backlight compensation.
+        """
+        self._update_camera_parameters()
+        return self._camera_parameters.backlight_compensation
+
+    def set_backlight_compensation(self, compensation: int):
+        """Set the camera backlight compensation.
+
+        Only available on Ultra.
+
+        Args:
+            compensation (int): Set the backlight compensation (-150..150), 10 is the default.
+
+        Raises:
+            RuntimeError: If the connected drone is running a Blunux version older than 5.0.0.
+        """
+        self._parent_drone._verify_required_blunux_version("5.0.0")
+        if self._camera_parameters is None:
+            self._update_camera_parameters()
+        self._camera_parameters.backlight_compensation = compensation
+        self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
+
+    def get_denoise(self) -> int:
+        """Get the camera noise reduction.
+
+        Only available on Ultra.
+
+        Returns:
+            The camera noise reduction.
+        """
+        self._update_camera_parameters()
+        return self._camera_parameters.denoise
+
+    def set_denoise(self, denoise: int):
+        """Set the camera noise reduction.
+
+        Only available on Ultra.
+
+        Args:
+            denoise (int): Set the noise reduction (-20..20), -20 is the default.
+
+        Raises:
+            RuntimeError: If the connected drone is running a Blunux version older than 5.0.0.
+        """
+        self._parent_drone._verify_required_blunux_version("5.0.0")
+        if self._camera_parameters is None:
+            self._update_camera_parameters()
+        self._camera_parameters.denoise = denoise
+        self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
+
+    def is_ehdr_enabled(self) -> bool:
+        """Get the state of the eHDR mode.
+
+        Only available on Ultra.
+
+        Returns:
+            The current state of the eHDR mode.
+        """
+        self._update_camera_parameters()
+        return self._camera_parameters.ehdr_enabled
+
+    def enable_ehdr(self, enable_ehdr: bool):
+        """Enable or disable the eHDR mode.
+
+        Only available on Ultra.
+
+        Args:
+            enable_ehdr (bool): True to enable eHDR mode, False to disable it. Enabled by default.
+
+        Raises:
+            RuntimeError: If the connected drone is running a Blunux version older than 5.0.0.
+        """
+        self._parent_drone._verify_required_blunux_version("5.0.0")
+        if self._camera_parameters is None:
+            self._update_camera_parameters()
+        self._camera_parameters.ehdr_enabled = enable_ehdr
+        self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
+
+    def get_ehdr_exposure_min_number(self) -> int:
+        """Get the minimum number of eHDR frames.
+
+        Only available on Ultra.
+
+        Returns:
+            The minimum number of eHDR frames.
+        """
+        self._update_camera_parameters()
+        return self._camera_parameters.ehdr_exposure_min_number
+
+    def set_ehdr_exposure_min_number(self, number: int):
+        """Set the minimum number of eHDR frames.
+
+        Only available on Ultra.
+
+        Args:
+            number (int): Set the minimum number of eHDR frames (1..4), 1 is the default.
+
+        Raises:
+            RuntimeError: If the connected drone is running a Blunux version older than 5.0.0.
+        """
+        self._parent_drone._verify_required_blunux_version("5.0.0")
+        if self._camera_parameters is None:
+            self._update_camera_parameters()
+        self._camera_parameters.ehdr_exposure_min_number = number
+        self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
+
+    def get_ehdr_exposure_max_number(self) -> int:
+        """Get the maximum number of eHDR frames.
+
+        Only available on Ultra.
+
+        Returns:
+            The maximum number of eHDR frames.
+        """
+        self._update_camera_parameters()
+        return self._camera_parameters.ehdr_exposure_max_number
+
+    def set_ehdr_exposure_max_number(self, number: int):
+        """Set the maximum number of eHDR frames.
+
+        Only available on Ultra.
+
+        Args:
+            number (int): Set the maximum number of eHDR frames (1..4), 2 is the default. Setting
+                it higher than 2 can reduce the frame rate.
+
+        Raises:
+            RuntimeError: If the connected drone is running a Blunux version older than 5.0.0.
+        """
+        self._parent_drone._verify_required_blunux_version("5.0.0")
+        if self._camera_parameters is None:
+            self._update_camera_parameters()
+        self._camera_parameters.ehdr_exposure_max_number = number
+        self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
+
     def get_resolution(self) -> int:
         """Get the camera resolution.
+
+        Deprecated:
+            Drones running Blunux 4.4 or newer take the resolution from the stream and recording
+            resolution fields. Use
+            [`get_stream_resolution`][blueye.sdk.camera.Camera.get_stream_resolution] and
+            [`get_recording_resolution`][blueye.sdk.camera.Camera.get_recording_resolution]
+            instead.
+
+        Raises:
+            RuntimeError: If the drone reports a resolution the SDK does not recognize.
 
         Returns:
             The camera resolution.
         """
+        warnings.warn(
+            "`Camera.get_resolution` is deprecated, use `Camera.get_stream_resolution` or "
+            "`Camera.get_recording_resolution` instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._update_camera_parameters()
-        if self._camera_parameters.resolution == blueye.protocol.Resolution.RESOLUTION_VGA_480P:
-            return 480
-        elif self._camera_parameters.resolution == blueye.protocol.Resolution.RESOLUTION_HD_720P:
-            return 720
-        elif (
-            self._camera_parameters.resolution == blueye.protocol.Resolution.RESOLUTION_FULLHD_1080P
-        ):
-            return 1080
-        elif self._camera_parameters.resolution == blueye.protocol.Resolution.RESOLUTION_QHD_2K:
-            return 1440
-        elif self._camera_parameters.resolution == blueye.protocol.Resolution.RESOLUTION_UHD_4K:
-            return 2160
+        try:
+            return _RESOLUTION_TO_HEIGHT[self._camera_parameters.resolution]
+        except KeyError:
+            raise RuntimeError(
+                "Drone reported an unsupported resolution: "
+                f"{self._camera_parameters.resolution.name}"
+            ) from None
 
     def set_resolution(self, resolution: int):
         """Set the camera resolution.
+
+        Deprecated:
+            Drones running Blunux 4.4 or newer ignore this field when camera parameters are set,
+            so calling this method has no effect on them. Use
+            [`set_stream_resolution`][blueye.sdk.camera.Camera.set_stream_resolution] and
+            [`set_recording_resolution`][blueye.sdk.camera.Camera.set_recording_resolution]
+            instead.
 
         Args:
             resolution (int): Set the camera in vertical pixels. Valid values are 480, 720, 1080,
@@ -1091,24 +1441,21 @@ class Camera:
         Raises:
             ValueError: If the resolution is not one of the valid values.
         """
-        if resolution not in (480, 720, 1080, 1440, 2160):
+        warnings.warn(
+            "`Camera.set_resolution` is deprecated and is ignored by drones running Blunux 4.4 or "
+            "newer, use `Camera.set_stream_resolution` or `Camera.set_recording_resolution` "
+            "instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if resolution not in _HEIGHT_TO_RESOLUTION:
             raise ValueError(
                 f"{resolution} is not a valid resolution. "
                 "Valid values are 480, 720, 1080, 1440 or 2160"
             )
         if self._camera_parameters is None:
             self._update_camera_parameters()
-        if resolution == 480:
-            self._camera_parameters.resolution = blueye.protocol.Resolution.RESOLUTION_VGA_480P
-        elif resolution == 720:
-            self._camera_parameters.resolution = blueye.protocol.Resolution.RESOLUTION_HD_720P
-        elif resolution == 1080:
-            self._camera_parameters.resolution = blueye.protocol.Resolution.RESOLUTION_FULLHD_1080P
-        elif resolution == 1440:
-            self._camera_parameters.resolution = blueye.protocol.Resolution.RESOLUTION_QHD_2K
-        elif resolution == 2160:
-            self._camera_parameters.resolution = blueye.protocol.Resolution.RESOLUTION_UHD_4K
-
+        self._camera_parameters.resolution = _HEIGHT_TO_RESOLUTION[resolution]
         self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
 
     resolution = deprecated_property("get_resolution", "set_resolution")
@@ -1200,33 +1547,38 @@ class Camera:
     def get_framerate(self) -> int:
         """Get the camera frame rate.
 
+        Raises:
+            RuntimeError: If the drone reports a frame rate the SDK does not recognize.
+
         Returns:
             The camera frame rate.
         """
         self._update_camera_parameters()
-        if self._camera_parameters.framerate == blueye.protocol.Framerate.FRAMERATE_FPS_25:
-            return 25
-        elif self._camera_parameters.framerate == blueye.protocol.Framerate.FRAMERATE_FPS_30:
-            return 30
+        try:
+            return _FRAMERATE_TO_FPS[self._camera_parameters.framerate]
+        except KeyError:
+            raise RuntimeError(
+                "Drone reported an unsupported framerate: "
+                f"{self._camera_parameters.framerate.name}"
+            ) from None
 
     def set_framerate(self, framerate: int):
         """Set the camera frame rate.
 
         Args:
-            framerate (int): Set the camera frame rate in frames per second.
-                             Valid values are 25 or 30.
+            framerate (int): Set the camera frame rate in frames per second. Valid values are 25,
+                30 or 60. 25 fps is only supported on Pioneer/Pro/X1/X3, and 60 fps only on the
+                Ultra at 1440p or lower. If the requested frame rate is not supported at the
+                current resolution the drone reduces it while respecting the resolution.
 
         Raises:
-            ValueError: If the framerate is not 25 or 30.
+            ValueError: If the frame rate is not 25, 30 or 60.
         """
-        if framerate not in (25, 30):
-            raise ValueError(f"{framerate} is not a valid framerate. Valid values are 25 or 30")
+        if framerate not in _FPS_TO_FRAMERATE:
+            raise ValueError(f"{framerate} is not a valid framerate. Valid values are 25, 30 or 60")
         if self._camera_parameters is None:
             self._update_camera_parameters()
-        if framerate == 25:
-            self._camera_parameters.framerate = blueye.protocol.Framerate.FRAMERATE_FPS_25
-        elif framerate == 30:
-            self._camera_parameters.framerate = blueye.protocol.Framerate.FRAMERATE_FPS_30
+        self._camera_parameters.framerate = _FPS_TO_FRAMERATE[framerate]
         self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
 
     framerate = deprecated_property("get_framerate", "set_framerate")
@@ -1320,6 +1672,31 @@ class Camera:
         self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
 
     streaming_protocol = deprecated_property("get_streaming_protocol", "set_streaming_protocol")
+
+    def get_mtu_size(self) -> int:
+        """Get the network MTU size used for video streaming.
+
+        Returns:
+            The MTU size in bytes (0 if the drone default is used).
+        """
+        self._update_camera_parameters()
+        return self._camera_parameters.mtu_size
+
+    def set_mtu_size(self, mtu_size: int):
+        """Set the network MTU size used for video streaming.
+
+        Args:
+            mtu_size (int): Set the MTU size in bytes (68..65535). The Blueye app allows values
+                between 500 and 1460. A value of 0 means the drone uses its default of 1400.
+
+        Raises:
+            RuntimeError: If the connected drone is running a Blunux version older than 5.1.0.
+        """
+        self._parent_drone._verify_required_blunux_version("5.1.0")
+        if self._camera_parameters is None:
+            self._update_camera_parameters()
+        self._camera_parameters.mtu_size = mtu_size
+        self._parent_drone._req_rep_client.set_camera_parameters(self._camera_parameters)
 
     def get_record_time(self) -> Optional[int]:
         """Get the duration of the current camera recording.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,24 @@ def mocked_ctrl_client(mocker):
 
 @pytest.fixture
 def mocked_telemetry_client(mocker):
-    return mocker.patch("blueye.sdk.drone.TelemetryClient", autospec=True)
+    """Patch the telemetry subscriber so unit tests never read telemetry off the network.
+
+    Without this the drone built by `mocked_drone` opens a real ZMQ subscriber against the
+    drone IP, and any drone on the same network fills its state within a few hundred
+    milliseconds. That makes every "returns None when no telemetry has been received" test
+    fail at random, depending on which one happens to run late enough to receive something.
+
+    The mock keeps a real dict for `_state` and looks messages up in it, raising KeyError for
+    the ones that are missing, so tests can keep seeding telemetry by assigning to
+    `drone._telemetry_watcher._state[SomeTel]`.
+    """
+    patched = mocker.patch("blueye.sdk.drone.TelemetryClient", autospec=True)
+    instance = patched.return_value
+    instance._state = {}
+    # Read the attribute on every call rather than closing over the dict, because the real
+    # get() looks up self._state and several tests rebind _state to a fresh dict.
+    instance.get.side_effect = lambda key: instance._state[key]
+    return patched
 
 
 @pytest.fixture
@@ -98,6 +115,7 @@ def mocked_drone(
     mocker,
     mocked_requests,
     mocked_ctrl_client,
+    mocked_telemetry_client,
     mocked_watchdog_publisher,
     mocked_req_rep_client,
 ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import time
+
 import blueye.protocol as bp
 import pytest
 
@@ -11,6 +13,23 @@ def real_drone():
     Used for integration tests with physical hardware.
     """
     return blueye.sdk.Drone()
+
+
+@pytest.fixture(scope="class")
+def drone_model(real_drone) -> bp.Model:
+    """Fixture that reports the model of the connected drone
+
+    Used to skip integration tests for camera parameters the connected hardware does not
+    support. Returns MODEL_UNSPECIFIED if no drone info is received, which is also what
+    drones older than the introduction of the model field report.
+    """
+    deadline = time.monotonic() + 3
+    while time.monotonic() < deadline:
+        drone_info = real_drone.telemetry.get(bp.DroneInfoTel)
+        if drone_info is not None:
+            return drone_info.drone_info.model
+        time.sleep(0.1)
+    return bp.Model.MODEL_UNSPECIFIED
 
 
 @pytest.fixture

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -84,6 +84,71 @@ def test_recording_resolution_invalid_type(mocked_camera):
         mocked_camera.recording_resolution = "invalid_resolution"
 
 
+@pytest.mark.parametrize(
+    "enum_value, expected",
+    [
+        (bp.Resolution.RESOLUTION_VGA_480P, 480),
+        (bp.Resolution.RESOLUTION_HD_720P, 720),
+        (bp.Resolution.RESOLUTION_FULLHD_1080P, 1080),
+        (bp.Resolution.RESOLUTION_QHD_2K, 1440),
+        (bp.Resolution.RESOLUTION_UHD_4K, 2160),
+    ],
+)
+def test_resolution_getter(mocked_camera, enum_value, expected):
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters(resolution=enum_value)
+    )
+    assert mocked_camera.resolution == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected_enum",
+    [
+        (480, bp.Resolution.RESOLUTION_VGA_480P),
+        (720, bp.Resolution.RESOLUTION_HD_720P),
+        (1080, bp.Resolution.RESOLUTION_FULLHD_1080P),
+        (1440, bp.Resolution.RESOLUTION_QHD_2K),
+        (2160, bp.Resolution.RESOLUTION_UHD_4K),
+    ],
+)
+def test_resolution_setter(mocked_camera, value, expected_enum):
+    mocked_camera._camera_parameters = bp.CameraParameters()
+    mocked_camera.resolution = value
+    assert mocked_camera._camera_parameters.resolution == expected_enum
+    mocked_camera._parent_drone._req_rep_client.set_camera_parameters.assert_called_once_with(
+        mocked_camera._camera_parameters
+    )
+
+
+def test_resolution_setter_invalid_value(mocked_camera):
+    with pytest.raises(ValueError):
+        mocked_camera.resolution = 600
+
+
+def test_streaming_protocol_getter(mocked_camera):
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters(streaming_protocol=bp.StreamingProtocol.STREAMING_PROTOCOL_RTSP_H264)
+    )
+    assert mocked_camera.streaming_protocol == bp.StreamingProtocol.STREAMING_PROTOCOL_RTSP_H264
+
+
+def test_streaming_protocol_setter(mocked_camera):
+    mocked_camera._camera_parameters = bp.CameraParameters()
+    mocked_camera.streaming_protocol = bp.StreamingProtocol.STREAMING_PROTOCOL_RTSP_MJPEG
+    assert (
+        mocked_camera._camera_parameters.streaming_protocol
+        == bp.StreamingProtocol.STREAMING_PROTOCOL_RTSP_MJPEG
+    )
+    mocked_camera._parent_drone._req_rep_client.set_camera_parameters.assert_called_once_with(
+        mocked_camera._camera_parameters
+    )
+
+
+def test_streaming_protocol_invalid_type(mocked_camera):
+    with pytest.raises(ValueError):
+        mocked_camera.streaming_protocol = "invalid_protocol"
+
+
 def test_old_drones_use_resolution_field(mocked_camera):
     # Set the version to a value that does not support separate recording resolution
     mocked_camera._parent_drone.software_version_short = "4.3"

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -476,3 +476,128 @@ def test_setter_on_a_cold_camera_fetches_current_parameters_first(mocked_ultra_c
     assert sent.recording_bitrate == 24_000_000
     assert sent.stream_resolution == bp.Resolution.RESOLUTION_FULLHD_1080P
     assert sent.framerate == bp.Framerate.FRAMERATE_FPS_30
+
+
+# (SDK accessor name, protobuf field name) for the fields whose names diverge
+BATCH_FIELD_ALIASES = [
+    ("whitebalance", "white_balance", 3200),
+    ("bitrate", "h264_bitrate", 3_000_000),
+    ("bitrate_still_picture", "mjpg_bitrate", 500_000),
+]
+
+
+@pytest.mark.parametrize("sdk_name, field_name, value", BATCH_FIELD_ALIASES)
+def test_configure_accepts_sdk_field_names(mocked_camera, sdk_name, field_name, value):
+    """configure() should take the same names as the setters, not raw protobuf names."""
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters()
+    )
+    with mocked_camera.configure() as params:
+        setattr(params, sdk_name, value)
+    sent = mocked_camera._parent_drone._req_rep_client.set_camera_parameters.call_args[0][0]
+    assert getattr(sent, field_name) == value
+
+
+@pytest.mark.parametrize("sdk_name, field_name, value", BATCH_FIELD_ALIASES)
+def test_configure_still_accepts_protobuf_field_names(mocked_camera, sdk_name, field_name, value):
+    """The protobuf names shipped in 2.7.0, so they have to keep working."""
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters()
+    )
+    with mocked_camera.configure() as params:
+        setattr(params, field_name, value)
+    sent = mocked_camera._parent_drone._req_rep_client.set_camera_parameters.call_args[0][0]
+    assert getattr(sent, field_name) == value
+
+
+@pytest.mark.parametrize("sdk_name, field_name, value", BATCH_FIELD_ALIASES)
+def test_configure_reads_back_through_sdk_names(mocked_camera, sdk_name, field_name, value):
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters(**{field_name: value})
+    )
+    with mocked_camera.configure() as params:
+        assert getattr(params, sdk_name) == value
+
+
+def test_configure_translates_framerate_int_to_enum(mocked_camera):
+    """set_framerate() takes fps, so the batch must too - not a raw enum number."""
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters()
+    )
+    with mocked_camera.configure() as params:
+        params.framerate = 60
+    sent = mocked_camera._parent_drone._req_rep_client.set_camera_parameters.call_args[0][0]
+    assert sent.framerate == bp.Framerate.FRAMERATE_FPS_60
+
+
+def test_configure_still_accepts_framerate_enum(mocked_camera):
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters()
+    )
+    with mocked_camera.configure() as params:
+        params.framerate = bp.Framerate.FRAMERATE_FPS_25
+    sent = mocked_camera._parent_drone._req_rep_client.set_camera_parameters.call_args[0][0]
+    assert sent.framerate == bp.Framerate.FRAMERATE_FPS_25
+
+
+def test_configure_rejects_invalid_framerate(mocked_camera):
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters()
+    )
+    with pytest.raises(ValueError):
+        with mocked_camera.configure() as params:
+            params.framerate = 24
+    mocked_camera._parent_drone._req_rep_client.set_camera_parameters.assert_not_called()
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_configure_translates_resolution_int_to_enum(mocked_camera):
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters()
+    )
+    with mocked_camera.configure() as params:
+        params.resolution = 1440
+    sent = mocked_camera._parent_drone._req_rep_client.set_camera_parameters.call_args[0][0]
+    assert sent.resolution == bp.Resolution.RESOLUTION_QHD_2K
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_configure_rejects_invalid_resolution(mocked_camera):
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters()
+    )
+    with pytest.raises(ValueError):
+        with mocked_camera.configure() as params:
+            params.resolution = 600
+
+
+def test_configure_warns_on_deprecated_resolution(mocked_camera):
+    """The batch must not become the quiet way to keep using the deprecated field."""
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters()
+    )
+    with pytest.warns(DeprecationWarning, match="stream_resolution"):
+        with mocked_camera.configure() as params:
+            params.resolution = 1080
+
+
+def test_configure_reads_back_framerate_and_resolution_as_ints(mocked_camera):
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters(
+            framerate=bp.Framerate.FRAMERATE_FPS_60,
+            resolution=bp.Resolution.RESOLUTION_UHD_4K,
+        )
+    )
+    with mocked_camera.configure() as params:
+        assert params.framerate == 60
+        with pytest.warns(DeprecationWarning):
+            assert params.resolution == 2160
+
+
+def test_configure_rejects_unknown_field_name(mocked_camera):
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters()
+    )
+    with pytest.raises(AttributeError):
+        with mocked_camera.configure() as params:
+            params.not_a_camera_parameter = 1

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -410,3 +410,69 @@ def test_configure_rejects_mtu_size_on_blunux_5_0(mocked_drone: Drone):
         with camera.configure() as params:
             params.mtu_size = 1200
     camera._parent_drone._req_rep_client.set_camera_parameters.assert_not_called()
+
+
+def test_recording_bitrate_getter(mocked_ultra_camera):
+    mocked_ultra_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters(recording_bitrate=24_000_000)
+    )
+    assert mocked_ultra_camera.get_recording_bitrate() == 24_000_000
+
+
+def test_recording_bitrate_setter(mocked_ultra_camera):
+    mocked_ultra_camera._camera_parameters = bp.CameraParameters(recording_bitrate=0)
+
+    mocked_ultra_camera.set_recording_bitrate(24_000_000)
+
+    mocked_ultra_camera._parent_drone._req_rep_client.set_camera_parameters.assert_called_once_with(
+        bp.CameraParameters(recording_bitrate=24_000_000)
+    )
+    assert mocked_ultra_camera._camera_parameters.recording_bitrate == 24_000_000
+
+
+def test_recording_bitrate_setter_requires_blunux_5(mocked_camera):
+    with pytest.raises(RuntimeError):
+        mocked_camera.set_recording_bitrate(24_000_000)
+
+
+def test_parameter_getter_refreshes_from_the_drone(mocked_ultra_camera):
+    """A getter must ask the drone, never answer from the cache.
+
+    Every getter method calls _update_camera_parameters() first, so a value
+    that changed since the last request - because another client set it, or
+    because the drone resolved an "automatic" request to a concrete number - is
+    reported as it is now and not as it was last written.
+    """
+    mocked_ultra_camera._camera_parameters = bp.CameraParameters(recording_bitrate=0)
+    mocked_ultra_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters(recording_bitrate=14_000_000)
+    )
+
+    assert mocked_ultra_camera.get_recording_bitrate() == 14_000_000
+    mocked_ultra_camera._parent_drone._req_rep_client.get_camera_parameters.assert_called_once()
+
+
+def test_setter_on_a_cold_camera_fetches_current_parameters_first(mocked_ultra_camera):
+    """A setter on a camera that has not talked to the drone yet must fetch the
+    current parameters before it sends.
+
+    set_camera_parameters carries the whole CameraParameters struct, so without
+    the lazy fetch the first setter after construction would send a
+    default-constructed one and zero every field the caller never touched -
+    resolution, framerate and codec among them.
+    """
+    assert mocked_ultra_camera._camera_parameters is None
+    mocked_ultra_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters(
+            stream_resolution=bp.Resolution.RESOLUTION_FULLHD_1080P,
+            framerate=bp.Framerate.FRAMERATE_FPS_30,
+        )
+    )
+
+    mocked_ultra_camera.set_recording_bitrate(24_000_000)
+
+    mocked_ultra_camera._parent_drone._req_rep_client.get_camera_parameters.assert_called_once()
+    sent = mocked_ultra_camera._parent_drone._req_rep_client.set_camera_parameters.call_args[0][0]
+    assert sent.recording_bitrate == 24_000_000
+    assert sent.stream_resolution == bp.Resolution.RESOLUTION_FULLHD_1080P
+    assert sent.framerate == bp.Framerate.FRAMERATE_FPS_30

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -84,6 +84,74 @@ def test_recording_resolution_invalid_type(mocked_camera):
         mocked_camera.set_recording_resolution("invalid_resolution")
 
 
+@pytest.mark.parametrize(
+    "enum_value, expected",
+    [
+        (bp.Resolution.RESOLUTION_VGA_480P, 480),
+        (bp.Resolution.RESOLUTION_HD_720P, 720),
+        (bp.Resolution.RESOLUTION_FULLHD_1080P, 1080),
+        (bp.Resolution.RESOLUTION_QHD_2K, 1440),
+        (bp.Resolution.RESOLUTION_UHD_4K, 2160),
+    ],
+)
+def test_resolution_getter(mocked_camera, enum_value, expected):
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters(resolution=enum_value)
+    )
+    assert mocked_camera.get_resolution() == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected_enum",
+    [
+        (480, bp.Resolution.RESOLUTION_VGA_480P),
+        (720, bp.Resolution.RESOLUTION_HD_720P),
+        (1080, bp.Resolution.RESOLUTION_FULLHD_1080P),
+        (1440, bp.Resolution.RESOLUTION_QHD_2K),
+        (2160, bp.Resolution.RESOLUTION_UHD_4K),
+    ],
+)
+def test_resolution_setter(mocked_camera, value, expected_enum):
+    mocked_camera._camera_parameters = bp.CameraParameters()
+    mocked_camera.set_resolution(value)
+    assert mocked_camera._camera_parameters.resolution == expected_enum
+    mocked_camera._parent_drone._req_rep_client.set_camera_parameters.assert_called_once_with(
+        mocked_camera._camera_parameters
+    )
+
+
+def test_resolution_setter_invalid_value(mocked_camera):
+    with pytest.raises(ValueError):
+        mocked_camera.set_resolution(600)
+
+
+def test_streaming_protocol_getter(mocked_camera):
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters(streaming_protocol=bp.StreamingProtocol.STREAMING_PROTOCOL_RTSP_H264)
+    )
+    assert (
+        mocked_camera.get_streaming_protocol()
+        == bp.StreamingProtocol.STREAMING_PROTOCOL_RTSP_H264
+    )
+
+
+def test_streaming_protocol_setter(mocked_camera):
+    mocked_camera._camera_parameters = bp.CameraParameters()
+    mocked_camera.set_streaming_protocol(bp.StreamingProtocol.STREAMING_PROTOCOL_RTSP_MJPEG)
+    assert (
+        mocked_camera._camera_parameters.streaming_protocol
+        == bp.StreamingProtocol.STREAMING_PROTOCOL_RTSP_MJPEG
+    )
+    mocked_camera._parent_drone._req_rep_client.set_camera_parameters.assert_called_once_with(
+        mocked_camera._camera_parameters
+    )
+
+
+def test_streaming_protocol_invalid_type(mocked_camera):
+    with pytest.raises(ValueError):
+        mocked_camera.set_streaming_protocol("invalid_protocol")
+
+
 def test_old_drones_use_resolution_field(mocked_camera):
     # Set the version to a value that does not support separate recording resolution
     mocked_camera._parent_drone.software_version_short = "4.3"

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -94,6 +94,7 @@ def test_recording_resolution_invalid_type(mocked_camera):
         (bp.Resolution.RESOLUTION_UHD_4K, 2160),
     ],
 )
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_resolution_getter(mocked_camera, enum_value, expected):
     mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
         bp.CameraParameters(resolution=enum_value)
@@ -111,6 +112,7 @@ def test_resolution_getter(mocked_camera, enum_value, expected):
         (2160, bp.Resolution.RESOLUTION_UHD_4K),
     ],
 )
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_resolution_setter(mocked_camera, value, expected_enum):
     mocked_camera._camera_parameters = bp.CameraParameters()
     mocked_camera.set_resolution(value)
@@ -120,6 +122,7 @@ def test_resolution_setter(mocked_camera, value, expected_enum):
     )
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_resolution_setter_invalid_value(mocked_camera):
     with pytest.raises(ValueError):
         mocked_camera.set_resolution(600)
@@ -130,8 +133,7 @@ def test_streaming_protocol_getter(mocked_camera):
         bp.CameraParameters(streaming_protocol=bp.StreamingProtocol.STREAMING_PROTOCOL_RTSP_H264)
     )
     assert (
-        mocked_camera.get_streaming_protocol()
-        == bp.StreamingProtocol.STREAMING_PROTOCOL_RTSP_H264
+        mocked_camera.get_streaming_protocol() == bp.StreamingProtocol.STREAMING_PROTOCOL_RTSP_H264
     )
 
 
@@ -218,3 +220,193 @@ def test_configure_passes_timeout(mocked_camera):
         mocked_camera._parent_drone._req_rep_client.set_camera_parameters.call_args[1]["timeout"]
         == 5.0
     )
+
+
+@pytest.fixture
+def mocked_ultra_camera(mocked_drone: Drone):
+    """A camera on a drone running a Blunux version that supports all camera parameters."""
+    from blueye.sdk.camera import Camera
+
+    mocked_drone.software_version_short = "5.1.0"
+    return Camera(mocked_drone)
+
+
+def test_get_resolution_warns_deprecation(mocked_camera):
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters(resolution=bp.Resolution.RESOLUTION_HD_720P)
+    )
+    with pytest.warns(DeprecationWarning, match="get_stream_resolution"):
+        assert mocked_camera.get_resolution() == 720
+
+
+def test_set_resolution_warns_deprecation(mocked_camera):
+    mocked_camera._camera_parameters = bp.CameraParameters()
+    with pytest.warns(DeprecationWarning, match="set_stream_resolution"):
+        mocked_camera.set_resolution(720)
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_resolution_getter_raises_on_unknown_resolution(mocked_camera):
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters(resolution=bp.Resolution.RESOLUTION_UNSPECIFIED)
+    )
+    with pytest.raises(RuntimeError):
+        mocked_camera.get_resolution()
+
+
+@pytest.mark.parametrize(
+    "enum_value, expected",
+    [
+        (bp.Framerate.FRAMERATE_FPS_25, 25),
+        (bp.Framerate.FRAMERATE_FPS_30, 30),
+        (bp.Framerate.FRAMERATE_FPS_60, 60),
+    ],
+)
+def test_framerate_getter(mocked_camera, enum_value, expected):
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters(framerate=enum_value)
+    )
+    assert mocked_camera.get_framerate() == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected_enum",
+    [
+        (25, bp.Framerate.FRAMERATE_FPS_25),
+        (30, bp.Framerate.FRAMERATE_FPS_30),
+        (60, bp.Framerate.FRAMERATE_FPS_60),
+    ],
+)
+def test_framerate_setter(mocked_camera, value, expected_enum):
+    mocked_camera._camera_parameters = bp.CameraParameters()
+    mocked_camera.set_framerate(value)
+    assert mocked_camera._camera_parameters.framerate == expected_enum
+    mocked_camera._parent_drone._req_rep_client.set_camera_parameters.assert_called_once_with(
+        mocked_camera._camera_parameters
+    )
+
+
+def test_framerate_setter_invalid_value(mocked_camera):
+    with pytest.raises(ValueError):
+        mocked_camera.set_framerate(24)
+
+
+def test_framerate_getter_raises_on_unknown_framerate(mocked_camera):
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters(framerate=bp.Framerate.FRAMERATE_UNSPECIFIED)
+    )
+    with pytest.raises(RuntimeError):
+        mocked_camera.get_framerate()
+
+
+# (getter, setter, CameraParameters field name, test value) for the Ultra-only image parameters
+ULTRA_IMAGE_PARAMETERS = [
+    ("get_brightness", "set_brightness", "brightness", 5),
+    ("get_contrast", "set_contrast", "contrast", 20),
+    ("get_saturation", "set_saturation", "saturation", 10),
+    ("get_gamma", "set_gamma", "gamma", 30),
+    ("get_sharpness", "set_sharpness", "sharpness", -10),
+    ("get_backlight_compensation", "set_backlight_compensation", "backlight_compensation", 100),
+    ("get_denoise", "set_denoise", "denoise", -5),
+    ("is_ehdr_enabled", "enable_ehdr", "ehdr_enabled", True),
+    (
+        "get_ehdr_exposure_min_number",
+        "set_ehdr_exposure_min_number",
+        "ehdr_exposure_min_number",
+        2,
+    ),
+    (
+        "get_ehdr_exposure_max_number",
+        "set_ehdr_exposure_max_number",
+        "ehdr_exposure_max_number",
+        3,
+    ),
+]
+
+
+@pytest.mark.parametrize("getter, setter, field_name, value", ULTRA_IMAGE_PARAMETERS)
+def test_ultra_image_parameter_getter(mocked_ultra_camera, getter, setter, field_name, value):
+    mocked_ultra_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters(**{field_name: value})
+    )
+    assert getattr(mocked_ultra_camera, getter)() == value
+
+
+@pytest.mark.parametrize("getter, setter, field_name, value", ULTRA_IMAGE_PARAMETERS)
+def test_ultra_image_parameter_setter(mocked_ultra_camera, getter, setter, field_name, value):
+    mocked_ultra_camera._camera_parameters = bp.CameraParameters()
+    getattr(mocked_ultra_camera, setter)(value)
+    assert getattr(mocked_ultra_camera._camera_parameters, field_name) == value
+    mocked_ultra_camera._parent_drone._req_rep_client.set_camera_parameters.assert_called_once_with(
+        mocked_ultra_camera._camera_parameters
+    )
+
+
+@pytest.mark.parametrize("getter, setter, field_name, value", ULTRA_IMAGE_PARAMETERS)
+def test_ultra_image_parameter_setter_requires_blunux_5(
+    mocked_camera, getter, setter, field_name, value
+):
+    # The mocked_camera fixture runs Blunux 4.4.1
+    with pytest.raises(RuntimeError):
+        getattr(mocked_camera, setter)(value)
+
+
+def test_gain_getter(mocked_camera):
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters(gain=0.5)
+    )
+    assert mocked_camera.get_gain() == pytest.approx(0.5)
+
+
+def test_gain_setter(mocked_camera):
+    mocked_camera._camera_parameters = bp.CameraParameters()
+    mocked_camera.set_gain(0.5)
+    assert mocked_camera._camera_parameters.gain == pytest.approx(0.5)
+    mocked_camera._parent_drone._req_rep_client.set_camera_parameters.assert_called_once_with(
+        mocked_camera._camera_parameters
+    )
+
+
+def test_mtu_size_getter(mocked_ultra_camera):
+    mocked_ultra_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters(mtu_size=1400)
+    )
+    assert mocked_ultra_camera.get_mtu_size() == 1400
+
+
+def test_mtu_size_setter(mocked_ultra_camera):
+    mocked_ultra_camera._camera_parameters = bp.CameraParameters()
+    mocked_ultra_camera.set_mtu_size(1200)
+    assert mocked_ultra_camera._camera_parameters.mtu_size == 1200
+    mocked_ultra_camera._parent_drone._req_rep_client.set_camera_parameters.assert_called_once_with(
+        mocked_ultra_camera._camera_parameters
+    )
+
+
+def test_mtu_size_setter_requires_blunux_5_1(mocked_camera):
+    # The mocked_camera fixture runs Blunux 4.4.1
+    with pytest.raises(RuntimeError):
+        mocked_camera.set_mtu_size(1200)
+
+
+def test_configure_rejects_ultra_image_parameters_on_old_drone(mocked_camera):
+    """Batched changes should honour the same Blunux version requirements as the setters."""
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        bp.CameraParameters()
+    )
+    with pytest.raises(RuntimeError):
+        with mocked_camera.configure() as params:
+            params.brightness = 5
+    mocked_camera._parent_drone._req_rep_client.set_camera_parameters.assert_not_called()
+
+
+def test_configure_rejects_mtu_size_on_blunux_5_0(mocked_drone: Drone):
+    from blueye.sdk.camera import Camera
+
+    mocked_drone.software_version_short = "5.0.0"
+    camera = Camera(mocked_drone)
+    camera._parent_drone._req_rep_client.get_camera_parameters.return_value = bp.CameraParameters()
+    with pytest.raises(RuntimeError):
+        with camera.configure() as params:
+            params.mtu_size = 1200
+    camera._parent_drone._req_rep_client.set_camera_parameters.assert_not_called()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,6 +4,14 @@ import blueye.protocol as bp
 import pytest
 from packaging import version
 
+ALL_RESOLUTIONS = [
+    bp.Resolution.RESOLUTION_VGA_480P,
+    bp.Resolution.RESOLUTION_HD_720P,
+    bp.Resolution.RESOLUTION_FULLHD_1080P,
+    bp.Resolution.RESOLUTION_QHD_2K,
+    bp.Resolution.RESOLUTION_UHD_4K,
+]
+
 
 def polling_assert_with_timeout(getter, value_to_wait_for, timeout):
     """Waits for a getter to return the value we are waiting for"""
@@ -48,7 +56,13 @@ class TestFunctionsWhenConnectedToDrone:
         real_drone.camera.set_recording(True)
         polling_assert_with_timeout(real_drone.camera.get_record_time, 1, 3)
 
-    def test_camera_bitrate(self, real_drone):
+    def test_camera_bitrate(self, real_drone, drone_model):
+        if drone_model == bp.Model.MODEL_X3_ULTRA:
+            pytest.xfail(
+                "The Ultra applies the stream bitrate but always reports it as 0. The drone "
+                "fills h264_bitrate from the camera control node, and the Ultra camera does not "
+                "encode H264 - the RTSP server does, and its bitrate never reaches the reply"
+            )
         _ = real_drone.camera.get_bitrate()
         real_drone.camera.set_bitrate(2000000)
         polling_assert_with_timeout(real_drone.camera.get_bitrate, 2000000, 1)
@@ -69,7 +83,11 @@ class TestFunctionsWhenConnectedToDrone:
         real_drone.camera.set_whitebalance(3400)
         polling_assert_with_timeout(real_drone.camera.get_whitebalance, 3400, 1)
 
-    def test_camera_hue(self, real_drone):
+    def test_camera_hue(self, real_drone, drone_model):
+        if drone_model == bp.Model.MODEL_X3_ULTRA:
+            pytest.skip(
+                "Hue is only available on Pioneer/Pro/X1/X3, the Ultra camera has no hue control"
+            )
         _ = real_drone.camera.get_hue()
         real_drone.camera.set_hue(20)
         polling_assert_with_timeout(real_drone.camera.get_hue, 20, 1)
@@ -89,19 +107,54 @@ class TestFunctionsWhenConnectedToDrone:
         real_drone.camera.set_resolution(1080)
         polling_assert_with_timeout(real_drone.camera.get_resolution, 1080, 1)
 
-    def test_camera_stream_resolution(self, real_drone):
+    @pytest.mark.parametrize("resolution", ALL_RESOLUTIONS, ids=lambda r: r.name)
+    def test_camera_stream_resolution(self, real_drone, resolution):
         original_resolution = real_drone.camera.get_stream_resolution()
         try:
-            real_drone.camera.set_stream_resolution(bp.Resolution.RESOLUTION_HD_720P)
-            polling_assert_with_timeout(
-                real_drone.camera.get_stream_resolution, bp.Resolution.RESOLUTION_HD_720P, 3
-            )
+            real_drone.camera.set_stream_resolution(resolution)
+            polling_assert_with_timeout(real_drone.camera.get_stream_resolution, resolution, 3)
         finally:
             real_drone.camera.set_stream_resolution(original_resolution)
 
-    def test_camera_framerate(self, real_drone):
+    @pytest.mark.parametrize("resolution", ALL_RESOLUTIONS, ids=lambda r: r.name)
+    def test_camera_recording_resolution(self, real_drone, resolution):
+        original_resolution = real_drone.camera.get_recording_resolution()
+        try:
+            real_drone.camera.set_recording_resolution(resolution)
+            polling_assert_with_timeout(real_drone.camera.get_recording_resolution, resolution, 3)
+        finally:
+            real_drone.camera.set_recording_resolution(original_resolution)
+
+    def test_camera_framerate(self, real_drone, drone_model):
+        if drone_model == bp.Model.MODEL_X3_ULTRA:
+            pytest.skip(
+                "The Ultra only applies 25 fps to the recording pipeline, and the reported frame "
+                "rate comes from the stream pipeline, which stays at 30. See "
+                "test_camera_framerate_60_fps for the frame rate the Ultra does support"
+            )
         _ = real_drone.camera.get_framerate()
         real_drone.camera.set_framerate(25)
         polling_assert_with_timeout(real_drone.camera.get_framerate, 25, 1)
         real_drone.camera.set_framerate(30)
         polling_assert_with_timeout(real_drone.camera.get_framerate, 30, 1)
+
+    def test_camera_framerate_60_fps(self, real_drone, drone_model):
+        """60 fps is only supported on the Ultra, and only at 1440p or lower.
+
+        The drone caps the frame rate against the highest of the stream and recording
+        resolution, so both must be lowered before requesting 60 fps.
+        """
+        if drone_model != bp.Model.MODEL_X3_ULTRA:
+            pytest.skip("60 fps is only supported on the Ultra")
+        original_stream_resolution = real_drone.camera.get_stream_resolution()
+        original_recording_resolution = real_drone.camera.get_recording_resolution()
+        original_framerate = real_drone.camera.get_framerate()
+        try:
+            real_drone.camera.set_stream_resolution(bp.Resolution.RESOLUTION_FULLHD_1080P)
+            real_drone.camera.set_recording_resolution(bp.Resolution.RESOLUTION_FULLHD_1080P)
+            real_drone.camera.set_framerate(60)
+            polling_assert_with_timeout(real_drone.camera.get_framerate, 60, 3)
+        finally:
+            real_drone.camera.set_framerate(original_framerate)
+            real_drone.camera.set_stream_resolution(original_stream_resolution)
+            real_drone.camera.set_recording_resolution(original_recording_resolution)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,8 @@
 from time import time
 
+import blueye.protocol as bp
 import pytest
+from packaging import version
 
 
 def polling_assert_with_timeout(getter, value_to_wait_for, timeout):
@@ -74,12 +76,28 @@ class TestFunctionsWhenConnectedToDrone:
         real_drone.camera.set_hue(30)
         polling_assert_with_timeout(real_drone.camera.get_hue, 30, 1)
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_camera_resolution(self, real_drone):
+        if version.parse(real_drone.software_version_short) >= version.parse("4.4"):
+            pytest.xfail(
+                "Drones running Blunux 4.4 or newer ignore the deprecated resolution field when "
+                "camera parameters are set, use the stream/recording resolution methods instead"
+            )
         _ = real_drone.camera.get_resolution()
         real_drone.camera.set_resolution(720)
         polling_assert_with_timeout(real_drone.camera.get_resolution, 720, 1)
         real_drone.camera.set_resolution(1080)
         polling_assert_with_timeout(real_drone.camera.get_resolution, 1080, 1)
+
+    def test_camera_stream_resolution(self, real_drone):
+        original_resolution = real_drone.camera.get_stream_resolution()
+        try:
+            real_drone.camera.set_stream_resolution(bp.Resolution.RESOLUTION_HD_720P)
+            polling_assert_with_timeout(
+                real_drone.camera.get_stream_resolution, bp.Resolution.RESOLUTION_HD_720P, 3
+            )
+        finally:
+            real_drone.camera.set_stream_resolution(original_resolution)
 
     def test_camera_framerate(self, real_drone):
         _ = real_drone.camera.get_framerate()

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1,6 +1,6 @@
 import json
 from time import time
-from unittest.mock import Mock, PropertyMock
+from unittest.mock import Mock, NonCallableMock, PropertyMock
 
 import blueye.protocol as bp
 import pytest
@@ -31,6 +31,20 @@ class TestPose:
         assert pose["roll"] == new_angle
         assert pose["pitch"] == new_angle
         assert pose["yaw"] == new_angle
+
+
+def test_mocked_drone_is_isolated_from_live_telemetry(mocked_drone):
+    """Unit tests must never read telemetry off the network.
+
+    `mocked_drone` used to build a real TelemetryClient, which subscribes to the drone IP. With
+    a drone on the same network that fills the state within a few hundred milliseconds, and the
+    tests asserting that a getter returns None when no telemetry has been received start failing
+    at random.
+    """
+    # A spec'd mock passes isinstance() against the class it specs, so check for the mock
+    # itself rather than asserting the watcher is not a TelemetryClient.
+    assert isinstance(mocked_drone._telemetry_watcher, NonCallableMock)
+    assert mocked_drone.telemetry.get(bp.ControlModeTel) is None
 
 
 def test_zmq_connection_error(mocked_drone):


### PR DESCRIPTION
**Description**

Completes the SDK's coverage of `CameraParameters` against blueye.protocol 3.3.0, and adds the
resolutions and frame rate the Ultra supports.

Built on top of #215, so everything here is expressed as getter/setter methods rather than
properties. Please merge that one first.

* **Resolutions.** `get_resolution`/`set_resolution` now cover 480 (VGA), 1440 (2K) and 2160 (4K)
  alongside 720 and 1080, using the enum members that actually exist in the protocol
  (`RESOLUTION_VGA_480P`, `RESOLUTION_QHD_2K`, `RESOLUTION_UHD_4K`).
* **60 fps.** Added to `get_framerate`/`set_framerate`. The Ultra supports it at 1440p and below;
  `p2_drone` and `gst_rtsp_record` already map and cap it.
* **Ultra image parameters.** `brightness`, `contrast`, `saturation`, `gamma`, `sharpness`,
  `backlight_compensation`, `denoise` and the eHDR options (`is_ehdr_enabled`/`enable_ehdr`,
  `get`/`set_ehdr_exposure_min_number`, `get`/`set_ehdr_exposure_max_number`), plus the ISO
  `gain` and the streaming `mtu_size`. All of them were already handled by the drone but had no
  SDK accessor. The Blunux version requirements are enforced in the setters and in
  `configure()`.
* **`get_resolution`/`set_resolution` are deprecated.** Drones running Blunux 4.4 or newer take
  the resolution from `stream_resolution`/`recording_resolution` and ignore this field when
  setting parameters, so setting it silently does nothing. Both now raise a `DeprecationWarning`
  pointing at the stream/recording resolution methods. Note this is deprecation on top of the
  `Camera.resolution` property shim from #215 — reading the old property warns twice, once for
  the property and once for the concept.
* **Unknown values raise.** `get_resolution` and `get_framerate` used to return `None` when the
  drone reported something the SDK did not recognise; they now raise `RuntimeError`. Both map
  through lookup tables instead of if/elif chains.

**Testing**

Unit tests cover the resolution and frame rate mapping in both directions, the new parameters'
getters/setters and their version gating, the `streaming_protocol` accessor (previously
untested), and two contracts that were implicit before: a getter always re-reads from the drone
rather than answering from the cache, and a setter on a camera that has not talked to the drone
yet fetches the current parameters before sending.

The drone-connected tests are now guarded by a `drone_model` fixture, because running them
against an X3 Ultra on Blunux 5.1.0 left three tests failing for reasons unrelated to the SDK:

* `bitrate` — the Ultra applies the stream bitrate but always reports it as 0. Measured on the
  wire, requesting 2 Mbit/s gives 1.98 Mbit/s and 12 Mbit/s gives 11.88 Mbit/s, so only the
  readback is missing. The drone fills `h264_bitrate` from the camera control node, and the Ultra
  encodes H264 in the RTSP server rather than in the camera. Marked xfail.
* `hue` — only available on Pioneer/Pro/X1/X3, the Ultra camera has no hue control. Skipped.
* `framerate` — the Ultra only applies 25 fps to the recording pipeline, and the reported frame
  rate comes from the stream pipeline, which stays at 30. Skipped, with
  `test_camera_framerate_60_fps` covering the frame rate the Ultra does support instead.

A drone-connected run is green on both families (verified against an X3 Ultra on Blunux 5.1.0:
18 passed, 4 skipped, 2 xfailed). The integration tests also sweep every resolution this PR adds
across both `stream_resolution` and `recording_resolution`.

Also carries an unrelated test-fixture fix that a drone-connected run turned up. `mocked_drone`
never requested the `mocked_telemetry_client` fixture, so every unit test built a real
`TelemetryClient` and subscribed to the drone over ZMQ. With a drone on the same network that
fills the telemetry state within ~250 ms, so the "returns None when no telemetry has been
received" tests failed at random - a different one each run. CI never saw it because there is no
drone there. The fixture is now wired in, which also drops the suite from 43s to 18s. The same
bug is on master, so it may be worth cherry-picking there rather than waiting for this to merge.

#### Checklist before merging

- [x] Merge #215 first
- [ ] Run the tests while connected to a drone
- [ ] Update the package version according to [semver](https://semver.org/)
