### PR TITLE
Raise RuntimeError as documented on unknown enums, bump to 2.8.0

### DIFF
--- a/blueye/sdk/camera.py
+++ b/blueye/sdk/camera.py
@@ -35,6 +35,16 @@ _FRAMERATE_TO_FPS = {
 _FPS_TO_FRAMERATE = {fps: framerate for framerate, fps in _FRAMERATE_TO_FPS.items()}
 
 
+def _describe_enum(value) -> str:
+    """Render a protocol enum value for an error message.
+
+    A drone running a newer Blunux than the SDK can report an enum value this build does not
+    know, and proto-plus surfaces those as a plain int rather than an enum member. Fall back to
+    the number so the error still says which value was rejected.
+    """
+    return getattr(value, "name", str(value))
+
+
 class Tilt:
     """Handles the camera tilt functionality for the Blueye drone."""
 
@@ -904,7 +914,7 @@ class Camera:
                     return from_enum[value]
                 except KeyError:
                     raise RuntimeError(
-                        f"Drone reported an unsupported {field}: {value.name}"
+                        f"Drone reported an unsupported {field}: {_describe_enum(value)}"
                     ) from None
             return value
 
@@ -1495,7 +1505,7 @@ class Camera:
         except KeyError:
             raise RuntimeError(
                 "Drone reported an unsupported resolution: "
-                f"{self._camera_parameters.resolution.name}"
+                f"{_describe_enum(self._camera_parameters.resolution)}"
             ) from None
 
     def set_resolution(self, resolution: int):
@@ -1633,7 +1643,7 @@ class Camera:
         except KeyError:
             raise RuntimeError(
                 "Drone reported an unsupported framerate: "
-                f"{self._camera_parameters.framerate.name}"
+                f"{_describe_enum(self._camera_parameters.framerate)}"
             ) from None
 
     def set_framerate(self, framerate: int):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blueye.sdk"
-version = "2.7.0"
+version = "2.8.0"
 license = { file = "LICENSE" }
 description = "SDK for controlling Blueye underwater drones"
 authors = [{ name = "Blueye Robotics", email = "contact@blueye.no" }]

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -601,3 +601,43 @@ def test_configure_rejects_unknown_field_name(mocked_camera):
     with pytest.raises(AttributeError):
         with mocked_camera.configure() as params:
             params.not_a_camera_parameter = 1
+
+
+def camera_parameters_with_unknown_enum(field: str, value: int) -> bp.CameraParameters:
+    """Build a CameraParameters reporting an enum value this SDK build does not know.
+
+    proto-plus surfaces an unrecognized enum value as a plain int rather than an enum member,
+    which is what a drone running a newer Blunux than the SDK would produce.
+    """
+    raw = bp.CameraParameters.pb(bp.CameraParameters())
+    setattr(raw, field, value)
+    return bp.CameraParameters.wrap(raw)
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_get_resolution_raises_runtime_error_on_unknown_enum(mocked_camera):
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        camera_parameters_with_unknown_enum("resolution", 42)
+    )
+    with pytest.raises(RuntimeError, match="42"):
+        mocked_camera.get_resolution()
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_get_framerate_raises_runtime_error_on_unknown_enum(mocked_camera):
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        camera_parameters_with_unknown_enum("framerate", 42)
+    )
+    with pytest.raises(RuntimeError, match="42"):
+        mocked_camera.get_framerate()
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_configure_raises_runtime_error_on_unknown_enum(mocked_camera):
+    mocked_camera._parent_drone._req_rep_client.get_camera_parameters.return_value = (
+        camera_parameters_with_unknown_enum("framerate", 42)
+    )
+    with pytest.raises(RuntimeError, match="42"):
+        with mocked_camera.configure() as params:
+            params.framerate

--- a/uv.lock
+++ b/uv.lock
@@ -119,7 +119,7 @@ wheels = [
 
 [[package]]
 name = "blueye-sdk"
-version = "2.7.0"
+version = "2.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "blueye-protocol" },


### PR DESCRIPTION
**Description**

Follow-up to #217, addressing the two review suggestions that came in on it rather than holding
up the merge.

### `RuntimeError` contract held everywhere except the case it was written for

`get_resolution`, `get_framerate` and the `configure()` batch all document that an unrecognized
value from the drone raises `RuntimeError`, and all three built the message with `.name` on the
reported enum.

That path exists for a drone running a newer Blunux than the SDK — and proto-plus surfaces an
enum value it does not recognize as a plain `int`, not an enum member. `.name` then raises
`AttributeError`, so the one scenario the contract was written for was the one where it did not
hold:

```
get_resolution()                 AttributeError: 'int' object has no attribute 'name'
get_framerate()                  AttributeError: 'int' object has no attribute 'name'
configure() -> params.framerate  AttributeError: 'int' object has no attribute 'name'
```

Formatting now goes through a helper that falls back to the number, so the error still names the
value that was rejected:

```
RuntimeError: Drone reported an unsupported resolution: 42
```

Copilot flagged the two getters on #217; the `configure()` batch had the same bug and is fixed
here too. Three regression tests cover it, building the unknown-enum state the way a newer drone
would produce it.

### Version bump

`pyproject.toml` and `uv.lock` were still at `2.7.0`, matching the last release. #217 added new
public accessors (VGA/2K/4K, 60 fps, the Ultra image parameters, MTU size), so this is a minor
bump to `2.8.0`. Lockfile regenerated — the only change is the version line.

#### Checklist before merging

- [x] Run the tests while connected to a drone
- [x] Update the package version according to [semver](https://semver.org/)
